### PR TITLE
feat: cache library data in Room for instant startup

### DIFF
--- a/app/schemas/com.anzupop.saki.android.data.local.database.SakiDatabase/7.json
+++ b/app/schemas/com.anzupop.saki.android.data.local.database.SakiDatabase/7.json
@@ -1,0 +1,546 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "8e4fdf5a91b0e4cb91492564b56f5737",
+    "entities": [
+      {
+        "tableName": "app_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `onboardingCompleted` INTEGER NOT NULL, `textScaleKey` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "onboardingCompleted",
+            "columnName": "onboardingCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textScaleKey",
+            "columnName": "textScaleKey",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `albumId` TEXT NOT NULL, `listType` TEXT NOT NULL, `name` TEXT NOT NULL, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `songCount` INTEGER, `durationSeconds` INTEGER, `year` INTEGER, `genre` TEXT, `created` TEXT, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `albumId`, `listType`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listType",
+            "columnName": "listType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "albumId",
+            "listType"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `name` TEXT NOT NULL, `sectionName` TEXT NOT NULL, `albumCount` INTEGER, `coverArtId` TEXT, `artistImageUrl` TEXT, PRIMARY KEY(`serverId`, `artistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sectionName",
+            "columnName": "sectionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumCount",
+            "columnName": "albumCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistImageUrl",
+            "columnName": "artistImageUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `playlistId` TEXT NOT NULL, `name` TEXT NOT NULL, `owner` TEXT, `isPublic` INTEGER, `songCount` INTEGER, `durationSeconds` INTEGER, `coverArtId` TEXT, `created` TEXT, `changed` TEXT, PRIMARY KEY(`serverId`, `playlistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPublic",
+            "columnName": "isPublic",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "changed",
+            "columnName": "changed",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "playlistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheId` TEXT NOT NULL, `serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `title` TEXT NOT NULL, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `coverArtPath` TEXT, `localPath` TEXT NOT NULL, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `suffix` TEXT, `contentType` TEXT, `qualityKey` TEXT NOT NULL, `fileSizeBytes` INTEGER NOT NULL, `downloadedAt` INTEGER NOT NULL, PRIMARY KEY(`cacheId`))",
+        "fields": [
+          {
+            "fieldPath": "cacheId",
+            "columnName": "cacheId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtPath",
+            "columnName": "coverArtPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "track",
+            "columnName": "track",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "qualityKey",
+            "columnName": "qualityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "fileSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_songs_serverId_songId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cached_songs_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `streamQualityKey` TEXT NOT NULL, `soundBalancingEnabled` INTEGER NOT NULL, `soundBalancingModeKey` TEXT NOT NULL, `streamCacheSizeMb` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamQualityKey",
+            "columnName": "streamQualityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "soundBalancingEnabled",
+            "columnName": "soundBalancingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "soundBalancingModeKey",
+            "columnName": "soundBalancingModeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamCacheSizeMb",
+            "columnName": "streamCacheSizeMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `clientName` TEXT NOT NULL, `apiVersion` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientName",
+            "columnName": "clientName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiVersion",
+            "columnName": "apiVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "server_endpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serverId` INTEGER NOT NULL, `label` TEXT NOT NULL, `baseUrl` TEXT NOT NULL, `isPrimary` INTEGER NOT NULL, `displayOrder` INTEGER NOT NULL, FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrimary",
+            "columnName": "isPrimary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_server_endpoints_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_server_endpoints_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8e4fdf5a91b0e4cb91492564b56f5737')"
+    ]
+  }
+}

--- a/app/src/main/java/com/anzupop/saki/android/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/local/dao/LibraryCacheDao.kt
@@ -1,0 +1,59 @@
+package com.anzupop.saki.android.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.anzupop.saki.android.data.local.entity.CachedAlbumEntity
+import com.anzupop.saki.android.data.local.entity.CachedArtistEntity
+import com.anzupop.saki.android.data.local.entity.CachedPlaylistEntity
+
+@Dao
+interface LibraryCacheDao {
+
+    @Query("SELECT * FROM cached_artists WHERE serverId = :serverId ORDER BY sectionName, name")
+    suspend fun getArtists(serverId: Long): List<CachedArtistEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertArtists(artists: List<CachedArtistEntity>)
+
+    @Query("DELETE FROM cached_artists WHERE serverId = :serverId")
+    suspend fun clearArtists(serverId: Long)
+
+    @Transaction
+    suspend fun replaceArtists(serverId: Long, artists: List<CachedArtistEntity>) {
+        clearArtists(serverId)
+        insertArtists(artists)
+    }
+
+    @Query("SELECT * FROM cached_albums WHERE serverId = :serverId AND listType = :listType ORDER BY sortOrder")
+    suspend fun getAlbums(serverId: Long, listType: String): List<CachedAlbumEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAlbums(albums: List<CachedAlbumEntity>)
+
+    @Query("DELETE FROM cached_albums WHERE serverId = :serverId AND listType = :listType")
+    suspend fun clearAlbums(serverId: Long, listType: String)
+
+    @Transaction
+    suspend fun replaceAlbums(serverId: Long, listType: String, albums: List<CachedAlbumEntity>) {
+        clearAlbums(serverId, listType)
+        insertAlbums(albums)
+    }
+
+    @Query("SELECT * FROM cached_playlists WHERE serverId = :serverId ORDER BY name")
+    suspend fun getPlaylists(serverId: Long): List<CachedPlaylistEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPlaylists(playlists: List<CachedPlaylistEntity>)
+
+    @Query("DELETE FROM cached_playlists WHERE serverId = :serverId")
+    suspend fun clearPlaylists(serverId: Long)
+
+    @Transaction
+    suspend fun replacePlaylists(serverId: Long, playlists: List<CachedPlaylistEntity>) {
+        clearPlaylists(serverId)
+        insertPlaylists(playlists)
+    }
+}

--- a/app/src/main/java/com/anzupop/saki/android/data/local/database/SakiDatabase.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/local/database/SakiDatabase.kt
@@ -3,10 +3,14 @@ package com.anzupop.saki.android.data.local.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.anzupop.saki.android.data.local.dao.CachedSongDao
+import com.anzupop.saki.android.data.local.dao.LibraryCacheDao
 import com.anzupop.saki.android.data.local.dao.PlaybackPreferencesDao
 import com.anzupop.saki.android.data.local.dao.AppPreferencesDao
 import com.anzupop.saki.android.data.local.dao.ServerConfigDao
 import com.anzupop.saki.android.data.local.entity.AppPreferencesEntity
+import com.anzupop.saki.android.data.local.entity.CachedAlbumEntity
+import com.anzupop.saki.android.data.local.entity.CachedArtistEntity
+import com.anzupop.saki.android.data.local.entity.CachedPlaylistEntity
 import com.anzupop.saki.android.data.local.entity.CachedSongEntity
 import com.anzupop.saki.android.data.local.entity.PlaybackPreferencesEntity
 import com.anzupop.saki.android.data.local.entity.ServerEndpointEntity
@@ -15,18 +19,23 @@ import com.anzupop.saki.android.data.local.entity.ServerEntity
 @Database(
     entities = [
         AppPreferencesEntity::class,
+        CachedAlbumEntity::class,
+        CachedArtistEntity::class,
+        CachedPlaylistEntity::class,
         CachedSongEntity::class,
         PlaybackPreferencesEntity::class,
         ServerEntity::class,
         ServerEndpointEntity::class,
     ],
-    version = 6,
+    version = 7,
     exportSchema = true,
 )
 abstract class SakiDatabase : RoomDatabase() {
     abstract fun appPreferencesDao(): AppPreferencesDao
 
     abstract fun cachedSongDao(): CachedSongDao
+
+    abstract fun libraryCacheDao(): LibraryCacheDao
 
     abstract fun playbackPreferencesDao(): PlaybackPreferencesDao
 

--- a/app/src/main/java/com/anzupop/saki/android/data/local/entity/CachedAlbumEntity.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/local/entity/CachedAlbumEntity.kt
@@ -1,0 +1,20 @@
+package com.anzupop.saki.android.data.local.entity
+
+import androidx.room.Entity
+
+@Entity(tableName = "cached_albums", primaryKeys = ["serverId", "albumId", "listType"])
+data class CachedAlbumEntity(
+    val serverId: Long,
+    val albumId: String,
+    val listType: String,
+    val name: String,
+    val artist: String?,
+    val artistId: String?,
+    val coverArtId: String?,
+    val songCount: Int?,
+    val durationSeconds: Int?,
+    val year: Int?,
+    val genre: String?,
+    val created: String?,
+    val sortOrder: Int,
+)

--- a/app/src/main/java/com/anzupop/saki/android/data/local/entity/CachedArtistEntity.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/local/entity/CachedArtistEntity.kt
@@ -1,0 +1,14 @@
+package com.anzupop.saki.android.data.local.entity
+
+import androidx.room.Entity
+
+@Entity(tableName = "cached_artists", primaryKeys = ["serverId", "artistId"])
+data class CachedArtistEntity(
+    val serverId: Long,
+    val artistId: String,
+    val name: String,
+    val sectionName: String,
+    val albumCount: Int?,
+    val coverArtId: String?,
+    val artistImageUrl: String?,
+)

--- a/app/src/main/java/com/anzupop/saki/android/data/local/entity/CachedPlaylistEntity.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/local/entity/CachedPlaylistEntity.kt
@@ -1,0 +1,17 @@
+package com.anzupop.saki.android.data.local.entity
+
+import androidx.room.Entity
+
+@Entity(tableName = "cached_playlists", primaryKeys = ["serverId", "playlistId"])
+data class CachedPlaylistEntity(
+    val serverId: Long,
+    val playlistId: String,
+    val name: String,
+    val owner: String?,
+    val isPublic: Boolean?,
+    val songCount: Int?,
+    val durationSeconds: Int?,
+    val coverArtId: String?,
+    val created: String?,
+    val changed: String?,
+)

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultLibraryCacheRepository.kt
@@ -1,0 +1,134 @@
+package com.anzupop.saki.android.data.repository
+
+import com.anzupop.saki.android.data.local.dao.LibraryCacheDao
+import com.anzupop.saki.android.data.local.entity.CachedAlbumEntity
+import com.anzupop.saki.android.data.local.entity.CachedArtistEntity
+import com.anzupop.saki.android.data.local.entity.CachedPlaylistEntity
+import com.anzupop.saki.android.domain.model.AlbumListType
+import com.anzupop.saki.android.domain.model.AlbumSummary
+import com.anzupop.saki.android.domain.model.ArtistSection
+import com.anzupop.saki.android.domain.model.ArtistSummary
+import com.anzupop.saki.android.domain.model.LibraryIndexes
+import com.anzupop.saki.android.domain.model.PlaylistSummary
+import com.anzupop.saki.android.domain.repository.LibraryCacheRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DefaultLibraryCacheRepository @Inject constructor(
+    private val dao: LibraryCacheDao,
+) : LibraryCacheRepository {
+
+    override suspend fun getArtists(serverId: Long): LibraryIndexes? {
+        val entities = dao.getArtists(serverId)
+        if (entities.isEmpty()) return null
+        // groupBy on an ordered list preserves insertion order (LinkedHashMap)
+        val sections = entities.groupBy(CachedArtistEntity::sectionName).map { (name, artists) ->
+            ArtistSection(
+                name = name,
+                artists = artists.map { it.toDomain() },
+            )
+        }
+        return LibraryIndexes(
+            lastModified = null,
+            ignoredArticles = null,
+            shortcuts = emptyList(),
+            sections = sections,
+        )
+    }
+
+    override suspend fun saveArtists(serverId: Long, indexes: LibraryIndexes) {
+        val entities = indexes.sections.flatMap { section ->
+            section.artists.map { artist ->
+                CachedArtistEntity(
+                    serverId = serverId,
+                    artistId = artist.id,
+                    name = artist.name,
+                    sectionName = section.name,
+                    albumCount = artist.albumCount,
+                    coverArtId = artist.coverArtId,
+                    artistImageUrl = artist.artistImageUrl,
+                )
+            }
+        }
+        dao.replaceArtists(serverId, entities)
+    }
+
+    override suspend fun getAlbums(serverId: Long, type: AlbumListType): List<AlbumSummary> =
+        dao.getAlbums(serverId, type.apiValue).map { it.toDomain() }
+
+    override suspend fun saveAlbums(serverId: Long, type: AlbumListType, albums: List<AlbumSummary>) {
+        val entities = albums.mapIndexed { index, album ->
+            CachedAlbumEntity(
+                serverId = serverId,
+                albumId = album.id,
+                listType = type.apiValue,
+                name = album.name,
+                artist = album.artist,
+                artistId = album.artistId,
+                coverArtId = album.coverArtId,
+                songCount = album.songCount,
+                durationSeconds = album.durationSeconds,
+                year = album.year,
+                genre = album.genre,
+                created = album.created,
+                sortOrder = index,
+            )
+        }
+        dao.replaceAlbums(serverId, type.apiValue, entities)
+    }
+
+    override suspend fun getPlaylists(serverId: Long): List<PlaylistSummary> =
+        dao.getPlaylists(serverId).map { it.toDomain() }
+
+    override suspend fun savePlaylists(serverId: Long, playlists: List<PlaylistSummary>) {
+        val entities = playlists.map { playlist ->
+            CachedPlaylistEntity(
+                serverId = serverId,
+                playlistId = playlist.id,
+                name = playlist.name,
+                owner = playlist.owner,
+                isPublic = playlist.isPublic,
+                songCount = playlist.songCount,
+                durationSeconds = playlist.durationSeconds,
+                coverArtId = playlist.coverArtId,
+                created = playlist.created,
+                changed = playlist.changed,
+            )
+        }
+        dao.replacePlaylists(serverId, entities)
+    }
+
+    private fun CachedArtistEntity.toDomain() = ArtistSummary(
+        id = artistId,
+        name = name,
+        albumCount = albumCount,
+        coverArtId = coverArtId,
+        artistImageUrl = artistImageUrl,
+    )
+
+    private fun CachedAlbumEntity.toDomain() = AlbumSummary(
+        id = albumId,
+        name = name,
+        artist = artist,
+        artistId = artistId,
+        coverArtId = coverArtId,
+        songCount = songCount,
+        durationSeconds = durationSeconds,
+        year = year,
+        genre = genre,
+        created = created,
+    )
+
+    private fun CachedPlaylistEntity.toDomain() = PlaylistSummary(
+        id = playlistId,
+        name = name,
+        owner = owner,
+        isPublic = isPublic,
+        songCount = songCount,
+        durationSeconds = durationSeconds,
+        coverArtId = coverArtId,
+        created = created,
+        changed = changed,
+    )
+}

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultLibraryCacheRepository.kt
@@ -4,6 +4,7 @@ import com.anzupop.saki.android.data.local.dao.LibraryCacheDao
 import com.anzupop.saki.android.data.local.entity.CachedAlbumEntity
 import com.anzupop.saki.android.data.local.entity.CachedArtistEntity
 import com.anzupop.saki.android.data.local.entity.CachedPlaylistEntity
+import com.anzupop.saki.android.di.IoDispatcher
 import com.anzupop.saki.android.domain.model.AlbumListType
 import com.anzupop.saki.android.domain.model.AlbumSummary
 import com.anzupop.saki.android.domain.model.ArtistSection
@@ -11,17 +12,20 @@ import com.anzupop.saki.android.domain.model.ArtistSummary
 import com.anzupop.saki.android.domain.model.LibraryIndexes
 import com.anzupop.saki.android.domain.model.PlaylistSummary
 import com.anzupop.saki.android.domain.repository.LibraryCacheRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class DefaultLibraryCacheRepository @Inject constructor(
     private val dao: LibraryCacheDao,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : LibraryCacheRepository {
 
-    override suspend fun getArtists(serverId: Long): LibraryIndexes? {
+    override suspend fun getArtists(serverId: Long): LibraryIndexes? = withContext(ioDispatcher) {
         val entities = dao.getArtists(serverId)
-        if (entities.isEmpty()) return null
+        if (entities.isEmpty()) return@withContext null
         // groupBy on an ordered list preserves insertion order (LinkedHashMap)
         val sections = entities.groupBy(CachedArtistEntity::sectionName).map { (name, artists) ->
             ArtistSection(
@@ -29,7 +33,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
                 artists = artists.map { it.toDomain() },
             )
         }
-        return LibraryIndexes(
+        LibraryIndexes(
             lastModified = null,
             ignoredArticles = null,
             shortcuts = emptyList(),
@@ -37,7 +41,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
         )
     }
 
-    override suspend fun saveArtists(serverId: Long, indexes: LibraryIndexes) {
+    override suspend fun saveArtists(serverId: Long, indexes: LibraryIndexes) = withContext(ioDispatcher) {
         val entities = indexes.sections.flatMap { section ->
             section.artists.map { artist ->
                 CachedArtistEntity(
@@ -54,10 +58,11 @@ class DefaultLibraryCacheRepository @Inject constructor(
         dao.replaceArtists(serverId, entities)
     }
 
-    override suspend fun getAlbums(serverId: Long, type: AlbumListType): List<AlbumSummary> =
+    override suspend fun getAlbums(serverId: Long, type: AlbumListType): List<AlbumSummary> = withContext(ioDispatcher) {
         dao.getAlbums(serverId, type.apiValue).map { it.toDomain() }
+    }
 
-    override suspend fun saveAlbums(serverId: Long, type: AlbumListType, albums: List<AlbumSummary>) {
+    override suspend fun saveAlbums(serverId: Long, type: AlbumListType, albums: List<AlbumSummary>) = withContext(ioDispatcher) {
         val entities = albums.mapIndexed { index, album ->
             CachedAlbumEntity(
                 serverId = serverId,
@@ -78,10 +83,11 @@ class DefaultLibraryCacheRepository @Inject constructor(
         dao.replaceAlbums(serverId, type.apiValue, entities)
     }
 
-    override suspend fun getPlaylists(serverId: Long): List<PlaylistSummary> =
+    override suspend fun getPlaylists(serverId: Long): List<PlaylistSummary> = withContext(ioDispatcher) {
         dao.getPlaylists(serverId).map { it.toDomain() }
+    }
 
-    override suspend fun savePlaylists(serverId: Long, playlists: List<PlaylistSummary>) {
+    override suspend fun savePlaylists(serverId: Long, playlists: List<PlaylistSummary>) = withContext(ioDispatcher) {
         val entities = playlists.map { playlist ->
             CachedPlaylistEntity(
                 serverId = serverId,

--- a/app/src/main/java/com/anzupop/saki/android/di/DatabaseModule.kt
+++ b/app/src/main/java/com/anzupop/saki/android/di/DatabaseModule.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.anzupop.saki.android.data.local.dao.AppPreferencesDao
 import com.anzupop.saki.android.data.local.dao.CachedSongDao
+import com.anzupop.saki.android.data.local.dao.LibraryCacheDao
 import com.anzupop.saki.android.data.local.dao.PlaybackPreferencesDao
 import com.anzupop.saki.android.data.local.dao.ServerConfigDao
 import com.anzupop.saki.android.data.local.database.SakiDatabase
@@ -141,6 +142,62 @@ object DatabaseModule {
         }
     }
 
+    private val migration6To7 = object : Migration(6, 7) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_artists` (
+                    `serverId` INTEGER NOT NULL,
+                    `artistId` TEXT NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `sectionName` TEXT NOT NULL,
+                    `albumCount` INTEGER,
+                    `coverArtId` TEXT,
+                    `artistImageUrl` TEXT,
+                    PRIMARY KEY(`serverId`, `artistId`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_albums` (
+                    `serverId` INTEGER NOT NULL,
+                    `albumId` TEXT NOT NULL,
+                    `listType` TEXT NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `artist` TEXT,
+                    `artistId` TEXT,
+                    `coverArtId` TEXT,
+                    `songCount` INTEGER,
+                    `durationSeconds` INTEGER,
+                    `year` INTEGER,
+                    `genre` TEXT,
+                    `created` TEXT,
+                    `sortOrder` INTEGER NOT NULL,
+                    PRIMARY KEY(`serverId`, `albumId`, `listType`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_playlists` (
+                    `serverId` INTEGER NOT NULL,
+                    `playlistId` TEXT NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `owner` TEXT,
+                    `isPublic` INTEGER,
+                    `songCount` INTEGER,
+                    `durationSeconds` INTEGER,
+                    `coverArtId` TEXT,
+                    `created` TEXT,
+                    `changed` TEXT,
+                    PRIMARY KEY(`serverId`, `playlistId`)
+                )
+                """.trimIndent(),
+            )
+        }
+    }
+
     @Provides
     @Singleton
     fun provideSakiDatabase(
@@ -150,7 +207,7 @@ object DatabaseModule {
             context,
             SakiDatabase::class.java,
             "saki.db",
-        ).addMigrations(migration1To2, migration2To3, migration3To4, migration4To5, migration5To6)
+        ).addMigrations(migration1To2, migration2To3, migration3To4, migration4To5, migration5To6, migration6To7)
             .build()
     }
 
@@ -159,6 +216,9 @@ object DatabaseModule {
 
     @Provides
     fun provideCachedSongDao(database: SakiDatabase): CachedSongDao = database.cachedSongDao()
+
+    @Provides
+    fun provideLibraryCacheDao(database: SakiDatabase): LibraryCacheDao = database.libraryCacheDao()
 
     @Provides
     fun providePlaybackPreferencesDao(database: SakiDatabase): PlaybackPreferencesDao = database.playbackPreferencesDao()

--- a/app/src/main/java/com/anzupop/saki/android/di/RepositoryModule.kt
+++ b/app/src/main/java/com/anzupop/saki/android/di/RepositoryModule.kt
@@ -4,12 +4,14 @@ import androidx.media3.common.util.UnstableApi
 import com.anzupop.saki.android.data.remote.SubsonicConnectionTester
 import com.anzupop.saki.android.data.repository.DefaultAppPreferencesRepository
 import com.anzupop.saki.android.data.repository.DefaultCachedSongRepository
+import com.anzupop.saki.android.data.repository.DefaultLibraryCacheRepository
 import com.anzupop.saki.android.data.repository.DefaultPlaybackPreferencesRepository
 import com.anzupop.saki.android.data.repository.DefaultServerConfigRepository
 import com.anzupop.saki.android.data.repository.DefaultStreamCacheRepository
 import com.anzupop.saki.android.data.repository.DefaultSubsonicRepository
 import com.anzupop.saki.android.domain.repository.AppPreferencesRepository
 import com.anzupop.saki.android.domain.repository.CachedSongRepository
+import com.anzupop.saki.android.domain.repository.LibraryCacheRepository
 import com.anzupop.saki.android.domain.repository.PlaybackManager
 import com.anzupop.saki.android.domain.repository.PlaybackPreferencesRepository
 import com.anzupop.saki.android.domain.repository.ServerConfigRepository
@@ -54,6 +56,11 @@ abstract class RepositoryModule {
     abstract fun bindCachedSongRepository(
         repository: DefaultCachedSongRepository,
     ): CachedSongRepository
+
+    @Binds
+    abstract fun bindLibraryCacheRepository(
+        repository: DefaultLibraryCacheRepository,
+    ): LibraryCacheRepository
 
     @Binds
     @UnstableApi

--- a/app/src/main/java/com/anzupop/saki/android/domain/repository/LibraryCacheRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/repository/LibraryCacheRepository.kt
@@ -1,0 +1,15 @@
+package com.anzupop.saki.android.domain.repository
+
+import com.anzupop.saki.android.domain.model.AlbumListType
+import com.anzupop.saki.android.domain.model.AlbumSummary
+import com.anzupop.saki.android.domain.model.LibraryIndexes
+import com.anzupop.saki.android.domain.model.PlaylistSummary
+
+interface LibraryCacheRepository {
+    suspend fun getArtists(serverId: Long): LibraryIndexes?
+    suspend fun saveArtists(serverId: Long, indexes: LibraryIndexes)
+    suspend fun getAlbums(serverId: Long, type: AlbumListType): List<AlbumSummary>
+    suspend fun saveAlbums(serverId: Long, type: AlbumListType, albums: List<AlbumSummary>)
+    suspend fun getPlaylists(serverId: Long): List<PlaylistSummary>
+    suspend fun savePlaylists(serverId: Long, playlists: List<PlaylistSummary>)
+}

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -21,6 +21,7 @@ import com.anzupop.saki.android.domain.model.StreamQuality
 import com.anzupop.saki.android.domain.model.TextScale
 import com.anzupop.saki.android.domain.repository.AppPreferencesRepository
 import com.anzupop.saki.android.domain.repository.CachedSongRepository
+import com.anzupop.saki.android.domain.repository.LibraryCacheRepository
 import com.anzupop.saki.android.domain.repository.PlaybackManager
 import com.anzupop.saki.android.domain.repository.PlaybackPreferencesRepository
 import com.anzupop.saki.android.domain.repository.ServerConfigRepository
@@ -52,6 +53,7 @@ class SakiAppViewModel @Inject constructor(
     private val cachedSongRepository: CachedSongRepository,
     private val streamCacheRepository: StreamCacheRepository,
     private val playbackPreferencesRepository: PlaybackPreferencesRepository,
+    private val libraryCacheRepository: LibraryCacheRepository,
     private val playbackManager: PlaybackManager,
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(SakiAppUiState())
@@ -733,33 +735,25 @@ class SakiAppViewModel @Inject constructor(
     ) {
         if (!forceRefresh && uiState.value.libraryIndexes != null) return
 
-        mutableUiState.update { state ->
-            state.copy(
-                isArtistsLoading = true,
-                artistsError = null,
-            )
-        }
-
         viewModelScope.launch {
+            if (!forceRefresh) {
+                val cached = runCatching { libraryCacheRepository.getArtists(serverId) }.getOrNull()
+                if (cached != null && uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { it.copy(libraryIndexes = cached) }
+                }
+            }
+
+            mutableUiState.update { it.copy(isArtistsLoading = true, artistsError = null) }
+
             runCatching {
                 subsonicRepository.getIndexes(serverId).data
             }.onSuccess { indexes ->
                 if (uiState.value.selectedServerId == serverId) {
-                    mutableUiState.update { state ->
-                        state.copy(
-                            libraryIndexes = indexes,
-                            isArtistsLoading = false,
-                            artistsError = null,
-                        )
-                    }
+                    mutableUiState.update { it.copy(libraryIndexes = indexes, isArtistsLoading = false, artistsError = null) }
                 }
+                runCatching { libraryCacheRepository.saveArtists(serverId, indexes) }
             }.onFailure { throwable ->
-                mutableUiState.update { state ->
-                    state.copy(
-                        isArtistsLoading = false,
-                        artistsError = throwable.message ?: "Unable to load artists.",
-                    )
-                }
+                mutableUiState.update { it.copy(isArtistsLoading = false, artistsError = throwable.message ?: "Unable to load artists.") }
             }
         }
     }
@@ -773,37 +767,25 @@ class SakiAppViewModel @Inject constructor(
             return
         }
 
-        mutableUiState.update { state ->
-            state.copy(
-                isAlbumsLoading = true,
-                albumsError = null,
-            )
-        }
-
         viewModelScope.launch {
+            if (!forceRefresh) {
+                val cached = runCatching { libraryCacheRepository.getAlbums(serverId, type) }.getOrNull()
+                if (!cached.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { it.copy(albums = cached) }
+                }
+            }
+
+            mutableUiState.update { it.copy(isAlbumsLoading = true, albumsError = null) }
+
             runCatching {
-                subsonicRepository.getAlbumList(
-                    serverId = serverId,
-                    type = type,
-                    size = 36,
-                ).data
+                subsonicRepository.getAlbumList(serverId = serverId, type = type, size = 36).data
             }.onSuccess { albums ->
                 if (uiState.value.selectedServerId == serverId) {
-                    mutableUiState.update { state ->
-                        state.copy(
-                            albums = albums,
-                            isAlbumsLoading = false,
-                            albumsError = null,
-                        )
-                    }
+                    mutableUiState.update { it.copy(albums = albums, isAlbumsLoading = false, albumsError = null) }
                 }
+                runCatching { libraryCacheRepository.saveAlbums(serverId, type, albums) }
             }.onFailure { throwable ->
-                mutableUiState.update { state ->
-                    state.copy(
-                        isAlbumsLoading = false,
-                        albumsError = throwable.message ?: "Unable to load albums.",
-                    )
-                }
+                mutableUiState.update { it.copy(isAlbumsLoading = false, albumsError = throwable.message ?: "Unable to load albums.") }
             }
         }
     }
@@ -814,33 +796,25 @@ class SakiAppViewModel @Inject constructor(
     ) {
         if (!forceRefresh && uiState.value.playlists.isNotEmpty()) return
 
-        mutableUiState.update { state ->
-            state.copy(
-                isPlaylistsLoading = true,
-                playlistsError = null,
-            )
-        }
-
         viewModelScope.launch {
+            if (!forceRefresh) {
+                val cached = runCatching { libraryCacheRepository.getPlaylists(serverId) }.getOrNull()
+                if (!cached.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { it.copy(playlists = cached) }
+                }
+            }
+
+            mutableUiState.update { it.copy(isPlaylistsLoading = true, playlistsError = null) }
+
             runCatching {
                 subsonicRepository.getPlaylists(serverId).data
             }.onSuccess { playlists ->
                 if (uiState.value.selectedServerId == serverId) {
-                    mutableUiState.update { state ->
-                        state.copy(
-                            playlists = playlists,
-                            isPlaylistsLoading = false,
-                            playlistsError = null,
-                        )
-                    }
+                    mutableUiState.update { it.copy(playlists = playlists, isPlaylistsLoading = false, playlistsError = null) }
                 }
+                runCatching { libraryCacheRepository.savePlaylists(serverId, playlists) }
             }.onFailure { throwable ->
-                mutableUiState.update { state ->
-                    state.copy(
-                        isPlaylistsLoading = false,
-                        playlistsError = throwable.message ?: "Unable to load playlists.",
-                    )
-                }
+                mutableUiState.update { it.copy(isPlaylistsLoading = false, playlistsError = throwable.message ?: "Unable to load playlists.") }
             }
         }
     }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -1,5 +1,6 @@
 package com.anzupop.saki.android.presentation
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.anzupop.saki.android.domain.model.Album
@@ -752,6 +753,7 @@ class SakiAppViewModel @Inject constructor(
                     mutableUiState.update { it.copy(libraryIndexes = indexes, isArtistsLoading = false, artistsError = null) }
                 }
                 runCatching { libraryCacheRepository.saveArtists(serverId, indexes) }
+                    .onFailure { Log.w("SakiApp", "Failed to cache artists", it) }
             }.onFailure { throwable ->
                 mutableUiState.update { it.copy(isArtistsLoading = false, artistsError = throwable.message ?: "Unable to load artists.") }
             }
@@ -784,6 +786,7 @@ class SakiAppViewModel @Inject constructor(
                     mutableUiState.update { it.copy(albums = albums, isAlbumsLoading = false, albumsError = null) }
                 }
                 runCatching { libraryCacheRepository.saveAlbums(serverId, type, albums) }
+                    .onFailure { Log.w("SakiApp", "Failed to cache albums", it) }
             }.onFailure { throwable ->
                 mutableUiState.update { it.copy(isAlbumsLoading = false, albumsError = throwable.message ?: "Unable to load albums.") }
             }
@@ -813,6 +816,7 @@ class SakiAppViewModel @Inject constructor(
                     mutableUiState.update { it.copy(playlists = playlists, isPlaylistsLoading = false, playlistsError = null) }
                 }
                 runCatching { libraryCacheRepository.savePlaylists(serverId, playlists) }
+                    .onFailure { Log.w("SakiApp", "Failed to cache playlists", it) }
             }.onFailure { throwable ->
                 mutableUiState.update { it.copy(isPlaylistsLoading = false, playlistsError = throwable.message ?: "Unable to load playlists.") }
             }


### PR DESCRIPTION
## Summary

Cache artists, albums, and playlists in Room so the app renders instantly on startup instead of waiting for API responses. Especially impactful on slow/VPN connections.

## Changes

- **3 new Room entities**: `CachedArtistEntity`, `CachedAlbumEntity`, `CachedPlaylistEntity`
- **`LibraryCacheDao`**: transactional replace (clear + insert) per server/type
- **`LibraryCacheRepository`**: domain ↔ entity mapping with section grouping for artists
- **Migration 6→7**: CREATE TABLE for all 3 cache tables
- **ViewModel**: `loadArtists`, `loadAlbums`, `loadPlaylists` now load from cache first, then refresh from API and update cache. `forceRefresh` (pull-to-refresh) bypasses cache.

## Behavior

1. First launch: normal API load, results saved to cache
2. Subsequent launches: instant render from cache → silent background refresh
3. Pull-to-refresh: skip cache, force API fetch

## Known limitations (tracked in #38)

- No `cachedAt` timestamp (always refreshes from API anyway)
- No cascade delete when server is removed
- `shortcuts` (pinned artists) not persisted in cache

## Testing

Verified on Xiaomi myron (Android 16) — second launch shows cached data instantly with Coil disk-cached covers.

Closes #37