### PR TITLE
feat: backup and restore server config + settings

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/data/repository/ConfigBackupManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/ConfigBackupManager.kt
@@ -3,6 +3,9 @@ package com.anzupop.saki.android.data.repository
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import com.anzupop.saki.android.di.IoDispatcher
+import com.anzupop.saki.android.domain.model.DEFAULT_SUBSONIC_API_VERSION
+import com.anzupop.saki.android.domain.model.DEFAULT_SUBSONIC_CLIENT
 import com.anzupop.saki.android.domain.model.ServerConfig
 import com.anzupop.saki.android.domain.model.ServerEndpoint
 import com.anzupop.saki.android.domain.repository.ServerConfigRepository
@@ -10,7 +13,14 @@ import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+private val EXCLUDED_SETTING_KEYS = setOf(
+    "room_migration_done",
+    DataStoreAppPreferencesRepository.KEY_ONBOARDING_COMPLETED.name,
+)
 
 @JsonClass(generateAdapter = true)
 data class BackupData(
@@ -41,8 +51,9 @@ class ConfigBackupManager @Inject constructor(
     private val serverConfigRepository: ServerConfigRepository,
     private val dataStore: DataStore<Preferences>,
     private val moshi: Moshi,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
-    suspend fun exportToJson(): String {
+    suspend fun exportToJson(): String = withContext(ioDispatcher) {
         val servers = serverConfigRepository.observeServerConfigs().first()
         val prefs = dataStore.data.first()
 
@@ -55,49 +66,46 @@ class ConfigBackupManager @Inject constructor(
                 apiVersion = server.apiVersion,
                 endpoints = server.endpoints
                     .sortedWith(compareByDescending<ServerEndpoint> { it.isPrimary }.thenBy { it.order })
-                    .map { ep ->
-                        BackupEndpoint(label = ep.label, url = ep.baseUrl, isPrimary = ep.isPrimary)
-                    },
+                    .map { ep -> BackupEndpoint(label = ep.label, url = ep.baseUrl, isPrimary = ep.isPrimary) },
             )
         }
 
         val settings = buildMap {
             prefs.asMap().forEach { (key, value) ->
-                // Skip migration flag and onboarding state
-                if (key.name != "room_migration_done" && key.name != "onboarding_completed") {
+                if (key.name !in EXCLUDED_SETTING_KEYS) {
                     put(key.name, value.toString())
                 }
             }
         }
 
         val backup = BackupData(servers = backupServers, settings = settings)
-        return moshi.adapter(BackupData::class.java).indent("  ").toJson(backup)
+        moshi.adapter(BackupData::class.java).indent("  ").toJson(backup)
     }
 
-    suspend fun importFromJson(json: String): ImportResult {
+    suspend fun importFromJson(json: String): ImportResult = withContext(ioDispatcher) {
         val backup = try {
             moshi.adapter(BackupData::class.java).fromJson(json)
         } catch (_: Exception) {
-            return ImportResult.InvalidFormat
-        } ?: return ImportResult.InvalidFormat
+            return@withContext ImportResult.InvalidFormat
+        } ?: return@withContext ImportResult.InvalidFormat
 
-        if (backup.version != 1) return ImportResult.UnsupportedVersion(backup.version)
+        if (backup.version != 1) return@withContext ImportResult.UnsupportedVersion(backup.version)
 
         var serversImported = 0
         val existingServers = serverConfigRepository.observeServerConfigs().first()
+        val seenKeys = existingServers.mapTo(mutableSetOf()) { it.name.trim() to it.username.trim() }
 
         for (backupServer in backup.servers) {
-            val isDuplicate = existingServers.any { existing ->
-                existing.name == backupServer.name && existing.username == backupServer.username
-            }
-            if (isDuplicate) continue
+            val key = backupServer.name.trim() to backupServer.username.trim()
+            if (key in seenKeys) continue
+            seenKeys.add(key)
 
             val config = ServerConfig(
-                name = backupServer.name,
-                username = backupServer.username,
+                name = backupServer.name.trim(),
+                username = backupServer.username.trim(),
                 password = backupServer.password,
-                clientName = backupServer.clientName ?: "Saki.Android",
-                apiVersion = backupServer.apiVersion ?: "1.16.1",
+                clientName = backupServer.clientName ?: DEFAULT_SUBSONIC_CLIENT,
+                apiVersion = backupServer.apiVersion ?: DEFAULT_SUBSONIC_API_VERSION,
                 endpoints = backupServer.endpoints.mapIndexed { index, ep ->
                     ServerEndpoint(label = ep.label, baseUrl = ep.url, isPrimary = ep.isPrimary, order = index)
                 },
@@ -106,27 +114,26 @@ class ConfigBackupManager @Inject constructor(
             serversImported++
         }
 
-        // Restore settings
         if (backup.settings.isNotEmpty()) {
             dataStore.edit { ds ->
                 backup.settings.forEach { (key, value) ->
-                    when {
-                        key == DataStorePlaybackPreferencesRepository.KEY_STREAM_CACHE_SIZE_MB.name ->
+                    when (key) {
+                        DataStorePlaybackPreferencesRepository.KEY_STREAM_CACHE_SIZE_MB.name ->
                             ds[DataStorePlaybackPreferencesRepository.KEY_STREAM_CACHE_SIZE_MB] = value.toIntOrNull() ?: return@forEach
-                        key == DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS.name ->
+                        DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS.name ->
                             ds[DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS] = value.toBooleanStrictOrNull() ?: return@forEach
-                        key == DataStoreAppPreferencesRepository.KEY_TEXT_SCALE.name ->
+                        DataStoreAppPreferencesRepository.KEY_TEXT_SCALE.name ->
                             ds[DataStoreAppPreferencesRepository.KEY_TEXT_SCALE] = value
-                        key == DataStorePlaybackPreferencesRepository.KEY_STREAM_QUALITY.name ->
+                        DataStorePlaybackPreferencesRepository.KEY_STREAM_QUALITY.name ->
                             ds[DataStorePlaybackPreferencesRepository.KEY_STREAM_QUALITY] = value
-                        key == DataStorePlaybackPreferencesRepository.KEY_SOUND_BALANCING_MODE.name ->
+                        DataStorePlaybackPreferencesRepository.KEY_SOUND_BALANCING_MODE.name ->
                             ds[DataStorePlaybackPreferencesRepository.KEY_SOUND_BALANCING_MODE] = value
                     }
                 }
             }
         }
 
-        return ImportResult.Success(serversImported = serversImported, settingsRestored = backup.settings.isNotEmpty())
+        ImportResult.Success(serversImported = serversImported, settingsRestored = backup.settings.isNotEmpty())
     }
 }
 

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/ConfigBackupManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/ConfigBackupManager.kt
@@ -1,0 +1,137 @@
+package com.anzupop.saki.android.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.anzupop.saki.android.domain.model.ServerConfig
+import com.anzupop.saki.android.domain.model.ServerEndpoint
+import com.anzupop.saki.android.domain.repository.ServerConfigRepository
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
+
+@JsonClass(generateAdapter = true)
+data class BackupData(
+    val version: Int = 1,
+    val servers: List<BackupServer>,
+    val settings: Map<String, String> = emptyMap(),
+)
+
+@JsonClass(generateAdapter = true)
+data class BackupServer(
+    val name: String,
+    val username: String,
+    val password: String,
+    val clientName: String? = null,
+    val apiVersion: String? = null,
+    val endpoints: List<BackupEndpoint>,
+)
+
+@JsonClass(generateAdapter = true)
+data class BackupEndpoint(
+    val label: String,
+    val url: String,
+    val isPrimary: Boolean = false,
+)
+
+@Singleton
+class ConfigBackupManager @Inject constructor(
+    private val serverConfigRepository: ServerConfigRepository,
+    private val dataStore: DataStore<Preferences>,
+    private val moshi: Moshi,
+) {
+    suspend fun exportToJson(): String {
+        val servers = serverConfigRepository.observeServerConfigs().first()
+        val prefs = dataStore.data.first()
+
+        val backupServers = servers.map { server ->
+            BackupServer(
+                name = server.name,
+                username = server.username,
+                password = server.password,
+                clientName = server.clientName,
+                apiVersion = server.apiVersion,
+                endpoints = server.endpoints
+                    .sortedWith(compareByDescending<ServerEndpoint> { it.isPrimary }.thenBy { it.order })
+                    .map { ep ->
+                        BackupEndpoint(label = ep.label, url = ep.baseUrl, isPrimary = ep.isPrimary)
+                    },
+            )
+        }
+
+        val settings = buildMap {
+            prefs.asMap().forEach { (key, value) ->
+                // Skip migration flag and onboarding state
+                if (key.name != "room_migration_done" && key.name != "onboarding_completed") {
+                    put(key.name, value.toString())
+                }
+            }
+        }
+
+        val backup = BackupData(servers = backupServers, settings = settings)
+        return moshi.adapter(BackupData::class.java).indent("  ").toJson(backup)
+    }
+
+    suspend fun importFromJson(json: String): ImportResult {
+        val backup = try {
+            moshi.adapter(BackupData::class.java).fromJson(json)
+        } catch (_: Exception) {
+            return ImportResult.InvalidFormat
+        } ?: return ImportResult.InvalidFormat
+
+        if (backup.version != 1) return ImportResult.UnsupportedVersion(backup.version)
+
+        var serversImported = 0
+        val existingServers = serverConfigRepository.observeServerConfigs().first()
+
+        for (backupServer in backup.servers) {
+            val isDuplicate = existingServers.any { existing ->
+                existing.name == backupServer.name && existing.username == backupServer.username
+            }
+            if (isDuplicate) continue
+
+            val config = ServerConfig(
+                name = backupServer.name,
+                username = backupServer.username,
+                password = backupServer.password,
+                clientName = backupServer.clientName ?: "Saki.Android",
+                apiVersion = backupServer.apiVersion ?: "1.16.1",
+                endpoints = backupServer.endpoints.mapIndexed { index, ep ->
+                    ServerEndpoint(label = ep.label, baseUrl = ep.url, isPrimary = ep.isPrimary, order = index)
+                },
+            )
+            serverConfigRepository.saveServerConfig(config)
+            serversImported++
+        }
+
+        // Restore settings
+        if (backup.settings.isNotEmpty()) {
+            dataStore.edit { ds ->
+                backup.settings.forEach { (key, value) ->
+                    when {
+                        key == DataStorePlaybackPreferencesRepository.KEY_STREAM_CACHE_SIZE_MB.name ->
+                            ds[DataStorePlaybackPreferencesRepository.KEY_STREAM_CACHE_SIZE_MB] = value.toIntOrNull() ?: return@forEach
+                        key == DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS.name ->
+                            ds[DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS] = value.toBooleanStrictOrNull() ?: return@forEach
+                        key == DataStoreAppPreferencesRepository.KEY_TEXT_SCALE.name ->
+                            ds[DataStoreAppPreferencesRepository.KEY_TEXT_SCALE] = value
+                        key == DataStorePlaybackPreferencesRepository.KEY_STREAM_QUALITY.name ->
+                            ds[DataStorePlaybackPreferencesRepository.KEY_STREAM_QUALITY] = value
+                        key == DataStorePlaybackPreferencesRepository.KEY_SOUND_BALANCING_MODE.name ->
+                            ds[DataStorePlaybackPreferencesRepository.KEY_SOUND_BALANCING_MODE] = value
+                    }
+                }
+            }
+        }
+
+        return ImportResult.Success(serversImported = serversImported, settingsRestored = backup.settings.isNotEmpty())
+    }
+}
+
+sealed interface ImportResult {
+    data class Success(val serversImported: Int, val settingsRestored: Boolean) : ImportResult
+    data object InvalidFormat : ImportResult
+    data class UnsupportedVersion(val version: Int) : ImportResult
+}

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -81,6 +81,10 @@ fun SakiApp(
                             viewModel.completeOnboarding()
                             showServerManager = true
                         },
+                        onImportConfig = { json ->
+                            viewModel.importConfig(json)
+                            viewModel.completeOnboarding()
+                        },
                     )
                 }
 
@@ -122,6 +126,8 @@ fun SakiApp(
                         onUpdateTextScale = viewModel::updateTextScale,
                         onReplayOnboarding = viewModel::replayOnboarding,
                         onUpdateBluetoothLyrics = viewModel::updateBluetoothLyrics,
+                        onExportConfig = viewModel::exportConfig,
+                        onImportConfig = viewModel::importConfig,
                         onOpenArtistFromPlayback = viewModel::openArtistFromPlayback,
                         onOpenAlbumFromPlayback = viewModel::openAlbumFromPlayback,
                         onPausePlayback = viewModel::pausePlayback,
@@ -183,6 +189,8 @@ private fun RootShell(
     onUpdateTextScale: (com.anzupop.saki.android.domain.model.TextScale) -> Unit,
     onReplayOnboarding: () -> Unit,
     onUpdateBluetoothLyrics: (Boolean) -> Unit,
+    onExportConfig: ((String) -> Unit) -> Unit,
+    onImportConfig: (String) -> Unit,
     onOpenArtistFromPlayback: (Long?, String?) -> Unit,
     onOpenAlbumFromPlayback: (Long?, String?) -> Unit,
     onPausePlayback: () -> Unit,
@@ -239,6 +247,8 @@ private fun RootShell(
                             onUpdateTextScale = onUpdateTextScale,
                             onReplayOnboarding = onReplayOnboarding,
                             onUpdateBluetoothLyrics = onUpdateBluetoothLyrics,
+                            onExportConfig = onExportConfig,
+                            onImportConfig = onImportConfig,
                             onPlayCachedSong = onPlayCachedSong,
                             onPlayCachedQueue = onPlayCachedQueue,
                             onDeleteCachedSong = onDeleteCachedSong,

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -82,8 +82,7 @@ fun SakiApp(
                             showServerManager = true
                         },
                         onImportConfig = { json ->
-                            viewModel.importConfig(json)
-                            viewModel.completeOnboarding()
+                            viewModel.importConfig(json) { viewModel.completeOnboarding() }
                         },
                     )
                 }
@@ -127,7 +126,7 @@ fun SakiApp(
                         onReplayOnboarding = viewModel::replayOnboarding,
                         onUpdateBluetoothLyrics = viewModel::updateBluetoothLyrics,
                         onExportConfig = viewModel::exportConfig,
-                        onImportConfig = viewModel::importConfig,
+                        onImportConfig = { json -> viewModel.importConfig(json) },
                         onOpenArtistFromPlayback = viewModel::openArtistFromPlayback,
                         onOpenAlbumFromPlayback = viewModel::openAlbumFromPlayback,
                         onPausePlayback = viewModel::pausePlayback,

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -1076,22 +1076,32 @@ class SakiAppViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching { configBackupManager.exportToJson() }
                 .onSuccess { onResult(it) }
-                .onFailure { snackbarMessages.tryEmit("Export failed: ${it.message}") }
+                .onFailure { e ->
+                    if (e is CancellationException) throw e
+                    snackbarMessages.tryEmit("Export failed: ${e.message}")
+                }
         }
     }
 
-    fun importConfig(json: String) {
+    fun importConfig(json: String, onSuccess: (() -> Unit)? = null) {
         viewModelScope.launch {
-            when (val result = configBackupManager.importFromJson(json)) {
-                is ImportResult.Success -> {
-                    val msg = buildString {
-                        append("Imported ${result.serversImported} server(s)")
-                        if (result.settingsRestored) append(", settings restored")
+            try {
+                when (val result = configBackupManager.importFromJson(json)) {
+                    is ImportResult.Success -> {
+                        val msg = buildString {
+                            append("Imported ${result.serversImported} server(s)")
+                            if (result.settingsRestored) append(", settings restored")
+                        }
+                        snackbarMessages.tryEmit(msg)
+                        onSuccess?.invoke()
                     }
-                    snackbarMessages.tryEmit(msg)
+                    is ImportResult.InvalidFormat -> snackbarMessages.tryEmit("Invalid backup file")
+                    is ImportResult.UnsupportedVersion -> snackbarMessages.tryEmit("Unsupported backup version ${result.version}")
                 }
-                is ImportResult.InvalidFormat -> snackbarMessages.tryEmit("Invalid backup file")
-                is ImportResult.UnsupportedVersion -> snackbarMessages.tryEmit("Unsupported backup version ${result.version}")
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                snackbarMessages.tryEmit("Import failed: ${e.message}")
             }
         }
     }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.anzupop.saki.android.data.remote.EndpointSelector
+import com.anzupop.saki.android.data.repository.ConfigBackupManager
+import com.anzupop.saki.android.data.repository.ImportResult
 import com.anzupop.saki.android.domain.model.Album
 import com.anzupop.saki.android.domain.model.AlbumListType
 import com.anzupop.saki.android.domain.model.AlbumSummary
@@ -63,6 +65,7 @@ class SakiAppViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val lyricsHolder: LyricsHolder,
     private val endpointSelector: EndpointSelector,
+    private val configBackupManager: ConfigBackupManager,
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(SakiAppUiState())
     private val snackbarMessages = MutableSharedFlow<String>(extraBufferCapacity = 1)
@@ -1065,6 +1068,30 @@ class SakiAppViewModel @Inject constructor(
                 refreshEndpointStatus()
             } finally {
                 mutableEndpointStatus.update { it.copy(isProbing = false) }
+            }
+        }
+    }
+
+    fun exportConfig(onResult: (String) -> Unit) {
+        viewModelScope.launch {
+            runCatching { configBackupManager.exportToJson() }
+                .onSuccess { onResult(it) }
+                .onFailure { snackbarMessages.tryEmit("Export failed: ${it.message}") }
+        }
+    }
+
+    fun importConfig(json: String) {
+        viewModelScope.launch {
+            when (val result = configBackupManager.importFromJson(json)) {
+                is ImportResult.Success -> {
+                    val msg = buildString {
+                        append("Imported ${result.serversImported} server(s)")
+                        if (result.settingsRestored) append(", settings restored")
+                    }
+                    snackbarMessages.tryEmit(msg)
+                }
+                is ImportResult.InvalidFormat -> snackbarMessages.tryEmit("Invalid backup file")
+                is ImportResult.UnsupportedVersion -> snackbarMessages.tryEmit("Unsupported backup version ${result.version}")
             }
         }
     }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/onboarding/OnboardingScreen.kt
@@ -1,5 +1,7 @@
 package com.anzupop.saki.android.presentation.onboarding
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -18,6 +20,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CloudDownload
 import androidx.compose.material.icons.rounded.LibraryMusic
+import androidx.compose.material.icons.rounded.Upload
 import androidx.compose.material.icons.rounded.WifiTethering
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -25,6 +28,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.CompositionLocalProvider
@@ -33,6 +37,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.unit.dp
@@ -41,6 +46,7 @@ import androidx.compose.ui.unit.dp
 fun OnboardingScreen(
     onContinue: () -> Unit,
     onSetUpNow: () -> Unit,
+    onImportConfig: (String) -> Unit = {},
 ) {
     val colorScheme = MaterialTheme.colorScheme
     val background = remember(colorScheme) {
@@ -109,6 +115,22 @@ fun OnboardingScreen(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text("Set up my library")
+                }
+                val context = LocalContext.current
+                val importLauncher = rememberLauncherForActivityResult(
+                    contract = ActivityResultContracts.OpenDocument(),
+                ) { uri ->
+                    if (uri != null) {
+                        val json = context.contentResolver.openInputStream(uri)?.bufferedReader()?.readText()
+                        if (json != null) onImportConfig(json)
+                    }
+                }
+                OutlinedButton(
+                    onClick = { importLauncher.launch(arrayOf("application/json", "*/*")) },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(Icons.Rounded.Upload, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+                    Text("Import backup")
                 }
                 TextButton(
                     onClick = onContinue,

--- a/app/src/main/java/com/anzupop/saki/android/presentation/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/onboarding/OnboardingScreen.kt
@@ -121,7 +121,9 @@ fun OnboardingScreen(
                     contract = ActivityResultContracts.OpenDocument(),
                 ) { uri ->
                     if (uri != null) {
-                        val json = context.contentResolver.openInputStream(uri)?.bufferedReader()?.readText()
+                        val json = runCatching {
+                            context.contentResolver.openInputStream(uri)?.use { it.bufferedReader().readText() }
+                        }.getOrNull()
                         if (json != null) onImportConfig(json)
                     }
                 }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/settings/SettingsScreen.kt
@@ -381,7 +381,9 @@ fun SettingsScreen(
             ) { uri ->
                 if (uri != null) {
                     onExportConfig { json ->
-                        context.contentResolver.openOutputStream(uri)?.use { it.write(json.toByteArray()) }
+                        runCatching {
+                            context.contentResolver.openOutputStream(uri)?.use { it.write(json.toByteArray()) }
+                        }
                     }
                 }
             }
@@ -389,7 +391,9 @@ fun SettingsScreen(
                 contract = ActivityResultContracts.OpenDocument(),
             ) { uri ->
                 if (uri != null) {
-                    val json = context.contentResolver.openInputStream(uri)?.bufferedReader()?.readText()
+                    val json = runCatching {
+                        context.contentResolver.openInputStream(uri)?.use { it.bufferedReader().readText() }
+                    }.getOrNull()
                     if (json != null) onImportConfig(json)
                 }
             }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/settings/SettingsScreen.kt
@@ -1,6 +1,9 @@
 package com.anzupop.saki.android.presentation.settings
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -17,9 +20,11 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CloudDownload
 import androidx.compose.material.icons.rounded.DeleteOutline
+import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Storage
+import androidx.compose.material.icons.rounded.Upload
 import androidx.compose.material.icons.rounded.TextFields
 import androidx.compose.material.icons.rounded.WifiTethering
 import androidx.compose.material3.Button
@@ -73,6 +78,8 @@ fun SettingsScreen(
     onUpdateTextScale: (TextScale) -> Unit,
     onReplayOnboarding: () -> Unit,
     onUpdateBluetoothLyrics: (Boolean) -> Unit,
+    onExportConfig: ((String) -> Unit) -> Unit,
+    onImportConfig: (String) -> Unit,
     onPlayCachedSong: (CachedSong) -> Unit,
     onPlayCachedQueue: (List<CachedSong>, Int) -> Unit,
     onDeleteCachedSong: (String) -> Unit,
@@ -363,6 +370,43 @@ fun SettingsScreen(
                         checked = checked,
                         onCheckedChange = null,
                     )
+                }
+            }
+        }
+
+        item {
+            val context = LocalContext.current
+            val exportLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.CreateDocument("application/json"),
+            ) { uri ->
+                if (uri != null) {
+                    onExportConfig { json ->
+                        context.contentResolver.openOutputStream(uri)?.use { it.write(json.toByteArray()) }
+                    }
+                }
+            }
+            val importLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.OpenDocument(),
+            ) { uri ->
+                if (uri != null) {
+                    val json = context.contentResolver.openInputStream(uri)?.bufferedReader()?.readText()
+                    if (json != null) onImportConfig(json)
+                }
+            }
+            SettingsSectionCard(
+                title = "Backup & Restore",
+                body = "Export or import server configuration and settings as a JSON file.",
+                action = null,
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = { exportLauncher.launch("saki-backup.json") }) {
+                        Icon(Icons.Rounded.Upload, contentDescription = null)
+                        Text("Export", modifier = Modifier.padding(start = 8.dp))
+                    }
+                    OutlinedButton(onClick = { importLauncher.launch(arrayOf("application/json", "*/*")) }) {
+                        Icon(Icons.Rounded.Download, contentDescription = null)
+                        Text("Import", modifier = Modifier.padding(start = 8.dp))
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Export and import server configuration + app settings as JSON file.

## Features

### Export (Settings → Backup & Restore → Export)
- Exports all servers with endpoints (name, credentials, URLs, primary flag)
- Exports DataStore settings (stream quality, sound balancing, text scale, etc.)
- Excludes onboarding state and migration flags
- Uses Android SAF file picker, default filename `saki-backup.json`

### Import (Settings → Import, or Onboarding → Import backup)
- Validates JSON structure and version
- Creates servers/endpoints, skips duplicates (same name + username)
- Restores DataStore settings
- Available in both Settings (existing users) and Onboarding (fresh install)

### JSON format
```json
{
  "version": 1,
  "servers": [{
    "name": "My Server",
    "username": "user",
    "password": "pass",
    "endpoints": [
      {"label": "LAN", "url": "http://192.168.1.100:4533", "isPrimary": true},
      {"label": "WAN", "url": "https://music.example.com", "isPrimary": false}
    ]
  }],
  "settings": {
    "stream_quality": "original",
    "text_scale": "default"
  }
}
```

## Dependencies

Builds on `refactor/datastore-settings` (#51) for DataStore-based settings.

Closes #44