### PR TITLE
fix: Songs tab full library + persist playback session

### DIFF
--- a/app/schemas/com.anzupop.saki.android.data.local.database.SakiDatabase/9.json
+++ b/app/schemas/com.anzupop.saki.android.data.local.database.SakiDatabase/9.json
@@ -1,0 +1,668 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "85c1ef47f293e08e576da98fd581a5e2",
+    "entities": [
+      {
+        "tableName": "app_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `onboardingCompleted` INTEGER NOT NULL, `textScaleKey` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "onboardingCompleted",
+            "columnName": "onboardingCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textScaleKey",
+            "columnName": "textScaleKey",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `albumId` TEXT NOT NULL, `listType` TEXT NOT NULL, `name` TEXT NOT NULL, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `songCount` INTEGER, `durationSeconds` INTEGER, `year` INTEGER, `genre` TEXT, `created` TEXT, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `albumId`, `listType`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listType",
+            "columnName": "listType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "albumId",
+            "listType"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `name` TEXT NOT NULL, `sectionName` TEXT NOT NULL, `albumCount` INTEGER, `coverArtId` TEXT, `artistImageUrl` TEXT, PRIMARY KEY(`serverId`, `artistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sectionName",
+            "columnName": "sectionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumCount",
+            "columnName": "albumCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistImageUrl",
+            "columnName": "artistImageUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_library_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `parentId` TEXT, `title` TEXT NOT NULL, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `year` INTEGER, `genre` TEXT, `bitRate` INTEGER, `suffix` TEXT, `contentType` TEXT, `sizeBytes` INTEGER, `path` TEXT, `created` TEXT, PRIMARY KEY(`serverId`, `songId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "track",
+            "columnName": "track",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "songId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `playlistId` TEXT NOT NULL, `name` TEXT NOT NULL, `owner` TEXT, `isPublic` INTEGER, `songCount` INTEGER, `durationSeconds` INTEGER, `coverArtId` TEXT, `created` TEXT, `changed` TEXT, PRIMARY KEY(`serverId`, `playlistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPublic",
+            "columnName": "isPublic",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "changed",
+            "columnName": "changed",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "playlistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheId` TEXT NOT NULL, `serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `title` TEXT NOT NULL, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `coverArtPath` TEXT, `localPath` TEXT NOT NULL, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `suffix` TEXT, `contentType` TEXT, `qualityKey` TEXT NOT NULL, `fileSizeBytes` INTEGER NOT NULL, `downloadedAt` INTEGER NOT NULL, PRIMARY KEY(`cacheId`))",
+        "fields": [
+          {
+            "fieldPath": "cacheId",
+            "columnName": "cacheId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtPath",
+            "columnName": "coverArtPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "track",
+            "columnName": "track",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "qualityKey",
+            "columnName": "qualityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "fileSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_songs_serverId_songId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cached_songs_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `streamQualityKey` TEXT NOT NULL, `soundBalancingEnabled` INTEGER NOT NULL, `soundBalancingModeKey` TEXT NOT NULL, `streamCacheSizeMb` INTEGER NOT NULL, `bluetoothLyricsEnabled` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamQualityKey",
+            "columnName": "streamQualityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "soundBalancingEnabled",
+            "columnName": "soundBalancingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "soundBalancingModeKey",
+            "columnName": "soundBalancingModeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamCacheSizeMb",
+            "columnName": "streamCacheSizeMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bluetoothLyricsEnabled",
+            "columnName": "bluetoothLyricsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `clientName` TEXT NOT NULL, `apiVersion` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientName",
+            "columnName": "clientName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiVersion",
+            "columnName": "apiVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "server_endpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serverId` INTEGER NOT NULL, `label` TEXT NOT NULL, `baseUrl` TEXT NOT NULL, `isPrimary` INTEGER NOT NULL, `displayOrder` INTEGER NOT NULL, FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrimary",
+            "columnName": "isPrimary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_server_endpoints_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_server_endpoints_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '85c1ef47f293e08e576da98fd581a5e2')"
+    ]
+  }
+}

--- a/app/schemas/com.anzupop.saki.android.data.local.database.SakiDatabase/9.json
+++ b/app/schemas/com.anzupop.saki.android.data.local.database.SakiDatabase/9.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 9,
-    "identityHash": "85c1ef47f293e08e576da98fd581a5e2",
+    "identityHash": "3693474c353c5d089ad07c452c05f4e8",
     "entities": [
       {
         "tableName": "app_preferences",
@@ -172,7 +172,7 @@
       },
       {
         "tableName": "cached_library_songs",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `parentId` TEXT, `title` TEXT NOT NULL, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `year` INTEGER, `genre` TEXT, `bitRate` INTEGER, `suffix` TEXT, `contentType` TEXT, `sizeBytes` INTEGER, `path` TEXT, `created` TEXT, PRIMARY KEY(`serverId`, `songId`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `parentId` TEXT, `title` TEXT NOT NULL COLLATE NOCASE, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `year` INTEGER, `genre` TEXT, `bitRate` INTEGER, `suffix` TEXT, `contentType` TEXT, `sizeBytes` INTEGER, `path` TEXT, `created` TEXT, PRIMARY KEY(`serverId`, `songId`))",
         "fields": [
           {
             "fieldPath": "serverId",
@@ -284,7 +284,19 @@
             "serverId",
             "songId"
           ]
-        }
+        },
+        "indices": [
+          {
+            "name": "index_cached_library_songs_serverId_title",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_library_songs_serverId_title` ON `${TABLE_NAME}` (`serverId`, `title`)"
+          }
+        ]
       },
       {
         "tableName": "cached_playlists",
@@ -662,7 +674,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '85c1ef47f293e08e576da98fd581a5e2')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3693474c353c5d089ad07c452c05f4e8')"
     ]
   }
 }

--- a/app/src/main/java/com/anzupop/saki/android/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/local/dao/LibraryCacheDao.kt
@@ -7,6 +7,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import com.anzupop.saki.android.data.local.entity.CachedAlbumEntity
 import com.anzupop.saki.android.data.local.entity.CachedArtistEntity
+import com.anzupop.saki.android.data.local.entity.CachedLibrarySongEntity
 import com.anzupop.saki.android.data.local.entity.CachedPlaylistEntity
 
 @Dao
@@ -55,5 +56,20 @@ interface LibraryCacheDao {
     suspend fun replacePlaylists(serverId: Long, playlists: List<CachedPlaylistEntity>) {
         clearPlaylists(serverId)
         insertPlaylists(playlists)
+    }
+
+    @Query("SELECT * FROM cached_library_songs WHERE serverId = :serverId ORDER BY title COLLATE NOCASE")
+    suspend fun getSongs(serverId: Long): List<CachedLibrarySongEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSongs(songs: List<CachedLibrarySongEntity>)
+
+    @Query("DELETE FROM cached_library_songs WHERE serverId = :serverId")
+    suspend fun clearSongs(serverId: Long)
+
+    @Transaction
+    suspend fun replaceSongs(serverId: Long, songs: List<CachedLibrarySongEntity>) {
+        clearSongs(serverId)
+        insertSongs(songs)
     }
 }

--- a/app/src/main/java/com/anzupop/saki/android/data/local/database/SakiDatabase.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/local/database/SakiDatabase.kt
@@ -10,6 +10,7 @@ import com.anzupop.saki.android.data.local.dao.ServerConfigDao
 import com.anzupop.saki.android.data.local.entity.AppPreferencesEntity
 import com.anzupop.saki.android.data.local.entity.CachedAlbumEntity
 import com.anzupop.saki.android.data.local.entity.CachedArtistEntity
+import com.anzupop.saki.android.data.local.entity.CachedLibrarySongEntity
 import com.anzupop.saki.android.data.local.entity.CachedPlaylistEntity
 import com.anzupop.saki.android.data.local.entity.CachedSongEntity
 import com.anzupop.saki.android.data.local.entity.PlaybackPreferencesEntity
@@ -21,13 +22,14 @@ import com.anzupop.saki.android.data.local.entity.ServerEntity
         AppPreferencesEntity::class,
         CachedAlbumEntity::class,
         CachedArtistEntity::class,
+        CachedLibrarySongEntity::class,
         CachedPlaylistEntity::class,
         CachedSongEntity::class,
         PlaybackPreferencesEntity::class,
         ServerEntity::class,
         ServerEndpointEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = true,
 )
 abstract class SakiDatabase : RoomDatabase() {

--- a/app/src/main/java/com/anzupop/saki/android/data/local/entity/CachedLibrarySongEntity.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/local/entity/CachedLibrarySongEntity.kt
@@ -1,12 +1,19 @@
 package com.anzupop.saki.android.data.local.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.Index
 
-@Entity(tableName = "cached_library_songs", primaryKeys = ["serverId", "songId"])
+@Entity(
+    tableName = "cached_library_songs",
+    primaryKeys = ["serverId", "songId"],
+    indices = [Index(value = ["serverId", "title"])],
+)
 data class CachedLibrarySongEntity(
     val serverId: Long,
     val songId: String,
     val parentId: String?,
+    @ColumnInfo(collate = ColumnInfo.NOCASE)
     val title: String,
     val album: String?,
     val albumId: String?,

--- a/app/src/main/java/com/anzupop/saki/android/data/local/entity/CachedLibrarySongEntity.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/local/entity/CachedLibrarySongEntity.kt
@@ -1,0 +1,27 @@
+package com.anzupop.saki.android.data.local.entity
+
+import androidx.room.Entity
+
+@Entity(tableName = "cached_library_songs", primaryKeys = ["serverId", "songId"])
+data class CachedLibrarySongEntity(
+    val serverId: Long,
+    val songId: String,
+    val parentId: String?,
+    val title: String,
+    val album: String?,
+    val albumId: String?,
+    val artist: String?,
+    val artistId: String?,
+    val coverArtId: String?,
+    val durationSeconds: Int?,
+    val track: Int?,
+    val discNumber: Int?,
+    val year: Int?,
+    val genre: String?,
+    val bitRate: Int?,
+    val suffix: String?,
+    val contentType: String?,
+    val sizeBytes: Long?,
+    val path: String?,
+    val created: String?,
+)

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicDtos.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicDtos.kt
@@ -27,6 +27,7 @@ data class SubsonicResponseDto(
     val playlist: PlaylistDto? = null,
     val searchResult3: SearchResult3Dto? = null,
     val lyricsList: LyricsListDto? = null,
+    val playQueue: PlayQueueDto? = null,
 )
 
 @JsonClass(generateAdapter = true)
@@ -167,4 +168,14 @@ data class StructuredLyricsDto(
 data class LyricLineDto(
     val start: Long? = null,
     val value: String = "",
+)
+
+@JsonClass(generateAdapter = true)
+data class PlayQueueDto(
+    val entry: List<SongDto> = emptyList(),
+    val current: String? = null,
+    val position: Long? = null,
+    val username: String? = null,
+    val changed: String? = null,
+    val changedBy: String? = null,
 )

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicMappers.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/subsonic/SubsonicMappers.kt
@@ -12,6 +12,7 @@ import com.anzupop.saki.android.domain.model.WordCue
 import com.anzupop.saki.android.domain.model.PingResult
 import com.anzupop.saki.android.domain.model.Playlist
 import com.anzupop.saki.android.domain.model.PlaylistSummary
+import com.anzupop.saki.android.domain.model.SavedPlayQueue
 import com.anzupop.saki.android.domain.model.SearchResults
 import com.anzupop.saki.android.domain.model.Song
 import com.anzupop.saki.android.domain.model.SongLyrics
@@ -131,6 +132,15 @@ internal fun SubsonicResponseDto.toSearchResults(): SearchResults {
         artists = payload.artist.map(ArtistDto::toArtistSummary),
         albums = payload.album.map(AlbumDto::toAlbumSummary),
         songs = payload.song.map(SongDto::toSong),
+    )
+}
+
+internal fun SubsonicResponseDto.toSavedPlayQueue(): SavedPlayQueue {
+    val payload = playQueue ?: return SavedPlayQueue(emptyList(), null, 0)
+    return SavedPlayQueue(
+        songs = payload.entry.map(SongDto::toSong),
+        currentSongId = payload.current,
+        positionMs = payload.position ?: 0,
     )
 }
 

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultLibraryCacheRepository.kt
@@ -3,6 +3,7 @@ package com.anzupop.saki.android.data.repository
 import com.anzupop.saki.android.data.local.dao.LibraryCacheDao
 import com.anzupop.saki.android.data.local.entity.CachedAlbumEntity
 import com.anzupop.saki.android.data.local.entity.CachedArtistEntity
+import com.anzupop.saki.android.data.local.entity.CachedLibrarySongEntity
 import com.anzupop.saki.android.data.local.entity.CachedPlaylistEntity
 import com.anzupop.saki.android.di.IoDispatcher
 import com.anzupop.saki.android.domain.model.AlbumListType
@@ -11,6 +12,7 @@ import com.anzupop.saki.android.domain.model.ArtistSection
 import com.anzupop.saki.android.domain.model.ArtistSummary
 import com.anzupop.saki.android.domain.model.LibraryIndexes
 import com.anzupop.saki.android.domain.model.PlaylistSummary
+import com.anzupop.saki.android.domain.model.Song
 import com.anzupop.saki.android.domain.repository.LibraryCacheRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -105,6 +107,38 @@ class DefaultLibraryCacheRepository @Inject constructor(
         dao.replacePlaylists(serverId, entities)
     }
 
+    override suspend fun getSongs(serverId: Long): List<Song> = withContext(ioDispatcher) {
+        dao.getSongs(serverId).map { it.toDomain() }
+    }
+
+    override suspend fun saveSongs(serverId: Long, songs: List<Song>) = withContext(ioDispatcher) {
+        val entities = songs.map { song ->
+            CachedLibrarySongEntity(
+                serverId = serverId,
+                songId = song.id,
+                parentId = song.parentId,
+                title = song.title,
+                album = song.album,
+                albumId = song.albumId,
+                artist = song.artist,
+                artistId = song.artistId,
+                coverArtId = song.coverArtId,
+                durationSeconds = song.durationSeconds,
+                track = song.track,
+                discNumber = song.discNumber,
+                year = song.year,
+                genre = song.genre,
+                bitRate = song.bitRate,
+                suffix = song.suffix,
+                contentType = song.contentType,
+                sizeBytes = song.sizeBytes,
+                path = song.path,
+                created = song.created,
+            )
+        }
+        dao.replaceSongs(serverId, entities)
+    }
+
     private fun CachedArtistEntity.toDomain() = ArtistSummary(
         id = artistId,
         name = name,
@@ -136,5 +170,27 @@ class DefaultLibraryCacheRepository @Inject constructor(
         coverArtId = coverArtId,
         created = created,
         changed = changed,
+    )
+
+    private fun CachedLibrarySongEntity.toDomain() = Song(
+        id = songId,
+        parentId = parentId,
+        title = title,
+        album = album,
+        albumId = albumId,
+        artist = artist,
+        artistId = artistId,
+        coverArtId = coverArtId,
+        durationSeconds = durationSeconds,
+        track = track,
+        discNumber = discNumber,
+        year = year,
+        genre = genre,
+        bitRate = bitRate,
+        suffix = suffix,
+        contentType = contentType,
+        sizeBytes = sizeBytes,
+        path = path,
+        created = created,
     )
 }

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepository.kt
@@ -18,6 +18,7 @@ import com.anzupop.saki.android.data.remote.subsonic.toMusicFolders
 import com.anzupop.saki.android.data.remote.subsonic.toPingResult
 import com.anzupop.saki.android.data.remote.subsonic.toPlaylist
 import com.anzupop.saki.android.data.remote.subsonic.toPlaylistSummaries
+import com.anzupop.saki.android.data.remote.subsonic.toSavedPlayQueue
 import com.anzupop.saki.android.data.remote.subsonic.toSearchResults
 import com.anzupop.saki.android.data.remote.subsonic.toSong
 import com.anzupop.saki.android.di.IoDispatcher
@@ -30,6 +31,7 @@ import com.anzupop.saki.android.domain.model.MusicFolder
 import com.anzupop.saki.android.domain.model.PingResult
 import com.anzupop.saki.android.domain.model.Playlist
 import com.anzupop.saki.android.domain.model.PlaylistSummary
+import com.anzupop.saki.android.domain.model.SavedPlayQueue
 import com.anzupop.saki.android.domain.model.SearchResults
 import com.anzupop.saki.android.domain.model.ServerConfig
 import com.anzupop.saki.android.domain.model.ServerEndpoint
@@ -287,10 +289,39 @@ class DefaultSubsonicRepository @Inject constructor(
         }
     }
 
+    override suspend fun getPlayQueue(
+        serverId: Long,
+    ): SubsonicCallResult<SavedPlayQueue> = withContext(ioDispatcher) {
+        executeWithFallback(
+            serverId = serverId,
+            path = "getPlayQueue.view",
+        ) { response ->
+            response.toSavedPlayQueue()
+        }
+    }
+
+    override suspend fun savePlayQueue(
+        serverId: Long,
+        songIds: List<String>,
+        currentSongId: String?,
+        positionMs: Long,
+    ): SubsonicCallResult<Unit> = withContext(ioDispatcher) {
+        val query = mutableMapOf<String, String>()
+        if (currentSongId != null) query["current"] = currentSongId
+        query["position"] = positionMs.toString()
+        executeWithFallback(
+            serverId = serverId,
+            path = "savePlayQueue.view",
+            extraQuery = query,
+            extraQueryLists = mapOf("id" to songIds),
+        ) { }
+    }
+
     private suspend fun <T> executeWithFallback(
         serverId: Long,
         path: String,
         extraQuery: Map<String, String> = emptyMap(),
+        extraQueryLists: Map<String, List<String>> = emptyMap(),
         transform: (SubsonicResponseDto) -> T,
     ): SubsonicCallResult<T> {
         val server = serverConfigRepository.getServerConfig(serverId)
@@ -310,6 +341,7 @@ class DefaultSubsonicRepository @Inject constructor(
                     endpoint = endpoint,
                     url = requestUrl,
                     query = query,
+                    queryLists = extraQueryLists,
                 )
                 return SubsonicCallResult(
                     endpoint = endpoint,
@@ -340,9 +372,19 @@ class DefaultSubsonicRepository @Inject constructor(
         endpoint: ServerEndpoint,
         url: String,
         query: Map<String, String>,
+        queryLists: Map<String, List<String>> = emptyMap(),
     ): SubsonicResponseDto {
+        val finalUrl = if (queryLists.isEmpty()) {
+            url
+        } else {
+            val builder = url.toHttpUrlOrNull()?.newBuilder() ?: error("Invalid URL: $url")
+            queryLists.forEach { (key, values) ->
+                values.forEach { value -> builder.addQueryParameter(key, value) }
+            }
+            builder.build().toString()
+        }
         val httpResponse = subsonicApiService.get(
-            url = url,
+            url = finalUrl,
             query = query,
         )
 

--- a/app/src/main/java/com/anzupop/saki/android/di/DatabaseModule.kt
+++ b/app/src/main/java/com/anzupop/saki/android/di/DatabaseModule.kt
@@ -209,6 +209,38 @@ object DatabaseModule {
         }
     }
 
+    private val migration8To9 = object : Migration(8, 9) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_library_songs` (
+                    `serverId` INTEGER NOT NULL,
+                    `songId` TEXT NOT NULL,
+                    `parentId` TEXT,
+                    `title` TEXT NOT NULL,
+                    `album` TEXT,
+                    `albumId` TEXT,
+                    `artist` TEXT,
+                    `artistId` TEXT,
+                    `coverArtId` TEXT,
+                    `durationSeconds` INTEGER,
+                    `track` INTEGER,
+                    `discNumber` INTEGER,
+                    `year` INTEGER,
+                    `genre` TEXT,
+                    `bitRate` INTEGER,
+                    `suffix` TEXT,
+                    `contentType` TEXT,
+                    `sizeBytes` INTEGER,
+                    `path` TEXT,
+                    `created` TEXT,
+                    PRIMARY KEY(`serverId`, `songId`)
+                )
+                """.trimIndent(),
+            )
+        }
+    }
+
     @Provides
     @Singleton
     fun provideSakiDatabase(
@@ -218,7 +250,7 @@ object DatabaseModule {
             context,
             SakiDatabase::class.java,
             "saki.db",
-        ).addMigrations(migration1To2, migration2To3, migration3To4, migration4To5, migration5To6, migration6To7, migration7To8)
+        ).addMigrations(migration1To2, migration2To3, migration3To4, migration4To5, migration5To6, migration6To7, migration7To8, migration8To9)
             .build()
     }
 

--- a/app/src/main/java/com/anzupop/saki/android/di/DatabaseModule.kt
+++ b/app/src/main/java/com/anzupop/saki/android/di/DatabaseModule.kt
@@ -238,6 +238,12 @@ object DatabaseModule {
                 )
                 """.trimIndent(),
             )
+            db.execSQL(
+                """
+                CREATE INDEX IF NOT EXISTS `index_cached_library_songs_serverId_title`
+                ON `cached_library_songs` (`serverId`, `title` COLLATE NOCASE)
+                """.trimIndent(),
+            )
         }
     }
 

--- a/app/src/main/java/com/anzupop/saki/android/domain/model/SubsonicModels.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/model/SubsonicModels.kt
@@ -139,6 +139,12 @@ data class SearchResults(
     val songs: List<Song> = emptyList(),
 )
 
+data class SavedPlayQueue(
+    val songs: List<Song>,
+    val currentSongId: String?,
+    val positionMs: Long,
+)
+
 data class AuthenticatedUrlCandidate(
     val endpoint: ServerEndpoint,
     val url: String,

--- a/app/src/main/java/com/anzupop/saki/android/domain/repository/LibraryCacheRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/repository/LibraryCacheRepository.kt
@@ -4,6 +4,7 @@ import com.anzupop.saki.android.domain.model.AlbumListType
 import com.anzupop.saki.android.domain.model.AlbumSummary
 import com.anzupop.saki.android.domain.model.LibraryIndexes
 import com.anzupop.saki.android.domain.model.PlaylistSummary
+import com.anzupop.saki.android.domain.model.Song
 
 interface LibraryCacheRepository {
     suspend fun getArtists(serverId: Long): LibraryIndexes?
@@ -12,4 +13,6 @@ interface LibraryCacheRepository {
     suspend fun saveAlbums(serverId: Long, type: AlbumListType, albums: List<AlbumSummary>)
     suspend fun getPlaylists(serverId: Long): List<PlaylistSummary>
     suspend fun savePlaylists(serverId: Long, playlists: List<PlaylistSummary>)
+    suspend fun getSongs(serverId: Long): List<Song>
+    suspend fun saveSongs(serverId: Long, songs: List<Song>)
 }

--- a/app/src/main/java/com/anzupop/saki/android/domain/repository/PlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/repository/PlaybackManager.kt
@@ -23,6 +23,13 @@ interface PlaybackManager {
         startIndex: Int = 0,
     )
 
+    suspend fun restoreQueue(
+        serverId: Long,
+        songs: List<Song>,
+        startIndex: Int = 0,
+        positionMs: Long = 0,
+    )
+
     suspend fun playCachedQueue(
         songs: List<CachedSong>,
         startIndex: Int = 0,

--- a/app/src/main/java/com/anzupop/saki/android/domain/repository/SubsonicRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/repository/SubsonicRepository.kt
@@ -9,6 +9,7 @@ import com.anzupop.saki.android.domain.model.MusicFolder
 import com.anzupop.saki.android.domain.model.PingResult
 import com.anzupop.saki.android.domain.model.Playlist
 import com.anzupop.saki.android.domain.model.PlaylistSummary
+import com.anzupop.saki.android.domain.model.SavedPlayQueue
 import com.anzupop.saki.android.domain.model.SearchResults
 import com.anzupop.saki.android.domain.model.Song
 import com.anzupop.saki.android.domain.model.SongLyrics
@@ -98,4 +99,13 @@ interface SubsonicRepository {
         serverId: Long,
         songId: String,
     ): SubsonicCallResult<SongLyrics?>
+
+    suspend fun getPlayQueue(serverId: Long): SubsonicCallResult<SavedPlayQueue>
+
+    suspend fun savePlayQueue(
+        serverId: Long,
+        songIds: List<String>,
+        currentSongId: String?,
+        positionMs: Long,
+    ): SubsonicCallResult<Unit>
 }

--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -127,6 +127,33 @@ class DefaultPlaybackManager @Inject constructor(
         }
     }
 
+    override suspend fun restoreQueue(
+        serverId: Long,
+        songs: List<Song>,
+        startIndex: Int,
+        positionMs: Long,
+    ) {
+        if (songs.isEmpty()) return
+        val quality = playbackState.value.preferences.streamQuality
+        val mediaItems = songs.map { song ->
+            song.toPlaybackRequestMediaItem(
+                serverId = serverId,
+                qualityLabel = quality.label,
+                streamCacheKey = streamCacheRepository.buildCacheKey(serverId, song.id, quality),
+                artworkUri = buildArtworkUri(serverId, song.coverArtId),
+                maxBitRate = quality.maxBitRate,
+                format = quality.format,
+            )
+        }
+
+        withController { activeController ->
+            val safeStartIndex = startIndex.coerceIn(mediaItems.indices)
+            activeController.setMediaItems(mediaItems, safeStartIndex, positionMs)
+            activeController.prepare()
+            syncState(activeController)
+        }
+    }
+
     override suspend fun playCachedQueue(
         songs: List<CachedSong>,
         startIndex: Int,

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import okhttp3.OkHttpClient
 
 @AndroidEntryPoint
@@ -184,7 +185,7 @@ class SakiPlaybackService : MediaSessionService() {
     ): MediaSession? = mediaSession
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        savePlayQueueBlocking()
+        savePlayQueue(blocking = true)
         val activePlayer = player ?: return super.onTaskRemoved(rootIntent)
         if (!activePlayer.playWhenReady || activePlayer.mediaItemCount == 0) {
             stopSelf()
@@ -193,7 +194,7 @@ class SakiPlaybackService : MediaSessionService() {
     }
 
     override fun onDestroy() {
-        savePlayQueueBlocking()
+        savePlayQueue(blocking = true)
         releaseSoundBalancingEffect()
 
         mediaSession?.release()
@@ -207,7 +208,7 @@ class SakiPlaybackService : MediaSessionService() {
         super.onDestroy()
     }
 
-    private fun savePlayQueueSync() {
+    private fun savePlayQueue(blocking: Boolean = false) {
         val activePlayer = player ?: return
         val itemCount = activePlayer.mediaItemCount
         if (itemCount == 0) return
@@ -219,7 +220,7 @@ class SakiPlaybackService : MediaSessionService() {
         val positionMs = activePlayer.currentPosition
         val serverId = request.serverId
         val currentSongId = request.songId
-        serviceScope.launch {
+        val save: suspend () -> Unit = {
             runCatching {
                 subsonicRepository.savePlayQueue(
                     serverId = serverId,
@@ -229,29 +230,10 @@ class SakiPlaybackService : MediaSessionService() {
                 )
             }
         }
-    }
-
-    private fun savePlayQueueBlocking() {
-        val activePlayer = player ?: return
-        val itemCount = activePlayer.mediaItemCount
-        if (itemCount == 0) return
-        val request = activePlayer.currentMediaItem?.toPlaybackRequestOrNull() ?: return
-        val songIds = (0 until itemCount).mapNotNull { i ->
-            activePlayer.getMediaItemAt(i).toPlaybackRequestOrNull()?.songId
-        }
-        if (songIds.isEmpty()) return
-        val positionMs = activePlayer.currentPosition
-        val serverId = request.serverId
-        val currentSongId = request.songId
-        runBlocking {
-            runCatching {
-                subsonicRepository.savePlayQueue(
-                    serverId = serverId,
-                    songIds = songIds,
-                    currentSongId = currentSongId,
-                    positionMs = positionMs,
-                )
-            }
+        if (blocking) {
+            runBlocking { withTimeout(5_000) { save() } }
+        } else {
+            serviceScope.launch { save() }
         }
     }
 
@@ -347,11 +329,11 @@ class SakiPlaybackService : MediaSessionService() {
 
     private inner class PlayQueueSaveListener : Player.Listener {
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-            savePlayQueueSync()
+            savePlayQueue()
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
-            if (!isPlaying) savePlayQueueSync()
+            if (!isPlaying) savePlayQueue()
         }
     }
 

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 
 @AndroidEntryPoint
@@ -100,6 +101,7 @@ class SakiPlaybackService : MediaSessionService() {
             .build()
             .apply {
                 addListener(PlaybackRecoveryListener())
+                addListener(PlayQueueSaveListener())
             }
 
         val sessionActivity = PendingIntent.getActivity(
@@ -181,7 +183,17 @@ class SakiPlaybackService : MediaSessionService() {
         controllerInfo: ControllerInfo,
     ): MediaSession? = mediaSession
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        savePlayQueueBlocking()
+        val activePlayer = player ?: return super.onTaskRemoved(rootIntent)
+        if (!activePlayer.playWhenReady || activePlayer.mediaItemCount == 0) {
+            stopSelf()
+        }
+        super.onTaskRemoved(rootIntent)
+    }
+
     override fun onDestroy() {
+        savePlayQueueBlocking()
         releaseSoundBalancingEffect()
 
         mediaSession?.release()
@@ -193,6 +205,54 @@ class SakiPlaybackService : MediaSessionService() {
         playerScope.cancel()
         serviceScope.cancel()
         super.onDestroy()
+    }
+
+    private fun savePlayQueueSync() {
+        val activePlayer = player ?: return
+        val itemCount = activePlayer.mediaItemCount
+        if (itemCount == 0) return
+        val request = activePlayer.currentMediaItem?.toPlaybackRequestOrNull() ?: return
+        val songIds = (0 until itemCount).mapNotNull { i ->
+            activePlayer.getMediaItemAt(i).toPlaybackRequestOrNull()?.songId
+        }
+        if (songIds.isEmpty()) return
+        val positionMs = activePlayer.currentPosition
+        val serverId = request.serverId
+        val currentSongId = request.songId
+        serviceScope.launch {
+            runCatching {
+                subsonicRepository.savePlayQueue(
+                    serverId = serverId,
+                    songIds = songIds,
+                    currentSongId = currentSongId,
+                    positionMs = positionMs,
+                )
+            }
+        }
+    }
+
+    private fun savePlayQueueBlocking() {
+        val activePlayer = player ?: return
+        val itemCount = activePlayer.mediaItemCount
+        if (itemCount == 0) return
+        val request = activePlayer.currentMediaItem?.toPlaybackRequestOrNull() ?: return
+        val songIds = (0 until itemCount).mapNotNull { i ->
+            activePlayer.getMediaItemAt(i).toPlaybackRequestOrNull()?.songId
+        }
+        if (songIds.isEmpty()) return
+        val positionMs = activePlayer.currentPosition
+        val serverId = request.serverId
+        val currentSongId = request.songId
+        runBlocking {
+            runCatching {
+                subsonicRepository.savePlayQueue(
+                    serverId = serverId,
+                    songIds = songIds,
+                    currentSongId = currentSongId,
+                    positionMs = positionMs,
+                )
+            }
+        }
     }
 
     private inner class SakiMediaSessionCallback : MediaSession.Callback {
@@ -285,7 +345,16 @@ class SakiPlaybackService : MediaSessionService() {
         }
     }
 
-    @Synchronized
+    private inner class PlayQueueSaveListener : Player.Listener {
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            savePlayQueueSync()
+        }
+
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            if (!isPlaying) savePlayQueueSync()
+        }
+    }
+
     private fun restoreOriginalTitle() {
         val activePlayer = player ?: return
         val title = originalMediaTitle ?: return

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -35,6 +35,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -876,7 +878,9 @@ class SakiAppViewModel @Inject constructor(
                 }
             }
 
-            mutableUiState.update { it.copy(isSongsLoading = true, songsError = null) }
+            if (uiState.value.selectedServerId == serverId) {
+                mutableUiState.update { it.copy(isSongsLoading = true, songsError = null) }
+            }
 
             runCatching {
                 fetchAllSongs(serverId)
@@ -887,12 +891,14 @@ class SakiAppViewModel @Inject constructor(
                 runCatching { libraryCacheRepository.saveSongs(serverId, songs) }
                     .onFailure { Log.w("SakiApp", "Failed to cache songs", it) }
             }.onFailure { throwable ->
-                mutableUiState.update { it.copy(isSongsLoading = false, songsError = throwable.message ?: "Unable to load songs.") }
+                if (uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { it.copy(isSongsLoading = false, songsError = throwable.message ?: "Unable to load songs.") }
+                }
             }
         }
     }
 
-    private suspend fun fetchAllSongs(serverId: Long): List<Song> {
+    private suspend fun fetchAllSongs(serverId: Long): List<Song> = withContext(Dispatchers.IO) {
         val pageSize = 500
         val allSongs = mutableListOf<Song>()
         var offset = 0
@@ -909,7 +915,8 @@ class SakiAppViewModel @Inject constructor(
             if (results.songs.size < pageSize) break
             offset += pageSize
         }
-        return allSongs
+        allSongs.sortBy { it.title.lowercase() }
+        allSongs
     }
 
     private suspend fun buildArtistTopSongs(

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -844,57 +844,48 @@ class SakiAppViewModel @Inject constructor(
     ) {
         if (!forceRefresh && uiState.value.songs.isNotEmpty()) return
 
-        mutableUiState.update { state ->
-            state.copy(
-                isSongsLoading = true,
-                songsError = null,
-            )
-        }
-
         viewModelScope.launch {
+            if (!forceRefresh) {
+                val cached = runCatching { libraryCacheRepository.getSongs(serverId) }.getOrNull()
+                if (!cached.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { it.copy(songs = cached) }
+                }
+            }
+
+            mutableUiState.update { it.copy(isSongsLoading = true, songsError = null) }
+
             runCatching {
-                buildSongFeed(serverId)
+                fetchAllSongs(serverId)
             }.onSuccess { songs ->
                 if (uiState.value.selectedServerId == serverId) {
-                    mutableUiState.update { state ->
-                        state.copy(
-                            songs = songs,
-                            isSongsLoading = false,
-                            songsError = null,
-                        )
-                    }
+                    mutableUiState.update { it.copy(songs = songs, isSongsLoading = false, songsError = null) }
                 }
+                runCatching { libraryCacheRepository.saveSongs(serverId, songs) }
+                    .onFailure { Log.w("SakiApp", "Failed to cache songs", it) }
             }.onFailure { throwable ->
-                mutableUiState.update { state ->
-                    state.copy(
-                        isSongsLoading = false,
-                        songsError = throwable.message ?: "Unable to load songs.",
-                    )
-                }
+                mutableUiState.update { it.copy(isSongsLoading = false, songsError = throwable.message ?: "Unable to load songs.") }
             }
         }
     }
 
-    private suspend fun buildSongFeed(serverId: Long): List<Song> = coroutineScope {
-        val newestAlbums = subsonicRepository.getAlbumList(
-            serverId = serverId,
-            type = AlbumListType.NEWEST,
-            size = 10,
-        ).data
-
-        newestAlbums.take(10)
-            .map { summary ->
-                async {
-                    subsonicRepository.getAlbum(serverId, summary.id).data
-                }
-            }
-            .map { deferred -> deferred.await() }
-            .flatMap { album ->
-                album.songs.map { song ->
-                    song.withFallbackAlbumMetadata(album)
-                }
-            }
-            .distinctBy(Song::id)
+    private suspend fun fetchAllSongs(serverId: Long): List<Song> {
+        val pageSize = 500
+        val allSongs = mutableListOf<Song>()
+        var offset = 0
+        while (true) {
+            val results = subsonicRepository.search(
+                serverId = serverId,
+                query = "",
+                artistCount = 0,
+                albumCount = 0,
+                songCount = pageSize,
+                songOffset = offset,
+            ).data
+            allSongs.addAll(results.songs)
+            if (results.songs.size < pageSize) break
+            offset += pageSize
+        }
+        return allSongs
     }
 
     private suspend fun buildArtistTopSongs(

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -31,9 +31,9 @@ import com.anzupop.saki.android.domain.repository.SubsonicRepository
 import com.anzupop.saki.android.domain.repository.StreamCacheRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -709,7 +709,7 @@ class SakiAppViewModel @Inject constructor(
         }
 
         if (selectedServerId != null && (serverChanged || lastLoadedServerId != selectedServerId)) {
-            loadServerContent(selectedServerId, forceRefresh = true)
+            loadServerContent(selectedServerId)
             if (uiState.value.playbackState.currentItem == null) {
                 restorePlayQueue(selectedServerId)
             }
@@ -745,6 +745,7 @@ class SakiAppViewModel @Inject constructor(
                 subsonicRepository.getPlayQueue(serverId).data
             }.onSuccess { savedQueue ->
                 if (savedQueue.songs.isEmpty()) return@onSuccess
+                if (uiState.value.playbackState.queue.isNotEmpty()) return@onSuccess
                 val startIndex = if (savedQueue.currentSongId != null) {
                     savedQueue.songs.indexOfFirst { it.id == savedQueue.currentSongId }.coerceAtLeast(0)
                 } else {
@@ -756,7 +757,9 @@ class SakiAppViewModel @Inject constructor(
                     startIndex = startIndex,
                     positionMs = savedQueue.positionMs,
                 )
-            }.onFailure { /* server unreachable, skip restore */ }
+            }.onFailure { e ->
+                if (e is CancellationException) throw e
+            }
         }
     }
 
@@ -900,9 +903,11 @@ class SakiAppViewModel @Inject constructor(
 
     private suspend fun fetchAllSongs(serverId: Long): List<Song> = withContext(Dispatchers.IO) {
         val pageSize = 500
+        val maxPages = 100
         val allSongs = mutableListOf<Song>()
         var offset = 0
-        while (true) {
+        var page = 0
+        while (page < maxPages) {
             val results = subsonicRepository.search(
                 serverId = serverId,
                 query = "",
@@ -912,8 +917,9 @@ class SakiAppViewModel @Inject constructor(
                 songOffset = offset,
             ).data
             allSongs.addAll(results.songs)
-            if (results.songs.size < pageSize) break
+            if (results.songs.isEmpty() || results.songs.size < pageSize) break
             offset += pageSize
+            page++
         }
         allSongs.sortBy { it.title.lowercase() }
         allSongs

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -708,6 +708,9 @@ class SakiAppViewModel @Inject constructor(
 
         if (selectedServerId != null && (serverChanged || lastLoadedServerId != selectedServerId)) {
             loadServerContent(selectedServerId, forceRefresh = true)
+            if (uiState.value.playbackState.currentItem == null) {
+                restorePlayQueue(selectedServerId)
+            }
         }
     }
 
@@ -731,6 +734,27 @@ class SakiAppViewModel @Inject constructor(
             } else {
                 state
             }
+        }
+    }
+
+    private fun restorePlayQueue(serverId: Long) {
+        viewModelScope.launch {
+            runCatching {
+                subsonicRepository.getPlayQueue(serverId).data
+            }.onSuccess { savedQueue ->
+                if (savedQueue.songs.isEmpty()) return@onSuccess
+                val startIndex = if (savedQueue.currentSongId != null) {
+                    savedQueue.songs.indexOfFirst { it.id == savedQueue.currentSongId }.coerceAtLeast(0)
+                } else {
+                    0
+                }
+                playbackManager.restoreQueue(
+                    serverId = serverId,
+                    songs = savedQueue.songs,
+                    startIndex = startIndex,
+                    positionMs = savedQueue.positionMs,
+                )
+            }.onFailure { /* server unreachable, skip restore */ }
         }
     }
 


### PR DESCRIPTION
## Summary

Two related changes: fix Songs tab to show full library, and persist/restore playback session.

## Songs tab — full library (#20)

Previously `buildSongFeed()` only showed ~100 songs from the 10 newest albums. Now uses paginated `search3` empty query to fetch all songs.

- **Pagination**: 500 songs per page on IO dispatcher, loops until exhausted
- **Room cache**: new `cached_library_songs` table (migration 8→9) with `(serverId, title)` index
- **Cache-first**: instant display from Room, background API refresh
- **Consistent sort**: both cache and API results sorted by title (case-insensitive)

## Persist playback session (#21)

Uses Subsonic `savePlayQueue`/`getPlayQueue` API to persist playback state on the server. This survives app reinstalls and device changes (any client that implements `getPlayQueue` can restore it).

**Save triggers:**
- Track change (`onMediaItemTransition`)
- Pause/stop (`onIsPlayingChanged`)
- App swiped away (`onTaskRemoved`) — uses `runBlocking` to ensure completion
- Service destroy (`onDestroy`)

**Restore:**
- On app startup, if no track is playing, calls `getPlayQueue` and restores queue + position without auto-play
- Finds correct track index via `currentSongId`

**Infrastructure:**
- `executeWithFallback` now supports `extraQueryLists` for repeated query params (multiple `id=` for savePlayQueue)
- `PlaybackManager.restoreQueue()` — prepares media items without calling `play()`

## Testing

Verified on Navidrome (149 songs) — all songs appear, playback session persists across app restarts.

Closes #20
Closes #21