### PR TITLE
feat: synced scrolling lyrics in Now Playing

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicDtos.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicDtos.kt
@@ -26,6 +26,7 @@ data class SubsonicResponseDto(
     val playlists: PlaylistsDto? = null,
     val playlist: PlaylistDto? = null,
     val searchResult3: SearchResult3Dto? = null,
+    val lyricsList: LyricsListDto? = null,
 )
 
 @JsonClass(generateAdapter = true)
@@ -147,4 +148,23 @@ data class SearchResult3Dto(
     val artist: List<ArtistDto> = emptyList(),
     val album: List<AlbumDto> = emptyList(),
     val song: List<SongDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class LyricsListDto(
+    val structuredLyrics: List<StructuredLyricsDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class StructuredLyricsDto(
+    val lang: String? = null,
+    val synced: Boolean = false,
+    val offset: Long = 0,
+    val line: List<LyricLineDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class LyricLineDto(
+    val start: Long? = null,
+    val value: String = "",
 )

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicMappers.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicMappers.kt
@@ -6,12 +6,14 @@ import com.anzupop.saki.android.domain.model.Artist
 import com.anzupop.saki.android.domain.model.ArtistSection
 import com.anzupop.saki.android.domain.model.ArtistSummary
 import com.anzupop.saki.android.domain.model.LibraryIndexes
+import com.anzupop.saki.android.domain.model.LyricLine
 import com.anzupop.saki.android.domain.model.MusicFolder
 import com.anzupop.saki.android.domain.model.PingResult
 import com.anzupop.saki.android.domain.model.Playlist
 import com.anzupop.saki.android.domain.model.PlaylistSummary
 import com.anzupop.saki.android.domain.model.SearchResults
 import com.anzupop.saki.android.domain.model.Song
+import com.anzupop.saki.android.domain.model.SongLyrics
 
 internal fun SubsonicResponseDto.toPingResult(): PingResult {
     return PingResult(
@@ -196,3 +198,13 @@ private fun PlaylistDto.toPlaylistSummary(): PlaylistSummary {
 
 private val AlbumDto.displayName: String
     get() = name ?: title ?: "Unknown Album"
+
+internal fun SubsonicResponseDto.toLyrics(): SongLyrics? {
+    val candidates = lyricsList?.structuredLyrics ?: return null
+    // Prefer synced lyrics, fall back to unsynced
+    val best = candidates.firstOrNull { it.synced } ?: candidates.firstOrNull() ?: return null
+    return SongLyrics(
+        synced = best.synced,
+        lines = best.line.map { LyricLine(startMs = ((it.start ?: 0L) - best.offset).coerceAtLeast(0L), text = it.value) },
+    )
+}

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepository.kt
@@ -13,6 +13,7 @@ import com.anzupop.saki.android.data.remote.subsonic.toArtist
 import com.anzupop.saki.android.data.remote.subsonic.toAlbum
 import com.anzupop.saki.android.data.remote.subsonic.toAlbumSummaries
 import com.anzupop.saki.android.data.remote.subsonic.toLibraryIndexes
+import com.anzupop.saki.android.data.remote.subsonic.toLyrics
 import com.anzupop.saki.android.data.remote.subsonic.toMusicFolders
 import com.anzupop.saki.android.data.remote.subsonic.toPingResult
 import com.anzupop.saki.android.data.remote.subsonic.toPlaylist
@@ -33,6 +34,7 @@ import com.anzupop.saki.android.domain.model.SearchResults
 import com.anzupop.saki.android.domain.model.ServerConfig
 import com.anzupop.saki.android.domain.model.ServerEndpoint
 import com.anzupop.saki.android.domain.model.Song
+import com.anzupop.saki.android.domain.model.SongLyrics
 import com.anzupop.saki.android.domain.model.SubsonicCallResult
 import com.anzupop.saki.android.domain.model.SubsonicCoverArtRequest
 import com.anzupop.saki.android.domain.model.SubsonicDownloadRequest
@@ -270,6 +272,19 @@ class DefaultSubsonicRepository @Inject constructor(
                 ),
             ),
         )
+    }
+
+    override suspend fun getLyrics(
+        serverId: Long,
+        songId: String,
+    ): SubsonicCallResult<SongLyrics?> = withContext(ioDispatcher) {
+        executeWithFallback(
+            serverId = serverId,
+            path = "getLyricsBySongId.view",
+            extraQuery = mapOf("id" to songId),
+        ) { response ->
+            response.toLyrics()
+        }
     }
 
     private suspend fun <T> executeWithFallback(

--- a/app/src/main/java/com/anzupop/saki/android/domain/model/SubsonicModels.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/model/SubsonicModels.kt
@@ -160,3 +160,13 @@ data class SubsonicCoverArtRequest(
     val coverArtId: String,
     val candidates: List<AuthenticatedUrlCandidate>,
 )
+
+data class LyricLine(
+    val startMs: Long,
+    val text: String,
+)
+
+data class SongLyrics(
+    val synced: Boolean,
+    val lines: List<LyricLine>,
+)

--- a/app/src/main/java/com/anzupop/saki/android/domain/repository/SubsonicRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/repository/SubsonicRepository.kt
@@ -11,6 +11,7 @@ import com.anzupop.saki.android.domain.model.Playlist
 import com.anzupop.saki.android.domain.model.PlaylistSummary
 import com.anzupop.saki.android.domain.model.SearchResults
 import com.anzupop.saki.android.domain.model.Song
+import com.anzupop.saki.android.domain.model.SongLyrics
 import com.anzupop.saki.android.domain.model.SubsonicCallResult
 import com.anzupop.saki.android.domain.model.SubsonicCoverArtRequest
 import com.anzupop.saki.android.domain.model.SubsonicDownloadRequest
@@ -92,4 +93,9 @@ interface SubsonicRepository {
         coverArtId: String,
         size: Int? = null,
     ): SubsonicCoverArtRequest
+
+    suspend fun getLyrics(
+        serverId: Long,
+        songId: String,
+    ): SubsonicCallResult<SongLyrics?>
 }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -312,6 +312,7 @@ private fun RootShell(
             onSkipToQueueItem = onSkipToQueueItem,
             onRemoveQueueItem = onRemoveQueueItem,
             currentServer = uiState.servers.firstOrNull { it.id == track.serverId },
+            lyrics = uiState.currentLyrics,
         )
     }
 }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -15,6 +15,7 @@ import com.anzupop.saki.android.domain.model.PlaylistSummary
 import com.anzupop.saki.android.domain.model.SearchResults
 import com.anzupop.saki.android.domain.model.ServerConfig
 import com.anzupop.saki.android.domain.model.Song
+import com.anzupop.saki.android.domain.model.SongLyrics
 import com.anzupop.saki.android.domain.model.SoundBalancingMode
 import com.anzupop.saki.android.domain.model.StreamQuality
 import com.anzupop.saki.android.domain.model.TextScale
@@ -102,6 +103,27 @@ class SakiAppViewModel @Inject constructor(
                     state.copy(playbackState = playbackState)
                 }
             }
+        }
+
+        // Fetch lyrics when current track changes
+        viewModelScope.launch {
+            playbackManager.playbackState
+                .map { it.currentItem?.songId }
+                .distinctUntilChanged()
+                .collectLatest { songId ->
+                    val serverId = uiState.value.selectedServerId
+                    if (songId == null || serverId == null) {
+                        mutableUiState.update { it.copy(currentLyrics = null) }
+                        return@collectLatest
+                    }
+                    mutableUiState.update { it.copy(currentLyrics = null) }
+                    try {
+                        val lyrics = subsonicRepository.getLyrics(serverId, songId).data
+                        mutableUiState.update { it.copy(currentLyrics = lyrics) }
+                    } catch (_: Exception) {
+                        // Lyrics not available — silently ignore
+                    }
+                }
         }
 
         viewModelScope.launch {
@@ -1041,6 +1063,7 @@ data class SakiAppUiState(
     val streamCachedSongIds: Set<String> = emptySet(),
     val downloadingSongIds: Set<String> = emptySet(),
     val playbackState: PlaybackSessionState = PlaybackSessionState(),
+    val currentLyrics: SongLyrics? = null,
 )
 
 private fun Song.withFallbackAlbumMetadata(album: Album): Song {

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -28,6 +28,7 @@ import com.anzupop.saki.android.domain.repository.SubsonicRepository
 import com.anzupop.saki.android.domain.repository.StreamCacheRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -108,18 +109,25 @@ class SakiAppViewModel @Inject constructor(
         // Fetch lyrics when current track changes
         viewModelScope.launch {
             playbackManager.playbackState
-                .map { it.currentItem?.songId }
+                .map { state ->
+                    state.currentItem?.let {
+                        val sid = it.serverId ?: return@let null
+                        sid to it.songId
+                    }
+                }
                 .distinctUntilChanged()
-                .collectLatest { songId ->
-                    val serverId = uiState.value.selectedServerId
-                    if (songId == null || serverId == null) {
+                .collectLatest { pair ->
+                    if (pair == null) {
                         mutableUiState.update { it.copy(currentLyrics = null) }
                         return@collectLatest
                     }
+                    val (serverId, songId) = pair
                     mutableUiState.update { it.copy(currentLyrics = null) }
                     try {
                         val lyrics = subsonicRepository.getLyrics(serverId, songId).data
                         mutableUiState.update { it.copy(currentLyrics = lyrics) }
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (_: Exception) {
                         // Lyrics not available — silently ignore
                     }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
+import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -41,6 +42,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.KeyboardArrowUp
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -92,6 +94,7 @@ import com.anzupop.saki.android.domain.model.PlaybackQueueItem
 import com.anzupop.saki.android.domain.model.PlaybackSessionState
 import com.anzupop.saki.android.domain.model.RepeatModeSetting
 import com.anzupop.saki.android.domain.model.ServerConfig
+import com.anzupop.saki.android.domain.model.SongLyrics
 import java.io.File
 import java.net.URL
 import coil3.imageLoader
@@ -204,12 +207,14 @@ fun NowPlayingOverlay(
     onSkipToQueueItem: (Int) -> Unit,
     onRemoveQueueItem: (Int) -> Unit,
     currentServer: ServerConfig?,
+    lyrics: SongLyrics? = null,
 ) {
     val artwork = rememberArtworkPresentation(
         fallbackModel = track.queueArtworkModel(),
     )
     var showDetails by remember(track.songId) { mutableStateOf(false) }
     var showMenu by remember(track.songId) { mutableStateOf(false) }
+    var showLyrics by remember { mutableStateOf(false) }
 
     // Preload adjacent cover art into Coil cache
     val context = LocalContext.current
@@ -234,6 +239,11 @@ fun NowPlayingOverlay(
 
     BackHandler(enabled = visible) {
         onDismiss()
+    }
+
+    // Reset lyrics overlay when Now Playing is dismissed
+    LaunchedEffect(visible) {
+        if (!visible) showLyrics = false
     }
 
     AnimatedVisibility(
@@ -396,23 +406,74 @@ fun NowPlayingOverlay(
                         }
                     }
                     item {
-                        HorizontalPager(
-                            state = artworkPagerState,
-                            modifier = Modifier.fillMaxWidth(),
-                            pageSpacing = 16.dp,
-                            beyondViewportPageCount = 1,
-                        ) { page ->
-                            Box(
-                                modifier = Modifier.fillMaxWidth(),
-                                contentAlignment = Alignment.Center,
+                        val hasLyrics = lyrics != null && lyrics.lines.isNotEmpty()
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    if (showLyrics) showLyrics = false
+                                    else if (hasLyrics) showLyrics = true
+                                },
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            HorizontalPager(
+                                state = artworkPagerState,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(34.dp)),
+                                pageSpacing = 16.dp,
+                                beyondViewportPageCount = 1,
+                            ) { page ->
+                                Box(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    val queueItem = playbackState.queue.getOrNull(page)
+                                    ArtworkCard(
+                                        model = queueItem?.queueArtworkModel(),
+                                        contentDescription = queueItem?.title,
+                                        modifier = Modifier.size(artworkSize),
+                                        cornerRadiusDp = 34,
+                                    )
+                                }
+                            }
+                            // Lyrics overlay on artwork
+                            AnimatedVisibility(
+                                visible = showLyrics,
+                                enter = fadeIn(tween(250)),
+                                exit = fadeOut(tween(250)),
                             ) {
-                                val queueItem = playbackState.queue.getOrNull(page)
-                                ArtworkCard(
-                                    model = queueItem?.queueArtworkModel(),
-                                    contentDescription = queueItem?.title,
-                                    modifier = Modifier.size(artworkSize),
-                                    cornerRadiusDp = 34,
-                                )
+                                Box(
+                                    modifier = Modifier
+                                        .size(artworkSize)
+                                        .clip(RoundedCornerShape(34.dp))
+                                        .background(Color.Black.copy(alpha = 0.65f)),
+                                ) {
+                                    if (lyrics != null && lyrics.lines.isNotEmpty()) {
+                                        SyncedLyricsView(
+                                            lyrics = lyrics,
+                                        positionMs = playbackState.positionMs,
+                                        isPlaying = playbackState.isPlaying,
+                                        onSeekTo = onSeekTo,
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 40.dp),
+                                        textColor = Color.White,
+                                    )
+                                    }
+                                    IconButton(
+                                        onClick = { showLyrics = false },
+                                        modifier = Modifier
+                                            .align(Alignment.BottomEnd)
+                                            .padding(8.dp),
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Close,
+                                            contentDescription = "Close lyrics",
+                                            tint = Color.White.copy(alpha = 0.7f),
+                                        )
+                                    }
+                                }
                             }
                         }
                     }
@@ -867,3 +928,60 @@ private fun formatBitrate(bitrate: Int): String {
 }
 
 private fun formatSampleRate(sampleRate: Int): String = "$sampleRate Hz"
+
+@Composable
+private fun SyncedLyricsView(
+    lyrics: SongLyrics,
+    positionMs: Long,
+    isPlaying: Boolean,
+    onSeekTo: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+    textColor: Color = MaterialTheme.colorScheme.onBackground,
+) {
+    val lines = lyrics.lines
+    val activeIndex = if (lyrics.synced) {
+        lines.indexOfLast { it.startMs <= positionMs }.coerceAtLeast(0)
+    } else {
+        -1
+    }
+
+    val lyricsListState = rememberLazyListState()
+
+    if (lyrics.synced && activeIndex >= 0) {
+        LaunchedEffect(activeIndex) {
+            lyricsListState.animateScrollToItem(
+                index = activeIndex,
+                scrollOffset = -200,
+            )
+        }
+    }
+
+    LazyColumn(
+        state = lyricsListState,
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        itemsIndexed(lines) { index, line ->
+            val isActive = index == activeIndex
+            Text(
+                text = line.text.ifBlank { "♪" },
+                style = if (isActive) {
+                    MaterialTheme.typography.bodyLarge.copy(fontSize = 18.sp)
+                } else {
+                    MaterialTheme.typography.bodyMedium
+                },
+                color = if (isActive) textColor else textColor.copy(alpha = 0.45f),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .then(
+                        if (lyrics.synced && line.startMs > 0) {
+                            Modifier.clickable { onSeekTo(line.startMs) }
+                        } else {
+                            Modifier
+                        },
+                    )
+                    .padding(vertical = 4.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -85,6 +85,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -439,7 +440,7 @@ fun NowPlayingOverlay(
                             }
                             // Lyrics overlay on artwork
                             AnimatedVisibility(
-                                visible = showLyrics,
+                                visible = showLyrics && hasLyrics,
                                 enter = fadeIn(tween(250)),
                                 exit = fadeOut(tween(250)),
                             ) {
@@ -946,12 +947,14 @@ private fun SyncedLyricsView(
     }
 
     val lyricsListState = rememberLazyListState()
+    val density = LocalDensity.current
 
-    if (lyrics.synced && activeIndex >= 0) {
+    if (lyrics.synced && activeIndex >= 0 && isPlaying) {
         LaunchedEffect(activeIndex) {
+            val offsetPx = with(density) { 80.dp.roundToPx() }
             lyricsListState.animateScrollToItem(
                 index = activeIndex,
-                scrollOffset = -200,
+                scrollOffset = -offsetPx,
             )
         }
     }
@@ -974,7 +977,7 @@ private fun SyncedLyricsView(
                 modifier = Modifier
                     .fillMaxWidth()
                     .then(
-                        if (lyrics.synced && line.startMs > 0) {
+                        if (lyrics.synced && line.startMs >= 0) {
                             Modifier.clickable { onSeekTo(line.startMs) }
                         } else {
                             Modifier


### PR DESCRIPTION
Adds synced scrolling lyrics to the Now Playing overlay via the OpenSubsonic `getLyricsBySongId` API.

**Features:**
- Auto-fetch lyrics when track changes (prefers synced over unsynced)
- Tap album art to toggle lyrics overlay with dark scrim
- Current line highlighted and auto-scrolled
- Tap any lyric line to seek to that timestamp
- Close button (×) in bottom-right corner
- Lyrics overlay resets when Now Playing is dismissed
- Supports LRC `offset` field for timestamp correction

**Data layer:**
- `LyricsListDto` / `StructuredLyricsDto` / `LyricLineDto` DTOs
- `SongLyrics` / `LyricLine` domain models
- `getLyrics()` in `SubsonicRepository` via `getLyricsBySongId.view`
- Offset applied as `start - offset` per OpenSubsonic spec

**Also fixes:**
- Clip `HorizontalPager` with rounded corners to prevent artwork overflow during page transitions

Closes #17