### PR TITLE
fix: show correct duration for transcoded streams

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -349,7 +349,9 @@ class DefaultPlaybackManager @Inject constructor(
                 currentIndex = currentIndex,
                 queue = queue,
                 positionMs = player.currentPosition.coerceKnownTime(),
-                durationMs = player.duration.coerceKnownTime(),
+                durationMs = player.duration.coerceKnownTime().takeIf { it > 0 }
+                    ?: player.currentMediaItem?.toPlaybackRequestOrNull()?.durationMs
+                    ?: 0L,
                 bufferedPositionMs = player.bufferedPosition.coerceKnownTime(),
                 repeatMode = player.repeatMode.toRepeatModeSetting(),
                 shuffleEnabled = player.shuffleModeEnabled,

--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -350,7 +350,7 @@ class DefaultPlaybackManager @Inject constructor(
                 queue = queue,
                 positionMs = player.currentPosition.coerceKnownTime(),
                 durationMs = player.duration.coerceKnownTime().takeIf { it > 0 }
-                    ?: player.currentMediaItem?.toPlaybackRequestOrNull()?.durationMs
+                    ?: player.currentMediaItem?.metadataDurationMs()
                     ?: 0L,
                 bufferedPositionMs = player.bufferedPosition.coerceKnownTime(),
                 repeatMode = player.repeatMode.toRepeatModeSetting(),

--- a/app/src/main/java/com/anzupop/saki/android/playback/SubsonicPlaybackItems.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SubsonicPlaybackItems.kt
@@ -138,6 +138,11 @@ internal fun CachedSong.toCachedMediaItem(): MediaItem {
         .build()
 }
 
+internal fun MediaItem.metadataDurationMs(): Long? {
+    val extras = requestMetadata.extras ?: return null
+    return extras.getLong(EXTRA_DURATION_MS).takeIf { extras.containsKey(EXTRA_DURATION_MS) }
+}
+
 internal fun MediaItem.toPlaybackRequestOrNull(): PlaybackRequest? {
     val extras = requestMetadata.extras ?: return null
     val songId = extras.getString(EXTRA_SONG_ID).orEmpty().ifBlank { mediaId }


### PR DESCRIPTION
## Problem

Playback duration shows `00:00` when streaming with non-original quality (transcoded). Transcoded streams use chunked HTTP transfer without `Content-Length`, so ExoPlayer returns `C.TIME_UNSET`.

## Fix

When `player.duration` is unknown, fall back to `durationMs` from song metadata in MediaItem extras (from Subsonic API).

Closes #42