### PR TITLE
fix: back button navigates from Settings to Browse

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -208,6 +208,11 @@ private fun RootShell(
         onDismissNowPlaying()
     }
 
+    // Navigate back to Browse when pressing back on Settings tab
+    BackHandler(enabled = !showNowPlaying && uiState.selectedAppTab != AppTab.BROWSE) {
+        onSelectRootTab(AppTab.BROWSE)
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -208,7 +208,7 @@ private fun RootShell(
         onDismissNowPlaying()
     }
 
-    // Navigate back to Browse when pressing back on Settings tab
+    // Navigate back to Browse when pressing back on a non-Browse tab
     BackHandler(enabled = !showNowPlaying && uiState.selectedAppTab != AppTab.BROWSE) {
         onSelectRootTab(AppTab.BROWSE)
     }


### PR DESCRIPTION
Pressing back on the Settings tab now returns to Browse instead of exiting the app.

Back button priority:
1. Now Playing open → dismiss overlay
2. Non-Browse tab → navigate to Browse
3. Browse with detail/search open → close detail/search (existing)
4. Browse root → exit app (system default)

Closes #8