### PR TITLE
feat: word-level karaoke lyrics with smooth fill

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicMappers.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicMappers.kt
@@ -227,10 +227,10 @@ internal fun SubsonicResponseDto.toLyrics(): SongLyrics? {
     return SongLyrics(
         synced = best.synced,
         lines = best.line.map { dto ->
-            val rawStart = (dto.start ?: 0L) - offset
-            val words = parseWordCues(rawStart.coerceAtLeast(0L), dto.value)
+            val rawStart = dto.start ?: 0L
+            val words = parseWordCues(rawStart, dto.value)
             LyricLine(
-                startMs = rawStart.coerceAtLeast(0L),
+                startMs = (rawStart - offset).coerceAtLeast(0L),
                 text = words?.joinToString("") { it.text } ?: dto.value,
                 words = words?.map { it.copy(startMs = (it.startMs - offset).coerceAtLeast(0L)) },
             )

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicMappers.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicMappers.kt
@@ -8,6 +8,7 @@ import com.anzupop.saki.android.domain.model.ArtistSummary
 import com.anzupop.saki.android.domain.model.LibraryIndexes
 import com.anzupop.saki.android.domain.model.LyricLine
 import com.anzupop.saki.android.domain.model.MusicFolder
+import com.anzupop.saki.android.domain.model.WordCue
 import com.anzupop.saki.android.domain.model.PingResult
 import com.anzupop.saki.android.domain.model.Playlist
 import com.anzupop.saki.android.domain.model.PlaylistSummary
@@ -199,12 +200,40 @@ private fun PlaylistDto.toPlaylistSummary(): PlaylistSummary {
 private val AlbumDto.displayName: String
     get() = name ?: title ?: "Unknown Album"
 
+private val INLINE_TS = Regex("\\[(\\d{2}):(\\d{2})\\.(\\d{2,3})]")
+
+private fun parseWordCues(lineStartMs: Long, value: String): List<WordCue>? {
+    if (!value.contains(INLINE_TS)) return null
+    val cues = mutableListOf<WordCue>()
+    var lastEnd = 0
+    var nextStartMs = lineStartMs
+    for (match in INLINE_TS.findAll(value)) {
+        val text = value.substring(lastEnd, match.range.first)
+        if (text.isNotEmpty()) cues += WordCue(nextStartMs, text)
+        val (mm, ss, frac) = match.destructured
+        val ms = frac.padEnd(3, '0').toLong()
+        nextStartMs = mm.toLong() * 60_000 + ss.toLong() * 1_000 + ms
+        lastEnd = match.range.last + 1
+    }
+    val tail = value.substring(lastEnd)
+    if (tail.isNotEmpty()) cues += WordCue(nextStartMs, tail)
+    return cues.ifEmpty { null }
+}
+
 internal fun SubsonicResponseDto.toLyrics(): SongLyrics? {
     val candidates = lyricsList?.structuredLyrics ?: return null
-    // Prefer synced lyrics, fall back to unsynced
     val best = candidates.firstOrNull { it.synced } ?: candidates.firstOrNull() ?: return null
+    val offset = best.offset
     return SongLyrics(
         synced = best.synced,
-        lines = best.line.map { LyricLine(startMs = ((it.start ?: 0L) - best.offset).coerceAtLeast(0L), text = it.value) },
+        lines = best.line.map { dto ->
+            val rawStart = (dto.start ?: 0L) - offset
+            val words = parseWordCues(rawStart.coerceAtLeast(0L), dto.value)
+            LyricLine(
+                startMs = rawStart.coerceAtLeast(0L),
+                text = words?.joinToString("") { it.text } ?: dto.value,
+                words = words?.map { it.copy(startMs = (it.startMs - offset).coerceAtLeast(0L)) },
+            )
+        },
     )
 }

--- a/app/src/main/java/com/anzupop/saki/android/domain/model/SubsonicModels.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/model/SubsonicModels.kt
@@ -161,9 +161,15 @@ data class SubsonicCoverArtRequest(
     val candidates: List<AuthenticatedUrlCandidate>,
 )
 
+data class WordCue(
+    val startMs: Long,
+    val text: String,
+)
+
 data class LyricLine(
     val startMs: Long,
     val text: String,
+    val words: List<WordCue>? = null,
 )
 
 data class SongLyrics(

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -16,7 +17,11 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,6 +31,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
@@ -85,8 +91,12 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.palette.graphics.Palette
@@ -943,8 +953,22 @@ private fun SyncedLyricsView(
     textColor: Color = MaterialTheme.colorScheme.onBackground,
 ) {
     val lines = lyrics.lines
+
+    // High-frequency position: interpolate between 500ms global updates
+    val smoothPositionMs by produceState(positionMs, positionMs, isPlaying) {
+        value = positionMs
+        if (!isPlaying) return@produceState
+        var lastFrame = withFrameNanos { it }
+        while (true) {
+            val now = withFrameNanos { it }
+            val delta = (now - lastFrame) / 1_000_000 // ns → ms
+            lastFrame = now
+            value += delta
+        }
+    }
+
     val activeIndex = if (lyrics.synced) {
-        lines.indexOfLast { it.startMs <= positionMs }.coerceAtLeast(0)
+        lines.indexOfLast { it.startMs <= smoothPositionMs }.coerceAtLeast(0)
     } else {
         -1
     }
@@ -969,25 +993,56 @@ private fun SyncedLyricsView(
     ) {
         itemsIndexed(lines) { index, line ->
             val isActive = index == activeIndex
-            Text(
-                text = line.text.ifBlank { "♪" },
-                style = if (isActive) {
-                    MaterialTheme.typography.bodyLarge.copy(fontSize = 18.sp)
-                } else {
-                    MaterialTheme.typography.bodyMedium
-                },
-                color = if (isActive) textColor else textColor.copy(alpha = 0.45f),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .then(
-                        if (lyrics.synced && line.startMs >= 0) {
-                            Modifier.clickable { onSeekTo(line.startMs) }
-                        } else {
-                            Modifier
+            val style = if (isActive) {
+                MaterialTheme.typography.bodyLarge.copy(fontSize = 18.sp)
+            } else {
+                MaterialTheme.typography.bodyMedium
+            }
+            val activeColor = if (isActive) textColor else textColor.copy(alpha = 0.45f)
+            val dimColor = textColor.copy(alpha = 0.45f)
+
+            if (isActive && line.words != null) {
+                val lineEndMs = lines.getOrNull(index + 1)?.startMs ?: (line.words.last().startMs + 1000)
+                val progress = ((smoothPositionMs - line.startMs).toFloat() / (lineEndMs - line.startMs).toFloat()).coerceIn(0f, 1f)
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (lyrics.synced && line.startMs >= 0) {
+                                Modifier.clickable { onSeekTo(line.startMs) }
+                            } else {
+                                Modifier
+                            },
+                        )
+                        .padding(vertical = 4.dp),
+                ) {
+                    Text(text = line.text, style = style, color = dimColor)
+                    Text(
+                        text = line.text,
+                        style = style,
+                        color = textColor,
+                        modifier = Modifier.drawWithContent {
+                            clipRect(right = size.width * progress) { this@drawWithContent.drawContent() }
                         },
                     )
-                    .padding(vertical = 4.dp),
-            )
+                }
+            } else {
+                Text(
+                    text = line.text.ifBlank { "♪" },
+                    style = style,
+                    color = activeColor,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (lyrics.synced && line.startMs >= 0) {
+                                Modifier.clickable { onSeekTo(line.startMs) }
+                            } else {
+                                Modifier
+                            },
+                        )
+                        .padding(vertical = 4.dp),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -17,21 +16,15 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
-import androidx.compose.runtime.produceState
-import androidx.compose.runtime.withFrameNanos
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.graphics.drawscope.clipRect
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
@@ -46,8 +39,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -71,8 +64,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -82,21 +75,21 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.palette.graphics.Palette
@@ -953,22 +946,28 @@ private fun SyncedLyricsView(
     textColor: Color = MaterialTheme.colorScheme.onBackground,
 ) {
     val lines = lyrics.lines
+    val hasWordLevelTiming = lyrics.synced && lines.any { it.words != null }
 
-    // High-frequency position: interpolate between 500ms global updates
-    val smoothPositionMs by produceState(positionMs, positionMs, isPlaying) {
+    // High-frequency position: interpolate between 500ms global updates (only for karaoke)
+    val smoothPositionMs by produceState(
+        initialValue = positionMs,
+        key1 = positionMs,
+        key2 = isPlaying,
+        key3 = hasWordLevelTiming,
+    ) {
         value = positionMs
-        if (!isPlaying) return@produceState
+        if (!isPlaying || !hasWordLevelTiming) return@produceState
         var lastFrame = withFrameNanos { it }
         while (true) {
             val now = withFrameNanos { it }
-            val delta = (now - lastFrame) / 1_000_000 // ns → ms
+            val delta = (now - lastFrame) / 1_000_000
             lastFrame = now
             value += delta
         }
     }
 
     val activeIndex = if (lyrics.synced) {
-        lines.indexOfLast { it.startMs <= smoothPositionMs }.coerceAtLeast(0)
+        lines.indexOfLast { it.startMs <= positionMs }.coerceAtLeast(0)
     } else {
         -1
     }
@@ -1003,27 +1002,46 @@ private fun SyncedLyricsView(
 
             if (isActive && line.words != null) {
                 val lineEndMs = lines.getOrNull(index + 1)?.startMs ?: (line.words.last().startMs + 1000)
-                val progress = ((smoothPositionMs - line.startMs).toFloat() / (lineEndMs - line.startMs).toFloat()).coerceIn(0f, 1f)
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .then(
-                            if (lyrics.synced && line.startMs >= 0) {
-                                Modifier.clickable { onSeekTo(line.startMs) }
-                            } else {
-                                Modifier
+                val lineDurationMs = lineEndMs - line.startMs
+                if (lineDurationMs > 0) {
+                    val progress = ((smoothPositionMs - line.startMs).toFloat() / lineDurationMs.toFloat()).coerceIn(0f, 1f)
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .then(
+                                if (lyrics.synced && line.startMs >= 0) {
+                                    Modifier.clickable { onSeekTo(line.startMs) }
+                                } else {
+                                    Modifier
+                                },
+                            )
+                            .padding(vertical = 4.dp),
+                    ) {
+                        Text(text = line.text, style = style, color = dimColor)
+                        Text(
+                            text = line.text,
+                            style = style,
+                            color = textColor,
+                            modifier = Modifier.drawWithContent {
+                                clipRect(right = size.width * progress) { this@drawWithContent.drawContent() }
                             },
                         )
-                        .padding(vertical = 4.dp),
-                ) {
-                    Text(text = line.text, style = style, color = dimColor)
+                    }
+                } else {
                     Text(
-                        text = line.text,
+                        text = line.text.ifBlank { "♪" },
                         style = style,
-                        color = textColor,
-                        modifier = Modifier.drawWithContent {
-                            clipRect(right = size.width * progress) { this@drawWithContent.drawContent() }
-                        },
+                        color = activeColor,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .then(
+                                if (lyrics.synced && line.startMs >= 0) {
+                                    Modifier.clickable { onSeekTo(line.startMs) }
+                                } else {
+                                    Modifier
+                                },
+                            )
+                            .padding(vertical = 4.dp),
                     )
                 }
             } else {


### PR DESCRIPTION
Word-level karaoke lyrics with smooth fill animation.

**Data layer:**
- `WordCue(startMs, text)` domain model for per-character timing
- Mapper parses inline `[mm:ss.xx]` timestamps from enhanced LRC format
- Strips raw timestamps from display text automatically

**Rendering:**
- Active line with word-level data: left-to-right `clipRect` fill animation
- `produceState` + `withFrameNanos` for 60fps position interpolation (global position updates at 500ms)
- Falls back to standard line-level highlight for non-word-level lyrics
- Zero overhead when lyrics hidden or paused

Closes #29