### PR TITLE
ci: upload debug APK artifact on master push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,11 @@ jobs:
 
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest --no-daemon
+
+      - name: Upload debug APK
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,10 @@ jobs:
         run: ./gradlew testDebugUnitTest --no-daemon
 
       - name: Upload debug APK
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: app-debug
           path: app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
           retention-days: 30


### PR DESCRIPTION
Upload debug APK as a GitHub Actions artifact on master push.

- Only runs on `push` to `master` (not on PRs)
- APK retained for 30 days
- PR CI unchanged (compile + test only)

Closes #14