### PR TITLE
fix: redesign tab bar and fix ripple clipping

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseComponents.kt
@@ -1,6 +1,7 @@
 package com.anzupop.saki.android.presentation.library
 
 import androidx.compose.foundation.clickable
+import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -300,9 +301,9 @@ fun ArtistShortcutCard(artist: ArtistSummary, onOpenArtist: (String) -> Unit) {
 @Composable
 fun AlbumCard(album: AlbumSummary, server: ServerConfig, onOpenAlbum: (String) -> Unit) {
     Card(
+        onClick = { onOpenAlbum(album.id) },
         modifier = Modifier
-            .padding(6.dp)
-            .clickable { onOpenAlbum(album.id) },
+            .padding(6.dp),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)),
     ) {
@@ -371,6 +372,7 @@ fun SongRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .clip(MaterialTheme.shapes.large)
             .clickable(onClick = onClick)
             .padding(vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -571,10 +573,10 @@ fun EmptyStateCard(title: String, body: String, icon: androidx.compose.ui.graphi
 @Composable
 private fun RowCard(title: String, subtitle: String, artwork: Any?, onClick: () -> Unit) {
     Card(
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 6.dp)
-            .clickable(onClick = onClick),
+            .padding(vertical = 6.dp),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.88f)),
     ) {

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
@@ -42,8 +42,6 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PrimaryTabRow
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -320,26 +318,23 @@ private fun BrowsePager(
                 onShowSongActions = onShowSongActions,
             )
         } else {
-            PrimaryTabRow(
-                selectedTabIndex = sections.indexOf(uiState.selectedBrowseSection).coerceAtLeast(0),
-                modifier = Modifier.padding(vertical = 12.dp),
-                containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.68f),
-                divider = {},
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 sections.forEach { section ->
-                    Tab(
+                    FilterChip(
                         selected = uiState.selectedBrowseSection == section,
                         onClick = { onSelectBrowseSection(section) },
-                        text = {
+                        label = {
                             Text(
                                 text = section.label,
                                 style = MaterialTheme.typography.labelMedium,
                                 maxLines = 1,
-                                softWrap = false,
                             )
                         },
-                        selectedContentColor = MaterialTheme.colorScheme.primary,
-                        unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
@@ -318,13 +318,13 @@ private fun BrowsePager(
                 onShowSongActions = onShowSongActions,
             )
         } else {
-            Row(
+            LazyRow(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = 12.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                sections.forEach { section ->
+                items(sections) { section ->
                     FilterChip(
                         selected = uiState.selectedBrowseSection == section,
                         onClick = { onSelectBrowseSection(section) },

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -124,6 +124,8 @@ fun NowPlayingCapsule(
     )
 
     Card(
+        onClick = onExpand,
+        enabled = track != null,
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 14.dp, vertical = 4.dp),
@@ -136,7 +138,6 @@ fun NowPlayingCapsule(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(enabled = track != null, onClick = onExpand)
                 .padding(horizontal = 12.dp, vertical = 8.dp),
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -804,6 +805,7 @@ private fun QueueRow(
     onRemove: () -> Unit,
 ) {
     Surface(
+        onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
         color = if (isCurrent) {
@@ -815,7 +817,6 @@ private fun QueueRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
                 .padding(horizontal = 14.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {


### PR DESCRIPTION
Redesign Browse tab bar and fix rectangular ripple effects across the app.

**Tab bar:**
- Replace `PrimaryTabRow` + `Tab` with `FilterChip` row
- Matches the album feed chip style (Newest / Recent / Random)
- No more gray background strip or flickering indicator

**Ripple clipping:**
- RowCard, AlbumCard: `Card.clickable` → `Card(onClick=)` so ripple follows card shape
- SongRow: add `clip(shapes.large)` before `clickable`
- QueueRow: `Surface` inner `clickable` → `Surface(onClick=)`
- Now Playing capsule: `Card` inner `clickable` → `Card(onClick=, enabled=)`

Closes #19