### PR TITLE
fix: UI improvements from device testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ PROCESS.md
 .externalNativeBuild
 .cxx
 local.properties
+scripts/setup-env.sh
+scripts/deploy.sh

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseComponents.kt
@@ -72,7 +72,7 @@ fun ArtistDetailScreen(
 ) {
     LibraryDetailScaffold(
         title = artist.name,
-        subtitle = artist.albumCount?.let { "$it albums" } ?: "Artist",
+        subtitle = artist.albumCount?.let { "$it ${if (it == 1) "album" else "albums"}" } ?: "Artist",
         artwork = null,
     ) {
         when {
@@ -123,7 +123,7 @@ fun AlbumDetailScreen(
 ) {
     LibraryDetailScaffold(
         title = album.name,
-        subtitle = listOfNotNull(album.artist, album.year?.toString(), album.songCount?.let { "$it songs" }).joinToString(" • "),
+        subtitle = listOfNotNull(album.artist, album.year?.toString(), album.songCount?.let { "$it ${if (it == 1) "song" else "songs"}" }).joinToString(" • "),
         artwork = resolveArtworkModel(server, album.coverArtId, null),
     ) {
         when {
@@ -169,7 +169,7 @@ fun PlaylistDetailScreen(
 ) {
     LibraryDetailScaffold(
         title = playlist.name,
-        subtitle = listOfNotNull(playlist.owner, playlist.songCount?.let { "$it songs" }).joinToString(" • "),
+        subtitle = listOfNotNull(playlist.owner, playlist.songCount?.let { "$it ${if (it == 1) "song" else "songs"}" }).joinToString(" • "),
         artwork = resolveArtworkModel(server, playlist.coverArtId, null),
     ) {
         when {
@@ -245,10 +245,10 @@ private fun LibraryDetailScaffold(
 }
 
 @Composable
-fun ArtistRow(artist: ArtistSummary, onOpenArtist: (String) -> Unit) {
+fun ArtistRow(artist: ArtistSummary, server: ServerConfig, onOpenArtist: (String) -> Unit) {
     RowCard(
         title = artist.name,
-        subtitle = artist.albumCount?.let { "$it albums" } ?: "Artist",
+        subtitle = artist.albumCount?.let { "$it ${if (it == 1) "album" else "albums"}" } ?: "Artist",
         artwork = null,
         onClick = { onOpenArtist(artist.id) },
     )
@@ -258,7 +258,7 @@ fun ArtistRow(artist: ArtistSummary, onOpenArtist: (String) -> Unit) {
 fun PlaylistCard(playlist: PlaylistSummary, server: ServerConfig, onOpenPlaylist: (String) -> Unit) {
     RowCard(
         title = playlist.name,
-        subtitle = listOfNotNull(playlist.owner, playlist.songCount?.let { "$it songs" }).joinToString(" • "),
+        subtitle = listOfNotNull(playlist.owner, playlist.songCount?.let { "$it ${if (it == 1) "song" else "songs"}" }).joinToString(" • "),
         artwork = resolveArtworkModel(server, playlist.coverArtId, null),
         onClick = { onOpenPlaylist(playlist.id) },
     )
@@ -268,7 +268,7 @@ fun PlaylistCard(playlist: PlaylistSummary, server: ServerConfig, onOpenPlaylist
 fun AlbumRow(album: AlbumSummary, server: ServerConfig, onOpenAlbum: (String) -> Unit) {
     RowCard(
         title = album.name,
-        subtitle = listOfNotNull(album.artist, album.year?.toString(), album.songCount?.let { "$it songs" }).joinToString(" • "),
+        subtitle = listOfNotNull(album.artist, album.year?.toString(), album.songCount?.let { "$it ${if (it == 1) "song" else "songs"}" }).joinToString(" • "),
         artwork = resolveArtworkModel(server, album.coverArtId, null),
         onClick = { onOpenAlbum(album.id) },
     )
@@ -557,9 +557,12 @@ fun ErrorStateCard(message: String) {
 }
 
 @Composable
-fun EmptyStateCard(title: String, body: String) {
+fun EmptyStateCard(title: String, body: String, icon: androidx.compose.ui.graphics.vector.ImageVector? = null) {
     Card(shape = MaterialTheme.shapes.large, colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.88f))) {
         Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            if (icon != null) {
+                Icon(icon, contentDescription = null, modifier = Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
             Text(text = title, style = MaterialTheme.typography.titleLarge)
             Text(text = body, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
@@ -585,8 +588,8 @@ private fun RowCard(title: String, subtitle: String, artwork: Any?, onClick: () 
                     .weight(1f)
                     .padding(start = if (artwork != null) 12.dp else 0.dp),
             ) {
-                Text(text = title, style = MaterialTheme.typography.titleLarge)
-                Text(text = subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(text = title, style = MaterialTheme.typography.titleLarge, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                Text(text = subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
             Icon(Icons.AutoMirrored.Rounded.ArrowForward, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
         }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseComponents.kt
@@ -245,7 +245,7 @@ private fun LibraryDetailScaffold(
 }
 
 @Composable
-fun ArtistRow(artist: ArtistSummary, server: ServerConfig, onOpenArtist: (String) -> Unit) {
+fun ArtistRow(artist: ArtistSummary, onOpenArtist: (String) -> Unit) {
     RowCard(
         title = artist.name,
         subtitle = artist.albumCount?.let { "$it ${if (it == 1) "album" else "albums"}" } ?: "Artist",

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
@@ -504,7 +504,7 @@ private fun SearchResultsPage(
                     )
                 }
                 items(results.artists, key = { it.id }) { artist ->
-                    ArtistRow(artist = artist, server = currentServer, onOpenArtist = onOpenArtist)
+                    ArtistRow(artist = artist, onOpenArtist = onOpenArtist)
                 }
             }
 
@@ -582,7 +582,7 @@ private fun ArtistsPage(
             if (section.artists.isNotEmpty()) {
                 item { SectionTitle(section.name, "${section.artists.size} ${if (section.artists.size == 1) "artist" else "artists"}") }
                 items(section.artists, key = { it.id }) { artist ->
-                    ArtistRow(artist = artist, server = server, onOpenArtist = onOpenArtist)
+                    ArtistRow(artist = artist, onOpenArtist = onOpenArtist)
                 }
             }
         }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.PagerSnapDistance
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Search
@@ -503,7 +504,7 @@ private fun SearchResultsPage(
                     )
                 }
                 items(results.artists, key = { it.id }) { artist ->
-                    ArtistRow(artist = artist, onOpenArtist = onOpenArtist)
+                    ArtistRow(artist = artist, server = currentServer, onOpenArtist = onOpenArtist)
                 }
             }
 
@@ -579,9 +580,9 @@ private fun ArtistsPage(
         }
         indexes.sections.forEach { section ->
             if (section.artists.isNotEmpty()) {
-                item { SectionTitle(section.name, "${section.artists.size} artists") }
+                item { SectionTitle(section.name, "${section.artists.size} ${if (section.artists.size == 1) "artist" else "artists"}") }
                 items(section.artists, key = { it.id }) { artist ->
-                    ArtistRow(artist = artist, onOpenArtist = onOpenArtist)
+                    ArtistRow(artist = artist, server = server, onOpenArtist = onOpenArtist)
                 }
             }
         }
@@ -662,7 +663,7 @@ private fun PlaylistsPage(
         return
     }
     if (playlists.isEmpty()) {
-        EmptyStateCard("No playlists", "Create a playlist on your server to see it here.")
+        EmptyStateCard("No playlists", "Create a playlist on your server to see it here.", icon = Icons.AutoMirrored.Rounded.QueueMusic)
         return
     }
     LazyColumn(

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -112,7 +112,7 @@ fun NowPlayingCapsule(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 14.dp, vertical = 8.dp),
+            .padding(horizontal = 14.dp, vertical = 4.dp),
         shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.96f),
@@ -123,15 +123,15 @@ fun NowPlayingCapsule(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable(enabled = track != null, onClick = onExpand)
-                .padding(horizontal = 14.dp, vertical = 12.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             ArtworkCard(
                 model = track?.queueArtworkModel(),
                 contentDescription = track?.title,
-                modifier = Modifier.size(56.dp),
-                cornerRadiusDp = 18,
+                modifier = Modifier.size(46.dp),
+                cornerRadiusDp = 14,
             )
             Column(
                 modifier = Modifier.weight(1f),

--- a/app/src/main/java/com/anzupop/saki/android/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/settings/SettingsScreen.kt
@@ -152,7 +152,7 @@ fun SettingsScreen(
         item {
             SettingsSectionCard(
                 title = "Stream quality",
-                body = "Subsonic stream uses `maxBitRate`; original keeps the source file when possible.",
+                body = "Limit streaming bitrate or keep the original source file when possible.",
                 action = null,
             ) {
                 FlowRow(


### PR DESCRIPTION
- Fix singular/plural grammar (1 song/songs, 1 album/albums, etc.)
- Limit RowCard title to 2 lines with ellipsis for long names
- Make Now Playing capsule more compact (smaller artwork, tighter padding)
- Replace technical backtick in Stream quality description
- Add optional icon to EmptyStateCard, used for empty Playlists