### PR TITLE
feat: auto-scroll queue to currently playing track

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -635,7 +635,12 @@ fun NowPlayingOverlay(
                     QueuePullAffordance(
                         onClick = {
                             coroutineScope.launch {
-                                listState.animateScrollToItem(9)
+                                val queueStart = listState.layoutInfo.totalItemsCount - playbackState.queue.size
+                                val targetIndex = queueStart + playbackState.currentIndex
+                                // Show current track ~40% from top; use fixed 3-row offset
+                                // since queue rows have consistent height
+                                val scrollTo = (targetIndex - 3).coerceAtLeast(0)
+                                listState.scrollToItem(scrollTo)
                             }
                         },
                     )

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Usage: deploy.sh <ip:port>
+# Example: deploy.sh 10.111.111.90:38541
+export PATH=$HOME/android-sdk/platform-tools:$PATH
+adb connect "$1" && sleep 2 && adb install -r /home/mew/repos/Saki.Android/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
## Summary

Queue pull affordance now scrolls to the currently playing track instead of a fixed position.

## Behavior

- Tap the queue affordance → jumps to current track in queue
- Current track positioned at ~40% from top so user sees surrounding context
- Instant scroll, no animation

Closes #56