### PR TITLE
fix: use Coil for Palette color extraction

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -1,6 +1,5 @@
 package com.anzupop.saki.android.presentation.library
 
-import android.graphics.BitmapFactory
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -881,7 +880,7 @@ private data class ArtworkPresentation(
 private fun rememberArtworkPresentation(
     fallbackModel: Any?,
 ): ArtworkPresentation {
-    val context = LocalContext.current
+    val context = LocalContext.current.applicationContext
     return produceState(
         initialValue = ArtworkPresentation(),
         key1 = fallbackModel,
@@ -894,16 +893,14 @@ private suspend fun loadArtworkPresentation(
     context: android.content.Context,
     model: Any?,
 ): ArtworkPresentation = withContext(Dispatchers.IO) {
-    val bitmap = when (model) {
-        is File -> if (model.exists()) BitmapFactory.decodeFile(model.absolutePath) else null
-        else -> if (model != null) {
-            val request = coil3.request.ImageRequest.Builder(context)
-                .data(model)
-                .size(300)
-                .build()
-            context.imageLoader.execute(request).image?.toBitmap()
-        } else null
-    } ?: return@withContext ArtworkPresentation()
+    if (model == null) return@withContext ArtworkPresentation()
+    val request = coil3.request.ImageRequest.Builder(context)
+        .data(model)
+        .size(300)
+        .build()
+    val image = context.imageLoader.execute(request).image
+        ?: return@withContext ArtworkPresentation()
+    val bitmap = image.toBitmap().copy(android.graphics.Bitmap.Config.ARGB_8888, false)
 
     val palette = Palette.from(bitmap).clearFilters().generate()
     ArtworkPresentation(

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -97,9 +97,9 @@ import com.anzupop.saki.android.domain.model.RepeatModeSetting
 import com.anzupop.saki.android.domain.model.ServerConfig
 import com.anzupop.saki.android.domain.model.SongLyrics
 import java.io.File
-import java.net.URL
 import coil3.imageLoader
 import coil3.request.ImageRequest
+import coil3.toBitmap
 import kotlin.math.roundToLong
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -881,23 +881,28 @@ private data class ArtworkPresentation(
 private fun rememberArtworkPresentation(
     fallbackModel: Any?,
 ): ArtworkPresentation {
+    val context = LocalContext.current
     return produceState(
         initialValue = ArtworkPresentation(),
         key1 = fallbackModel,
     ) {
-        value = loadArtworkPresentation(fallbackModel)
+        value = loadArtworkPresentation(context, fallbackModel)
     }.value
 }
 
 private suspend fun loadArtworkPresentation(
+    context: android.content.Context,
     model: Any?,
 ): ArtworkPresentation = withContext(Dispatchers.IO) {
     val bitmap = when (model) {
         is File -> if (model.exists()) BitmapFactory.decodeFile(model.absolutePath) else null
-        is String -> runCatching {
-            URL(model).openStream().use(BitmapFactory::decodeStream)
-        }.getOrNull()
-        else -> null
+        else -> if (model != null) {
+            val request = coil3.request.ImageRequest.Builder(context)
+                .data(model)
+                .size(300)
+                .build()
+            context.imageLoader.execute(request).image?.toBitmap()
+        } else null
     } ?: return@withContext ArtworkPresentation()
 
     val palette = Palette.from(bitmap).clearFilters().generate()


### PR DESCRIPTION
Replace `URL.openStream()` with Coil `ImageRequest` for Palette color extraction in Now Playing.

**Before:** Raw `URL.openStream()` → no timeout, no cache, no size limit → OOM risk on large album art
**After:** Coil `ImageRequest` with `size(300)` → uses OkHttp (timeouts), disk/memory cache, downsampled to 300px

Closes #6