### PR TITLE
feat: smart endpoint selection with network-aware probing

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/SakiApplication.kt
+++ b/app/src/main/java/com/anzupop/saki/android/SakiApplication.kt
@@ -8,6 +8,7 @@ import coil3.disk.DiskCache
 import coil3.disk.directory
 import coil3.memory.MemoryCache
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import com.anzupop.saki.android.data.remote.EndpointSelector
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 import okhttp3.OkHttpClient
@@ -16,6 +17,14 @@ import okhttp3.OkHttpClient
 class SakiApplication : Application(), SingletonImageLoader.Factory {
     @Inject
     lateinit var okHttpClient: OkHttpClient
+
+    @Inject
+    lateinit var endpointSelector: EndpointSelector
+
+    override fun onCreate() {
+        super.onCreate()
+        endpointSelector.start()
+    }
 
     override fun newImageLoader(context: Context): ImageLoader {
         return ImageLoader.Builder(context)

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -33,6 +33,15 @@ class EndpointSelector @Inject constructor(
     // serverId -> best endpoint id
     private val bestEndpoints = ConcurrentHashMap<Long, Long>()
 
+    // serverId -> last probe results
+    private val lastProbeResults = ConcurrentHashMap<Long, List<EndpointProbeResult>>()
+
+    data class EndpointProbeResult(
+        val endpoint: ServerEndpoint,
+        val latencyMs: Long?,
+        val reachable: Boolean,
+    )
+
     private var networkCallbackRegistered = false
 
     fun start() {
@@ -81,6 +90,10 @@ class EndpointSelector @Inject constructor(
             }.map { it.await() }
         }
 
+        lastProbeResults[serverId] = results.map { (ep, lat) ->
+            EndpointProbeResult(ep, lat, lat != null)
+        }
+
         val best = results
             .filter { it.second != null }
             .minByOrNull { it.second!! }
@@ -106,6 +119,11 @@ class EndpointSelector @Inject constructor(
             bestEndpoints.remove(serverId)
         }
     }
+
+    fun getActiveEndpointId(serverId: Long): Long? = bestEndpoints[serverId]
+
+    fun getLastProbeResults(serverId: Long): List<EndpointProbeResult> =
+        lastProbeResults[serverId] ?: emptyList()
 
     private suspend fun pingEndpoint(endpoint: ServerEndpoint): Long? {
         val url = endpoint.baseUrl.trimEnd('/').toHttpUrlOrNull()

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -79,9 +79,17 @@ class EndpointSelector @Inject constructor(
         serverConfigs[server.id] = server
     }
 
+    private var reprobeJob: kotlinx.coroutines.Job? = null
+
     private fun onNetworkChanged() {
-        serverConfigs.forEach { (serverId, server) ->
-            scope.launch { probe(serverId, server) }
+        reprobeJob?.cancel()
+        reprobeJob = scope.launch {
+            // Immediate probe, then re-probe with exponential backoff: 3s, 6s, 12s, then stop
+            val delays = longArrayOf(0, 3_000, 6_000, 12_000)
+            for (delay in delays) {
+                if (delay > 0) kotlinx.coroutines.delay(delay)
+                serverConfigs.forEach { (serverId, server) -> probe(serverId, server) }
+            }
         }
     }
 

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -1,0 +1,129 @@
+package com.anzupop.saki.android.data.remote
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.util.Log
+import com.anzupop.saki.android.di.IoDispatcher
+import com.anzupop.saki.android.domain.model.ServerEndpoint
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+@Singleton
+class EndpointSelector @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val okHttpClient: OkHttpClient,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+
+    // serverId -> best endpoint id
+    private val bestEndpoints = ConcurrentHashMap<Long, Long>()
+
+    private var networkCallbackRegistered = false
+
+    fun start() {
+        if (networkCallbackRegistered) return
+        val cm = context.getSystemService(ConnectivityManager::class.java) ?: return
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        cm.registerNetworkCallback(request, object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                onNetworkChanged()
+            }
+
+            override fun onLost(network: Network) {
+                onNetworkChanged()
+            }
+        })
+        networkCallbackRegistered = true
+    }
+
+    private var pendingProbes = ConcurrentHashMap<Long, List<ServerEndpoint>>()
+
+    fun registerEndpoints(serverId: Long, endpoints: List<ServerEndpoint>) {
+        pendingProbes[serverId] = endpoints
+    }
+
+    private fun onNetworkChanged() {
+        pendingProbes.forEach { (serverId, endpoints) ->
+            scope.launch { probe(serverId, endpoints) }
+        }
+    }
+
+    suspend fun probe(serverId: Long, endpoints: List<ServerEndpoint>): ServerEndpoint? {
+        if (endpoints.isEmpty()) return null
+        if (endpoints.size == 1) {
+            bestEndpoints[serverId] = endpoints.first().id
+            return endpoints.first()
+        }
+
+        val results = kotlinx.coroutines.coroutineScope {
+            endpoints.map { endpoint ->
+                async {
+                    val latency = pingEndpoint(endpoint)
+                    endpoint to latency
+                }
+            }.map { it.await() }
+        }
+
+        val best = results
+            .filter { it.second != null }
+            .minByOrNull { it.second!! }
+            ?.first
+
+        if (best != null) {
+            bestEndpoints[serverId] = best.id
+            Log.d("EndpointSelector", "Best endpoint for server $serverId: ${best.label} (${best.baseUrl})")
+        } else {
+            bestEndpoints.remove(serverId)
+        }
+        return best
+    }
+
+    fun sortedEndpoints(serverId: Long, endpoints: List<ServerEndpoint>): List<ServerEndpoint> {
+        val bestId = bestEndpoints[serverId] ?: return endpoints
+        val best = endpoints.find { it.id == bestId } ?: return endpoints
+        return listOf(best) + endpoints.filter { it.id != bestId }
+    }
+
+    fun invalidate(serverId: Long, failedEndpointId: Long) {
+        if (bestEndpoints[serverId] == failedEndpointId) {
+            bestEndpoints.remove(serverId)
+        }
+    }
+
+    private suspend fun pingEndpoint(endpoint: ServerEndpoint): Long? {
+        val url = endpoint.baseUrl.trimEnd('/').toHttpUrlOrNull()
+            ?.newBuilder()
+            ?.addPathSegments("rest/ping.view")
+            ?.addQueryParameter("f", "json")
+            ?.build() ?: return null
+
+        val request = Request.Builder().url(url).get().build()
+        return withTimeoutOrNull(3_000) {
+            val start = System.nanoTime()
+            try {
+                okHttpClient.newCall(request).execute().use { response ->
+                    if (response.isSuccessful) (System.nanoTime() - start) / 1_000_000 else null
+                }
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -5,28 +5,34 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
-import android.util.Log
 import com.anzupop.saki.android.data.remote.subsonic.SubsonicAuth
 import com.anzupop.saki.android.di.IoDispatcher
 import com.anzupop.saki.android.domain.model.ServerConfig
 import com.anzupop.saki.android.domain.model.ServerEndpoint
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+import kotlin.coroutines.resume
 
 @Singleton
 class EndpointSelector @Inject constructor(
@@ -36,18 +42,20 @@ class EndpointSelector @Inject constructor(
 ) {
     private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
-    // serverId -> best endpoint id
     private val bestEndpoints = ConcurrentHashMap<Long, Long>()
-
-    // serverId -> last probe results
     private val lastProbeResults = ConcurrentHashMap<Long, List<EndpointProbeResult>>()
-
-    // serverId -> server config (for auth + re-probing on network change)
     private val serverConfigs = ConcurrentHashMap<Long, ServerConfig>()
 
-    // Incremented after each probe completes, so observers can react
     private val _probeVersion = MutableStateFlow(0L)
     val probeVersion: StateFlow<Long> = _probeVersion.asStateFlow()
+
+    private val probeClient: OkHttpClient by lazy {
+        okHttpClient.newBuilder()
+            .callTimeout(1500, TimeUnit.MILLISECONDS)
+            .connectTimeout(1500, TimeUnit.MILLISECONDS)
+            .readTimeout(1500, TimeUnit.MILLISECONDS)
+            .build()
+    }
 
     data class EndpointProbeResult(
         val endpoint: ServerEndpoint,
@@ -64,13 +72,8 @@ class EndpointSelector @Inject constructor(
             .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
             .build()
         cm.registerNetworkCallback(request, object : ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                onNetworkChanged()
-            }
-
-            override fun onLost(network: Network) {
-                onNetworkChanged()
-            }
+            override fun onAvailable(network: Network) = onNetworkChanged()
+            override fun onLost(network: Network) = onNetworkChanged()
         })
         networkCallbackRegistered = true
     }
@@ -84,10 +87,9 @@ class EndpointSelector @Inject constructor(
     private fun onNetworkChanged() {
         reprobeJob?.cancel()
         reprobeJob = scope.launch {
-            // Immediate probe, then re-probe with exponential backoff: 3s, 6s, 12s, then stop
             val delays = longArrayOf(0, 3_000, 6_000, 12_000)
-            for (delay in delays) {
-                if (delay > 0) kotlinx.coroutines.delay(delay)
+            for (d in delays) {
+                if (d > 0) delay(d)
                 serverConfigs.forEach { (serverId, server) -> probe(serverId, server) }
             }
         }
@@ -101,39 +103,36 @@ class EndpointSelector @Inject constructor(
             val latency = pingEndpoint(ep, server)
             lastProbeResults[serverId] = listOf(EndpointProbeResult(ep, latency, latency != null))
             if (latency != null) bestEndpoints[serverId] = ep.id
-            _probeVersion.value++
+            _probeVersion.update { it + 1 }
             return if (latency != null) ep else null
         }
 
-        val resultsList = java.util.Collections.synchronizedList(
-            mutableListOf<Pair<ServerEndpoint, Long?>>(),
-        )
+        val probeResults = ConcurrentHashMap<Long, Long?>()
         kotlinx.coroutines.coroutineScope {
             endpoints.map { endpoint ->
                 async {
                     val latency = pingEndpoint(endpoint, server)
-                    resultsList.add(endpoint to latency)
-                    // Update best as soon as each result arrives
+                    probeResults[endpoint.id] = latency
                     if (latency != null) {
                         val currentBestId = bestEndpoints[serverId]
-                        val currentBestLatency = resultsList
-                            .firstOrNull { it.first.id == currentBestId }?.second
+                        val currentBestLatency = currentBestId?.let { probeResults[it] }
                         if (currentBestLatency == null || latency < currentBestLatency) {
                             bestEndpoints[serverId] = endpoint.id
-                            _probeVersion.value++
+                            _probeVersion.update { it + 1 }
                         }
                     }
                 }
             }.forEach { it.await() }
         }
 
-        lastProbeResults[serverId] = resultsList.map { (ep, lat) ->
+        lastProbeResults[serverId] = endpoints.map { ep ->
+            val lat = probeResults[ep.id]
             EndpointProbeResult(ep, lat, lat != null)
         }
-        if (resultsList.none { it.second != null }) {
+        if (probeResults.values.all { it == null }) {
             bestEndpoints.remove(serverId)
         }
-        _probeVersion.value++
+        _probeVersion.update { it + 1 }
         return endpoints.find { it.id == bestEndpoints[serverId] }
     }
 
@@ -161,21 +160,22 @@ class EndpointSelector @Inject constructor(
             ?.addPathSegments("rest/ping.view")
             ?.addQueryParameter("f", "json") ?: return null
         authQuery.forEach { (k, v) -> urlBuilder.addQueryParameter(k, v) }
-        val url = urlBuilder.build()
 
-        val request = Request.Builder().url(url).get().build()
-        return withContext(ioDispatcher) {
-            withTimeoutOrNull(1_500) {
-                val start = System.nanoTime()
-                try {
-                    okHttpClient.newCall(request).execute().use { response ->
-                        val ms = (System.nanoTime() - start) / 1_000_000
-                        if (response.isSuccessful) ms else null
-                    }
-                } catch (_: Exception) {
-                    null
+        val request = Request.Builder().url(urlBuilder.build()).get().build()
+        val start = System.nanoTime()
+        return suspendCancellableCoroutine { cont ->
+            val call = probeClient.newCall(request)
+            cont.invokeOnCancellation { call.cancel() }
+            call.enqueue(object : Callback {
+                override fun onResponse(call: Call, response: Response) {
+                    response.close()
+                    val ms = (System.nanoTime() - start) / 1_000_000
+                    cont.resume(if (response.isSuccessful) ms else null)
                 }
-            }
+                override fun onFailure(call: Call, e: IOException) {
+                    cont.resume(null)
+                }
+            })
         }
     }
 }

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -6,7 +6,9 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.util.Log
+import com.anzupop.saki.android.data.remote.subsonic.SubsonicAuth
 import com.anzupop.saki.android.di.IoDispatcher
+import com.anzupop.saki.android.domain.model.ServerConfig
 import com.anzupop.saki.android.domain.model.ServerEndpoint
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.concurrent.ConcurrentHashMap
@@ -36,6 +38,9 @@ class EndpointSelector @Inject constructor(
     // serverId -> last probe results
     private val lastProbeResults = ConcurrentHashMap<Long, List<EndpointProbeResult>>()
 
+    // serverId -> server config (for auth + re-probing on network change)
+    private val serverConfigs = ConcurrentHashMap<Long, ServerConfig>()
+
     data class EndpointProbeResult(
         val endpoint: ServerEndpoint,
         val latencyMs: Long?,
@@ -62,29 +67,32 @@ class EndpointSelector @Inject constructor(
         networkCallbackRegistered = true
     }
 
-    private var pendingProbes = ConcurrentHashMap<Long, List<ServerEndpoint>>()
-
-    fun registerEndpoints(serverId: Long, endpoints: List<ServerEndpoint>) {
-        pendingProbes[serverId] = endpoints
+    fun registerServer(server: ServerConfig) {
+        serverConfigs[server.id] = server
     }
 
     private fun onNetworkChanged() {
-        pendingProbes.forEach { (serverId, endpoints) ->
-            scope.launch { probe(serverId, endpoints) }
+        serverConfigs.forEach { (serverId, server) ->
+            scope.launch { probe(serverId, server) }
         }
     }
 
-    suspend fun probe(serverId: Long, endpoints: List<ServerEndpoint>): ServerEndpoint? {
+    suspend fun probe(serverId: Long, server: ServerConfig): ServerEndpoint? {
+        val endpoints = server.endpoints
         if (endpoints.isEmpty()) return null
         if (endpoints.size == 1) {
-            bestEndpoints[serverId] = endpoints.first().id
-            return endpoints.first()
+            val ep = endpoints.first()
+            val latency = pingEndpoint(ep, server)
+            lastProbeResults[serverId] = listOf(EndpointProbeResult(ep, latency, latency != null))
+            if (latency != null) bestEndpoints[serverId] = ep.id
+            return if (latency != null) ep else null
         }
 
+        val authQuery = SubsonicAuth.baseQuery(server)
         val results = kotlinx.coroutines.coroutineScope {
             endpoints.map { endpoint ->
                 async {
-                    val latency = pingEndpoint(endpoint)
+                    val latency = pingEndpoint(endpoint, server)
                     endpoint to latency
                 }
             }.map { it.await() }
@@ -125,12 +133,14 @@ class EndpointSelector @Inject constructor(
     fun getLastProbeResults(serverId: Long): List<EndpointProbeResult> =
         lastProbeResults[serverId] ?: emptyList()
 
-    private suspend fun pingEndpoint(endpoint: ServerEndpoint): Long? {
-        val url = endpoint.baseUrl.trimEnd('/').toHttpUrlOrNull()
+    private suspend fun pingEndpoint(endpoint: ServerEndpoint, server: ServerConfig): Long? {
+        val authQuery = SubsonicAuth.baseQuery(server)
+        val urlBuilder = endpoint.baseUrl.trimEnd('/').toHttpUrlOrNull()
             ?.newBuilder()
             ?.addPathSegments("rest/ping.view")
-            ?.addQueryParameter("f", "json")
-            ?.build() ?: return null
+            ?.addQueryParameter("f", "json") ?: return null
+        authQuery.forEach { (k, v) -> urlBuilder.addQueryParameter(k, v) }
+        val url = urlBuilder.build()
 
         val request = Request.Builder().url(url).get().build()
         return withTimeoutOrNull(3_000) {

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -105,33 +105,36 @@ class EndpointSelector @Inject constructor(
             return if (latency != null) ep else null
         }
 
-        val authQuery = SubsonicAuth.baseQuery(server)
-        val results = kotlinx.coroutines.coroutineScope {
+        val resultsList = java.util.Collections.synchronizedList(
+            mutableListOf<Pair<ServerEndpoint, Long?>>(),
+        )
+        kotlinx.coroutines.coroutineScope {
             endpoints.map { endpoint ->
                 async {
                     val latency = pingEndpoint(endpoint, server)
-                    endpoint to latency
+                    resultsList.add(endpoint to latency)
+                    // Update best as soon as each result arrives
+                    if (latency != null) {
+                        val currentBestId = bestEndpoints[serverId]
+                        val currentBestLatency = resultsList
+                            .firstOrNull { it.first.id == currentBestId }?.second
+                        if (currentBestLatency == null || latency < currentBestLatency) {
+                            bestEndpoints[serverId] = endpoint.id
+                            _probeVersion.value++
+                        }
+                    }
                 }
-            }.map { it.await() }
+            }.forEach { it.await() }
         }
 
-        lastProbeResults[serverId] = results.map { (ep, lat) ->
+        lastProbeResults[serverId] = resultsList.map { (ep, lat) ->
             EndpointProbeResult(ep, lat, lat != null)
         }
-
-        val best = results
-            .filter { it.second != null }
-            .minByOrNull { it.second!! }
-            ?.first
-
-        if (best != null) {
-            bestEndpoints[serverId] = best.id
-            Log.d("EndpointSelector", "Best endpoint for server $serverId: ${best.label} (${best.baseUrl})")
-        } else {
+        if (resultsList.none { it.second != null }) {
             bestEndpoints.remove(serverId)
         }
         _probeVersion.value++
-        return best
+        return endpoints.find { it.id == bestEndpoints[serverId] }
     }
 
     fun sortedEndpoints(serverId: Long, endpoints: List<ServerEndpoint>): List<ServerEndpoint> {

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -145,7 +145,7 @@ class EndpointSelector @Inject constructor(
 
         val request = Request.Builder().url(url).get().build()
         return withContext(ioDispatcher) {
-            withTimeoutOrNull(3_000) {
+            withTimeoutOrNull(1_500) {
                 val start = System.nanoTime()
                 try {
                     okHttpClient.newCall(request).execute().use { response ->

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -18,6 +18,9 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -41,6 +44,10 @@ class EndpointSelector @Inject constructor(
 
     // serverId -> server config (for auth + re-probing on network change)
     private val serverConfigs = ConcurrentHashMap<Long, ServerConfig>()
+
+    // Incremented after each probe completes, so observers can react
+    private val _probeVersion = MutableStateFlow(0L)
+    val probeVersion: StateFlow<Long> = _probeVersion.asStateFlow()
 
     data class EndpointProbeResult(
         val endpoint: ServerEndpoint,
@@ -86,6 +93,7 @@ class EndpointSelector @Inject constructor(
             val latency = pingEndpoint(ep, server)
             lastProbeResults[serverId] = listOf(EndpointProbeResult(ep, latency, latency != null))
             if (latency != null) bestEndpoints[serverId] = ep.id
+            _probeVersion.value++
             return if (latency != null) ep else null
         }
 
@@ -110,10 +118,11 @@ class EndpointSelector @Inject constructor(
 
         if (best != null) {
             bestEndpoints[serverId] = best.id
-        Log.d("EndpointSelector", "Best endpoint for server $serverId: ${best.label} (${best.baseUrl})")
+            Log.d("EndpointSelector", "Best endpoint for server $serverId: ${best.label} (${best.baseUrl})")
         } else {
             bestEndpoints.remove(serverId)
         }
+        _probeVersion.value++
         return best
     }
 

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -10,6 +10,7 @@ import com.anzupop.saki.android.di.IoDispatcher
 import com.anzupop.saki.android.domain.model.ServerConfig
 import com.anzupop.saki.android.domain.model.ServerEndpoint
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -25,14 +26,13 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import java.io.IOException
-import kotlin.coroutines.resume
 
 @Singleton
 class EndpointSelector @Inject constructor(
@@ -82,6 +82,12 @@ class EndpointSelector @Inject constructor(
         serverConfigs[server.id] = server
     }
 
+    fun unregisterServer(serverId: Long) {
+        serverConfigs.remove(serverId)
+        bestEndpoints.remove(serverId)
+        lastProbeResults.remove(serverId)
+    }
+
     private var reprobeJob: kotlinx.coroutines.Job? = null
 
     private fun onNetworkChanged() {
@@ -96,13 +102,18 @@ class EndpointSelector @Inject constructor(
     }
 
     suspend fun probe(serverId: Long, server: ServerConfig): ServerEndpoint? {
+        serverConfigs[serverId] = server
         val endpoints = server.endpoints
         if (endpoints.isEmpty()) return null
         if (endpoints.size == 1) {
             val ep = endpoints.first()
             val latency = pingEndpoint(ep, server)
             lastProbeResults[serverId] = listOf(EndpointProbeResult(ep, latency, latency != null))
-            if (latency != null) bestEndpoints[serverId] = ep.id
+            if (latency != null) {
+                bestEndpoints[serverId] = ep.id
+            } else {
+                bestEndpoints.remove(serverId)
+            }
             _probeVersion.update { it + 1 }
             return if (latency != null) ep else null
         }
@@ -143,8 +154,8 @@ class EndpointSelector @Inject constructor(
     }
 
     fun invalidate(serverId: Long, failedEndpointId: Long) {
-        if (bestEndpoints[serverId] == failedEndpointId) {
-            bestEndpoints.remove(serverId)
+        if (bestEndpoints.remove(serverId, failedEndpointId)) {
+            _probeVersion.update { it + 1 }
         }
     }
 
@@ -170,10 +181,10 @@ class EndpointSelector @Inject constructor(
                 override fun onResponse(call: Call, response: Response) {
                     response.close()
                     val ms = (System.nanoTime() - start) / 1_000_000
-                    cont.resume(if (response.isSuccessful) ms else null)
+                    if (cont.isActive) cont.resume(if (response.isSuccessful) ms else null)
                 }
                 override fun onFailure(call: Call, e: IOException) {
-                    cont.resume(null)
+                    if (cont.isActive) cont.resume(null)
                 }
             })
         }

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
@@ -109,7 +110,7 @@ class EndpointSelector @Inject constructor(
 
         if (best != null) {
             bestEndpoints[serverId] = best.id
-            Log.d("EndpointSelector", "Best endpoint for server $serverId: ${best.label} (${best.baseUrl})")
+        Log.d("EndpointSelector", "Best endpoint for server $serverId: ${best.label} (${best.baseUrl})")
         } else {
             bestEndpoints.remove(serverId)
         }
@@ -143,14 +144,17 @@ class EndpointSelector @Inject constructor(
         val url = urlBuilder.build()
 
         val request = Request.Builder().url(url).get().build()
-        return withTimeoutOrNull(3_000) {
-            val start = System.nanoTime()
-            try {
-                okHttpClient.newCall(request).execute().use { response ->
-                    if (response.isSuccessful) (System.nanoTime() - start) / 1_000_000 else null
+        return withContext(ioDispatcher) {
+            withTimeoutOrNull(3_000) {
+                val start = System.nanoTime()
+                try {
+                    okHttpClient.newCall(request).execute().use { response ->
+                        val ms = (System.nanoTime() - start) / 1_000_000
+                        if (response.isSuccessful) ms else null
+                    }
+                } catch (_: Exception) {
+                    null
                 }
-            } catch (_: Exception) {
-                null
             }
         }
     }

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/SubsonicConnectionTester.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/SubsonicConnectionTester.kt
@@ -80,7 +80,9 @@ class SubsonicConnectionTester @Inject constructor(
         )
 
         try {
+            val startNanos = System.nanoTime()
             requestClient.newCall(networkRequest).execute().use { response ->
+                val latencyMs = (System.nanoTime() - startNanos) / 1_000_000
                 if (!response.isSuccessful) {
                     return@withContext ConnectionTestResult.Failure(
                         endpointUrl = endpointUrl,
@@ -109,6 +111,7 @@ class SubsonicConnectionTester @Inject constructor(
                     return@withContext ConnectionTestResult.Success(
                         endpointUrl = endpointUrl,
                         serverVersion = subsonicResponse.optString("version").ifBlank { null },
+                        latencyMs = latencyMs,
                     )
                 }
 

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepository.kt
@@ -1,6 +1,7 @@
 package com.anzupop.saki.android.data.repository
 
 import com.anzupop.saki.android.data.remote.subsonic.EndpointFailure
+import com.anzupop.saki.android.data.remote.EndpointSelector
 import com.anzupop.saki.android.data.remote.subsonic.EndpointFallbackException
 import com.anzupop.saki.android.data.remote.subsonic.NoEndpointsConfiguredException
 import com.anzupop.saki.android.data.remote.subsonic.NoSuchServerException
@@ -59,6 +60,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 class DefaultSubsonicRepository @Inject constructor(
     private val serverConfigRepository: ServerConfigRepository,
     private val subsonicApiService: SubsonicApiService,
+    private val endpointSelector: EndpointSelector,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : SubsonicRepository {
     override suspend fun ping(serverId: Long): SubsonicCallResult<PingResult> = withContext(ioDispatcher) {
@@ -356,6 +358,7 @@ class DefaultSubsonicRepository @Inject constructor(
                     throw exception
                 }
                 failures += EndpointFailure(endpoint, exception)
+                endpointSelector.invalidate(serverId, endpoint.id)
             } catch (exception: IllegalStateException) {
                 throw SubsonicApiException(
                     endpoint = endpoint,
@@ -434,9 +437,13 @@ class DefaultSubsonicRepository @Inject constructor(
     }
 
     private fun orderedEndpoints(server: ServerConfig): List<ServerEndpoint> {
-        return server.endpoints.sortedWith(
-            compareByDescending<ServerEndpoint> { it.isPrimary }
-                .thenBy(ServerEndpoint::order),
+        endpointSelector.registerEndpoints(server.id, server.endpoints)
+        return endpointSelector.sortedEndpoints(
+            serverId = server.id,
+            endpoints = server.endpoints.sortedWith(
+                compareByDescending<ServerEndpoint> { it.isPrimary }
+                    .thenBy(ServerEndpoint::order),
+            ),
         )
     }
 

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepository.kt
@@ -437,7 +437,6 @@ class DefaultSubsonicRepository @Inject constructor(
     }
 
     private fun orderedEndpoints(server: ServerConfig): List<ServerEndpoint> {
-        endpointSelector.registerServer(server)
         return endpointSelector.sortedEndpoints(
             serverId = server.id,
             endpoints = server.endpoints.sortedWith(

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepository.kt
@@ -437,7 +437,7 @@ class DefaultSubsonicRepository @Inject constructor(
     }
 
     private fun orderedEndpoints(server: ServerConfig): List<ServerEndpoint> {
-        endpointSelector.registerEndpoints(server.id, server.endpoints)
+        endpointSelector.registerServer(server)
         return endpointSelector.sortedEndpoints(
             serverId = server.id,
             endpoints = server.endpoints.sortedWith(

--- a/app/src/main/java/com/anzupop/saki/android/di/DatabaseModule.kt
+++ b/app/src/main/java/com/anzupop/saki/android/di/DatabaseModule.kt
@@ -217,7 +217,7 @@ object DatabaseModule {
                     `serverId` INTEGER NOT NULL,
                     `songId` TEXT NOT NULL,
                     `parentId` TEXT,
-                    `title` TEXT NOT NULL,
+                    `title` TEXT NOT NULL COLLATE NOCASE,
                     `album` TEXT,
                     `albumId` TEXT,
                     `artist` TEXT,
@@ -241,7 +241,7 @@ object DatabaseModule {
             db.execSQL(
                 """
                 CREATE INDEX IF NOT EXISTS `index_cached_library_songs_serverId_title`
-                ON `cached_library_songs` (`serverId`, `title` COLLATE NOCASE)
+                ON `cached_library_songs` (`serverId`, `title`)
                 """.trimIndent(),
             )
         }

--- a/app/src/main/java/com/anzupop/saki/android/domain/model/ConnectionTestResult.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/model/ConnectionTestResult.kt
@@ -14,6 +14,7 @@ sealed interface ConnectionTestResult {
     data class Success(
         override val endpointUrl: String,
         val serverVersion: String?,
+        val latencyMs: Long,
     ) : ConnectionTestResult
 
     data class Failure(

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -183,7 +183,7 @@ class SakiPlaybackService : MediaSessionService() {
     ): MediaSession? = mediaSession
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        savePlayQueue()
+        savePlayQueue(immediate = true)
         val activePlayer = player ?: return super.onTaskRemoved(rootIntent)
         if (!activePlayer.playWhenReady || activePlayer.mediaItemCount == 0) {
             stopSelf()
@@ -192,7 +192,7 @@ class SakiPlaybackService : MediaSessionService() {
     }
 
     override fun onDestroy() {
-        savePlayQueue()
+        savePlayQueue(immediate = true)
         releaseSoundBalancingEffect()
 
         mediaSession?.release()
@@ -208,7 +208,7 @@ class SakiPlaybackService : MediaSessionService() {
 
     private var savePlayQueueJob: kotlinx.coroutines.Job? = null
 
-    private fun savePlayQueue() {
+    private fun savePlayQueue(immediate: Boolean = false) {
         val activePlayer = player ?: return
         val itemCount = activePlayer.mediaItemCount
         if (itemCount == 0) return
@@ -222,7 +222,7 @@ class SakiPlaybackService : MediaSessionService() {
         val currentSongId = request.songId
         savePlayQueueJob?.cancel()
         savePlayQueueJob = serviceScope.launch {
-            kotlinx.coroutines.delay(500)
+            if (!immediate) kotlinx.coroutines.delay(500)
             runCatching {
                 subsonicRepository.savePlayQueue(
                     serverId = serverId,

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -44,8 +44,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import okhttp3.OkHttpClient
 
 @AndroidEntryPoint
@@ -185,7 +183,7 @@ class SakiPlaybackService : MediaSessionService() {
     ): MediaSession? = mediaSession
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        savePlayQueue(blocking = true)
+        savePlayQueue()
         val activePlayer = player ?: return super.onTaskRemoved(rootIntent)
         if (!activePlayer.playWhenReady || activePlayer.mediaItemCount == 0) {
             stopSelf()
@@ -194,7 +192,7 @@ class SakiPlaybackService : MediaSessionService() {
     }
 
     override fun onDestroy() {
-        savePlayQueue(blocking = true)
+        savePlayQueue()
         releaseSoundBalancingEffect()
 
         mediaSession?.release()
@@ -208,7 +206,9 @@ class SakiPlaybackService : MediaSessionService() {
         super.onDestroy()
     }
 
-    private fun savePlayQueue(blocking: Boolean = false) {
+    private var savePlayQueueJob: kotlinx.coroutines.Job? = null
+
+    private fun savePlayQueue() {
         val activePlayer = player ?: return
         val itemCount = activePlayer.mediaItemCount
         if (itemCount == 0) return
@@ -220,7 +220,9 @@ class SakiPlaybackService : MediaSessionService() {
         val positionMs = activePlayer.currentPosition
         val serverId = request.serverId
         val currentSongId = request.songId
-        val save: suspend () -> Unit = {
+        savePlayQueueJob?.cancel()
+        savePlayQueueJob = serviceScope.launch {
+            kotlinx.coroutines.delay(500)
             runCatching {
                 subsonicRepository.savePlayQueue(
                     serverId = serverId,
@@ -229,11 +231,6 @@ class SakiPlaybackService : MediaSessionService() {
                     positionMs = positionMs,
                 )
             }
-        }
-        if (blocking) {
-            runBlocking { withTimeout(5_000) { save() } }
-        } else {
-            serviceScope.launch { save() }
         }
     }
 

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -321,6 +321,7 @@ private fun RootShell(
             onRemoveQueueItem = onRemoveQueueItem,
             currentServer = uiState.servers.firstOrNull { it.id == track.serverId },
             activeEndpointLabel = endpointStatus.activeEndpointLabel,
+            activeEndpointId = endpointStatus.activeEndpointId,
             endpointProbeResults = endpointStatus.probeResults,
             isProbing = endpointStatus.isProbing,
             onReprobeEndpoints = onReprobeEndpoints,

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -39,6 +39,7 @@ fun SakiApp(
     viewModel: SakiAppViewModel = viewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val endpointStatus by viewModel.endpointStatus.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     var showServerManager by rememberSaveable { mutableStateOf(false) }
     var showNowPlaying by rememberSaveable { mutableStateOf(false) }
@@ -62,6 +63,7 @@ fun SakiApp(
     LaunchedEffect(viewModel) {
         viewModel.openNowPlayingRequests.collectLatest {
             showNowPlaying = true
+            viewModel.refreshEndpointStatus()
         }
     }
 
@@ -131,6 +133,8 @@ fun SakiApp(
                         onToggleShuffle = viewModel::toggleShuffle,
                         onSkipToQueueItem = viewModel::skipToQueueItem,
                         onRemoveQueueItem = viewModel::removeQueueItem,
+                        endpointStatus = endpointStatus,
+                        onReprobeEndpoints = viewModel::reprobeEndpoints,
                     )
                 }
             }
@@ -190,6 +194,8 @@ private fun RootShell(
     onToggleShuffle: () -> Unit,
     onSkipToQueueItem: (Int) -> Unit,
     onRemoveQueueItem: (Int) -> Unit,
+    endpointStatus: EndpointStatus = EndpointStatus(),
+    onReprobeEndpoints: () -> Unit = {},
 ) {
     val currentOrQueuedTrack = uiState.playbackState.currentItem ?: uiState.playbackState.queue.firstOrNull()
     val shellBackgroundBrush = rememberBrowseBackgroundBrush()
@@ -314,6 +320,10 @@ private fun RootShell(
             onSkipToQueueItem = onSkipToQueueItem,
             onRemoveQueueItem = onRemoveQueueItem,
             currentServer = uiState.servers.firstOrNull { it.id == track.serverId },
+            activeEndpointLabel = endpointStatus.activeEndpointLabel,
+            endpointProbeResults = endpointStatus.probeResults,
+            isProbing = endpointStatus.isProbing,
+            onReprobeEndpoints = onReprobeEndpoints,
             lyrics = uiState.currentLyrics,
         )
     }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -1060,8 +1060,12 @@ class SakiAppViewModel @Inject constructor(
         val server = uiState.value.servers.find { it.id == serverId } ?: return
         mutableEndpointStatus.update { it.copy(isProbing = true) }
         viewModelScope.launch {
-            endpointSelector.probe(serverId, server)
-            refreshEndpointStatus()
+            try {
+                endpointSelector.probe(serverId, server)
+                refreshEndpointStatus()
+            } finally {
+                mutableEndpointStatus.update { it.copy(isProbing = false) }
+            }
         }
     }
 }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -718,7 +718,7 @@ class SakiAppViewModel @Inject constructor(
         }
 
         if (selectedServerId != null && (serverChanged || lastLoadedServerId != selectedServerId)) {
-            loadServerContent(selectedServerId)
+            loadServerContent(selectedServerId, forceRefresh = serverChanged)
             servers.find { it.id == selectedServerId }?.let { server ->
                 viewModelScope.launch {
                     endpointSelector.probe(selectedServerId, server)
@@ -916,6 +916,8 @@ class SakiAppViewModel @Inject constructor(
         }
     }
 
+    // Navidrome supports empty query in search3 to return all songs.
+    // This is not standard Subsonic behavior and may not work on other servers.
     private suspend fun fetchAllSongs(serverId: Long): List<Song> = withContext(Dispatchers.IO) {
         val pageSize = 500
         val maxPages = 100
@@ -1036,11 +1038,21 @@ class SakiAppViewModel @Inject constructor(
         val serverId = uiState.value.selectedServerId ?: return
         val results = endpointSelector.getLastProbeResults(serverId)
         val activeId = endpointSelector.getActiveEndpointId(serverId)
-        mutableEndpointStatus.value = EndpointStatus(
-            activeEndpointLabel = results.find { it.endpoint.id == activeId }?.endpoint?.label,
-            probeResults = results,
-            isProbing = false,
-        )
+        mutableEndpointStatus.update { current ->
+            current.copy(
+                activeEndpointLabel = results.find { it.endpoint.id == activeId }?.endpoint?.label,
+                activeEndpointId = activeId,
+                probeResults = results.map { r ->
+                    EndpointProbeInfo(
+                        id = r.endpoint.id,
+                        label = r.endpoint.label,
+                        baseUrl = r.endpoint.baseUrl,
+                        latencyMs = r.latencyMs,
+                        reachable = r.reachable,
+                    )
+                },
+            )
+        }
     }
 
     fun reprobeEndpoints() {
@@ -1056,8 +1068,17 @@ class SakiAppViewModel @Inject constructor(
 
 data class EndpointStatus(
     val activeEndpointLabel: String? = null,
-    val probeResults: List<EndpointSelector.EndpointProbeResult> = emptyList(),
+    val activeEndpointId: Long? = null,
+    val probeResults: List<EndpointProbeInfo> = emptyList(),
     val isProbing: Boolean = false,
+)
+
+data class EndpointProbeInfo(
+    val id: Long,
+    val label: String,
+    val baseUrl: String,
+    val latencyMs: Long?,
+    val reachable: Boolean,
 )
 
 enum class BrowseSection {

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -1039,7 +1039,7 @@ class SakiAppViewModel @Inject constructor(
         val server = uiState.value.servers.find { it.id == serverId } ?: return
         mutableEndpointStatus.update { it.copy(isProbing = true) }
         viewModelScope.launch {
-            endpointSelector.probe(serverId, server.endpoints)
+            endpointSelector.probe(serverId, server)
             refreshEndpointStatus()
         }
     }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -79,6 +79,9 @@ class SakiAppViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            endpointSelector.probeVersion.collectLatest { refreshEndpointStatus() }
+        }
+        viewModelScope.launch {
             appPreferencesRepository.observePreferences().collectLatest { preferences ->
                 mutableUiState.update { state ->
                     state.copy(

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -3,6 +3,7 @@ package com.anzupop.saki.android.presentation
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.anzupop.saki.android.data.remote.EndpointSelector
 import com.anzupop.saki.android.domain.model.Album
 import com.anzupop.saki.android.domain.model.AlbumListType
 import com.anzupop.saki.android.domain.model.AlbumSummary
@@ -41,6 +42,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -60,12 +62,16 @@ class SakiAppViewModel @Inject constructor(
     private val libraryCacheRepository: LibraryCacheRepository,
     private val playbackManager: PlaybackManager,
     private val lyricsHolder: LyricsHolder,
+    private val endpointSelector: EndpointSelector,
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(SakiAppUiState())
     private val snackbarMessages = MutableSharedFlow<String>(extraBufferCapacity = 1)
     private val openNowPlayingRequestsFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     private val searchQueryFlow = MutableStateFlow("")
     private var lastLoadedServerId: Long? = null
+
+    private val mutableEndpointStatus = MutableStateFlow(EndpointStatus())
+    val endpointStatus: StateFlow<EndpointStatus> = mutableEndpointStatus.asStateFlow()
 
     val uiState = mutableUiState.asStateFlow()
     val messages = snackbarMessages.asSharedFlow()
@@ -1016,7 +1022,34 @@ class SakiAppViewModel @Inject constructor(
             )
         }
     }
+
+    fun refreshEndpointStatus() {
+        val serverId = uiState.value.selectedServerId ?: return
+        val results = endpointSelector.getLastProbeResults(serverId)
+        val activeId = endpointSelector.getActiveEndpointId(serverId)
+        mutableEndpointStatus.value = EndpointStatus(
+            activeEndpointLabel = results.find { it.endpoint.id == activeId }?.endpoint?.label,
+            probeResults = results,
+            isProbing = false,
+        )
+    }
+
+    fun reprobeEndpoints() {
+        val serverId = uiState.value.selectedServerId ?: return
+        val server = uiState.value.servers.find { it.id == serverId } ?: return
+        mutableEndpointStatus.update { it.copy(isProbing = true) }
+        viewModelScope.launch {
+            endpointSelector.probe(serverId, server.endpoints)
+            refreshEndpointStatus()
+        }
+    }
 }
+
+data class EndpointStatus(
+    val activeEndpointLabel: String? = null,
+    val probeResults: List<EndpointSelector.EndpointProbeResult> = emptyList(),
+    val isProbing: Boolean = false,
+)
 
 enum class BrowseSection {
     ARTISTS,

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -716,6 +716,12 @@ class SakiAppViewModel @Inject constructor(
 
         if (selectedServerId != null && (serverChanged || lastLoadedServerId != selectedServerId)) {
             loadServerContent(selectedServerId)
+            servers.find { it.id == selectedServerId }?.let { server ->
+                viewModelScope.launch {
+                    endpointSelector.probe(selectedServerId, server)
+                    refreshEndpointStatus()
+                }
+            }
             if (uiState.value.playbackState.currentItem == null) {
                 restorePlayQueue(selectedServerId)
             }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -50,6 +50,7 @@ import androidx.compose.material.icons.rounded.Shuffle
 import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -93,6 +94,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.palette.graphics.Palette
+import com.anzupop.saki.android.data.remote.EndpointSelector
 import com.anzupop.saki.android.domain.model.PlaybackQueueItem
 import com.anzupop.saki.android.domain.model.PlaybackSessionState
 import com.anzupop.saki.android.domain.model.RepeatModeSetting
@@ -211,6 +213,10 @@ fun NowPlayingOverlay(
     onSkipToQueueItem: (Int) -> Unit,
     onRemoveQueueItem: (Int) -> Unit,
     currentServer: ServerConfig?,
+    activeEndpointLabel: String? = null,
+    endpointProbeResults: List<EndpointSelector.EndpointProbeResult> = emptyList(),
+    isProbing: Boolean = false,
+    onReprobeEndpoints: () -> Unit = {},
     lyrics: SongLyrics? = null,
 ) {
     val artwork = rememberArtworkPresentation(
@@ -219,6 +225,7 @@ fun NowPlayingOverlay(
     var showDetails by remember(track.songId) { mutableStateOf(false) }
     var showMenu by remember(track.songId) { mutableStateOf(false) }
     var showLyrics by remember { mutableStateOf(false) }
+    var showEndpointStatus by remember { mutableStateOf(false) }
 
     // Preload adjacent cover art into Coil cache
     val context = LocalContext.current
@@ -595,8 +602,11 @@ fun NowPlayingOverlay(
                                         },
                                     )
                                     DropdownMenuItem(
-                                        text = { Text(currentServer?.name ?: "Current server") },
-                                        onClick = { showMenu = false },
+                                        text = { Text(activeEndpointLabel ?: "No endpoint") },
+                                        onClick = {
+                                            showMenu = false
+                                            showEndpointStatus = true
+                                        },
                                     )
                                 }
                             }
@@ -662,6 +672,73 @@ fun NowPlayingOverlay(
                     item { DetailLine("Language", playbackState.runtimeInfo?.language) }
                     item { DetailLine("Cover art ID", track.coverArtId) }
                     item { DetailLine("Local file", track.localPath) }
+                }
+            },
+        )
+    }
+
+    if (showEndpointStatus) {
+        AlertDialog(
+            onDismissRequest = { showEndpointStatus = false },
+            confirmButton = {
+                TextButton(onClick = { showEndpointStatus = false }) {
+                    Text("Close")
+                }
+            },
+            title = { Text("Endpoint Status") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    if (endpointProbeResults.isEmpty()) {
+                        Text("No probe results yet.", style = MaterialTheme.typography.bodyMedium)
+                    } else {
+                        endpointProbeResults.forEach { result ->
+                            val isActive = result.endpoint.label == activeEndpointLabel
+                            Surface(
+                                shape = MaterialTheme.shapes.medium,
+                                color = if (isActive) {
+                                    MaterialTheme.colorScheme.primaryContainer
+                                } else {
+                                    MaterialTheme.colorScheme.surfaceVariant
+                                },
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(12.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(
+                                            text = result.endpoint.label + if (isActive) " ✓" else "",
+                                            style = MaterialTheme.typography.bodyLarge,
+                                        )
+                                        Text(
+                                            text = result.endpoint.baseUrl,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                    Text(
+                                        text = if (result.reachable) "${result.latencyMs} ms" else "Unreachable",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = if (result.reachable) {
+                                            MaterialTheme.colorScheme.onSurface
+                                        } else {
+                                            MaterialTheme.colorScheme.error
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    Button(
+                        onClick = onReprobeEndpoints,
+                        enabled = !isProbing,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(if (isProbing) "Probing…" else "Re-test endpoints")
+                    }
                 }
             },
         )

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -94,7 +94,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.palette.graphics.Palette
-import com.anzupop.saki.android.data.remote.EndpointSelector
+import com.anzupop.saki.android.presentation.EndpointProbeInfo
 import com.anzupop.saki.android.domain.model.PlaybackQueueItem
 import com.anzupop.saki.android.domain.model.PlaybackSessionState
 import com.anzupop.saki.android.domain.model.RepeatModeSetting
@@ -214,7 +214,8 @@ fun NowPlayingOverlay(
     onRemoveQueueItem: (Int) -> Unit,
     currentServer: ServerConfig?,
     activeEndpointLabel: String? = null,
-    endpointProbeResults: List<EndpointSelector.EndpointProbeResult> = emptyList(),
+    activeEndpointId: Long? = null,
+    endpointProbeResults: List<EndpointProbeInfo> = emptyList(),
     isProbing: Boolean = false,
     onReprobeEndpoints: () -> Unit = {},
     lyrics: SongLyrics? = null,
@@ -692,7 +693,7 @@ fun NowPlayingOverlay(
                         Text("No probe results yet.", style = MaterialTheme.typography.bodyMedium)
                     } else {
                         endpointProbeResults.forEach { result ->
-                            val isActive = result.endpoint.label == activeEndpointLabel
+                            val isActive = result.id == activeEndpointId
                             Surface(
                                 shape = MaterialTheme.shapes.medium,
                                 color = if (isActive) {
@@ -710,11 +711,11 @@ fun NowPlayingOverlay(
                                 ) {
                                     Column(modifier = Modifier.weight(1f)) {
                                         Text(
-                                            text = result.endpoint.label + if (isActive) " ✓" else "",
+                                            text = result.label + if (isActive) " ✓" else "",
                                             style = MaterialTheme.typography.bodyLarge,
                                         )
                                         Text(
-                                            text = result.endpoint.baseUrl,
+                                            text = result.baseUrl,
                                             style = MaterialTheme.typography.bodySmall,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )

--- a/app/src/main/java/com/anzupop/saki/android/presentation/serverconfig/ServerConfigScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/serverconfig/ServerConfigScreen.kt
@@ -814,10 +814,12 @@ private fun ConnectionStateBanner(
                 color = MaterialTheme.colorScheme.secondaryContainer,
             ) {
                 Text(
-                    text = if (testState.serverVersion.isNullOrBlank()) {
-                        "Connection successful."
-                    } else {
-                        "Connection successful. Server API ${testState.serverVersion} responded."
+                    text = buildString {
+                        append("Connection successful.")
+                        if (!testState.serverVersion.isNullOrBlank()) {
+                            append(" Server API ${testState.serverVersion}.")
+                        }
+                        append(" ${testState.latencyMs} ms.")
                     },
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
                     style = MaterialTheme.typography.bodyLarge,
@@ -881,7 +883,7 @@ private fun ServerConfigScreenPreview() {
                             label = "LAN",
                             baseUrl = "http://192.168.1.10:4040",
                             isPrimary = true,
-                            testState = EndpointConnectionState.Success(serverVersion = "1.16.1"),
+                            testState = EndpointConnectionState.Success(serverVersion = "1.16.1", latencyMs = 12),
                         ),
                         ServerEndpointEditorState(
                             editorId = 2,

--- a/app/src/main/java/com/anzupop/saki/android/presentation/serverconfig/ServerConfigViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/serverconfig/ServerConfigViewModel.kt
@@ -218,6 +218,7 @@ class ServerConfigViewModel @Inject constructor(
                         copy(
                             testState = EndpointConnectionState.Success(
                                 serverVersion = result.serverVersion,
+                                latencyMs = result.latencyMs,
                             ),
                         )
                     }
@@ -394,6 +395,7 @@ sealed interface EndpointConnectionState {
 
     data class Success(
         val serverVersion: String?,
+        val latencyMs: Long,
     ) : EndpointConnectionState
 
     data class Failure(

--- a/app/src/test/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepositoryTest.kt
+++ b/app/src/test/java/com/anzupop/saki/android/data/repository/DefaultSubsonicRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.anzupop.saki.android.data.repository
 
+import com.anzupop.saki.android.data.remote.EndpointSelector
 import com.anzupop.saki.android.data.remote.subsonic.SubsonicApiException
 import com.anzupop.saki.android.data.remote.subsonic.SubsonicApiService
 import com.anzupop.saki.android.di.IoDispatcher
@@ -41,6 +42,11 @@ class DefaultSubsonicRepositoryTest {
         repository = DefaultSubsonicRepository(
             serverConfigRepository = FakeServerConfigRepository(),
             subsonicApiService = createApiService(),
+            endpointSelector = EndpointSelector(
+                context = android.content.ContextWrapper(null),
+                okHttpClient = okhttp3.OkHttpClient(),
+                ioDispatcher = kotlinx.coroutines.Dispatchers.Unconfined,
+            ),
             ioDispatcher = kotlinx.coroutines.Dispatchers.Unconfined,
         )
     }


### PR DESCRIPTION
## Summary

Automatically selects the best endpoint based on latency probing, with network-aware switching.

## Changes

### EndpointSelector (new)
- Parallel ping (`ping.view` with auth) to all endpoints, 1.5s timeout
- Updates best endpoint as soon as first successful probe arrives (no waiting for slow/unreachable endpoints)
- `NetworkCallback` triggers re-probing on WiFi ↔ cellular ↔ VPN changes
- Exponential backoff re-probe after network change: immediate → 3s → 6s → 12s (handles WiFi not fully established)
- New network change cancels pending re-probes
- Exposes `probeVersion` StateFlow for UI reactivity

### Connection test RTT
- `ConnectionTestResult.Success` now includes `latencyMs`
- Displayed in server config test connection result

### Endpoint status UI
- Now Playing menu: server name replaced with active endpoint label
- Tap to open Endpoint Status dialog showing all endpoints with latency
- Active endpoint highlighted, unreachable endpoints shown in error color
- "Re-test endpoints" button for manual probe

### Integration
- `executeWithFallback` uses probed best endpoint first, falls back to others
- Failed endpoints invalidated from cache
- Auto-probe on server load, ViewModel observes probe changes

## Testing

Verified on device with 2 endpoints (LAN + WireGuard):
- LAN ~25ms, WG ~60ms → auto-selects LAN
- WiFi off → switches to WG via cellular
- WiFi on → re-probes, settles back to LAN after backoff

Partially addresses #45