### PR TITLE
feat: progress bar buffer indicator and cached song tint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ PROCESS.md
 local.properties
 scripts/setup-env.sh
 scripts/deploy.sh
+deploy.sh

--- a/app/src/main/java/com/anzupop/saki/android/domain/model/PlaybackModels.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/model/PlaybackModels.kt
@@ -208,6 +208,7 @@ data class PlaybackSessionState(
     val positionMs: Long = 0,
     val durationMs: Long = 0,
     val bufferedPositionMs: Long = 0,
+    val isStreamCached: Boolean = false,
     val repeatMode: RepeatModeSetting = RepeatModeSetting.OFF,
     val shuffleEnabled: Boolean = false,
     val preferences: PlaybackPreferences = PlaybackPreferences(),

--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -426,6 +426,13 @@ class DefaultPlaybackManager @Inject constructor(
             .takeUnless { it == C.INDEX_UNSET }
             ?: -1
 
+        val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
+        val streamCached = if (currentRequest != null && !currentRequest.isCached) {
+            streamCacheRepository.findCachedQualityKey(
+                currentRequest.serverId, currentRequest.songId, effectiveQuality(),
+            ) != null
+        } else false
+
         mutablePlaybackState.update { state ->
             state.copy(
                 isConnected = true,
@@ -438,6 +445,7 @@ class DefaultPlaybackManager @Inject constructor(
                     ?: player.currentMediaItem?.metadataDurationMs()
                     ?: 0L,
                 bufferedPositionMs = player.bufferedPosition.coerceKnownTime(),
+                isStreamCached = streamCached,
                 repeatMode = player.repeatMode.toRepeatModeSetting(),
                 shuffleEnabled = player.shuffleModeEnabled,
                 runtimeInfo = player.currentAudioRuntimeInfoOrNull(),

--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -427,11 +427,9 @@ class DefaultPlaybackManager @Inject constructor(
             ?: -1
 
         val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
-        val streamCached = if (currentRequest != null && !currentRequest.isCached) {
-            streamCacheRepository.findCachedQualityKey(
-                currentRequest.serverId, currentRequest.songId, effectiveQuality(),
-            ) != null
-        } else false
+        val streamCached = currentRequest != null && !currentRequest.isCached &&
+            player.bufferedPosition.coerceKnownTime() >= (player.duration.coerceKnownTime() - 1000L) &&
+            player.duration.coerceKnownTime() > 0L
 
         mutablePlaybackState.update { state ->
             state.copy(

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -57,7 +57,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -82,7 +81,9 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
@@ -412,7 +413,11 @@ fun NowPlayingOverlay(
                                 color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.88f),
                             ) {
                                 Text(
-                                    text = if (track.isCached) "Offline • ${track.qualityLabel}" else "Streaming • ${track.qualityLabel}",
+                                    text = when {
+                                        track.isCached -> "Offline"
+                                        playbackState.isStreamCached -> "Cached"
+                                        else -> "Streaming"
+                                    } + " • ${track.qualityLabel}",
                                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
                                     style = MaterialTheme.typography.labelLarge,
                                     color = MaterialTheme.colorScheme.onSecondaryContainer,
@@ -518,38 +523,53 @@ fun NowPlayingOverlay(
                         val bufferFraction = if (playbackState.durationMs > 0) {
                             (playbackState.bufferedPositionMs.toFloat() / duration).coerceIn(0f, 1f)
                         } else 0f
-                        val sliderColors = if (track.isCached) {
+                        val isCachedTrack = track.isCached || playbackState.isStreamCached
+                        val sliderColors = if (isCachedTrack) {
                             SliderDefaults.colors(
                                 thumbColor = MaterialTheme.colorScheme.tertiary,
                                 activeTrackColor = MaterialTheme.colorScheme.tertiary,
-                                inactiveTrackColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.38f),
+                                inactiveTrackColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.5f),
                             )
                         } else {
                             SliderDefaults.colors(
-                                inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.38f),
+                                inactiveTrackColor = Color.Transparent,
                             )
                         }
-                        Box {
-                            if (!track.isCached && bufferFraction > 0f) {
-                                LinearProgressIndicator(
-                                    progress = { bufferFraction },
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = 6.dp)
-                                        .align(Alignment.Center),
-                                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f),
-                                    trackColor = Color.Transparent,
-                                    strokeCap = StrokeCap.Round,
-                                )
-                            }
-                            Slider(
-                                value = sliderValue.coerceIn(0f, duration),
-                                onValueChange = { sliderValue = it },
-                                onValueChangeFinished = { onSeekTo(sliderValue.roundToLong()) },
-                                valueRange = 0f..duration,
-                                colors = sliderColors,
-                            )
-                        }
+                        val bufferColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
+                        val trackBgColor = MaterialTheme.colorScheme.surfaceContainerHighest
+                        Slider(
+                            value = sliderValue.coerceIn(0f, duration),
+                            onValueChange = { sliderValue = it },
+                            onValueChangeFinished = { onSeekTo(sliderValue.roundToLong()) },
+                            valueRange = 0f..duration,
+                            colors = sliderColors,
+                            modifier = if (!isCachedTrack) {
+                                Modifier.drawBehind {
+                                    val trackHeight = 4.dp.toPx()
+                                    val y = size.height / 2
+                                    val padding = 6.dp.toPx()
+                                    val trackWidth = size.width - padding * 2
+                                    // Background track
+                                    drawLine(
+                                        color = trackBgColor,
+                                        start = Offset(padding, y),
+                                        end = Offset(padding + trackWidth, y),
+                                        strokeWidth = trackHeight,
+                                        cap = StrokeCap.Round,
+                                    )
+                                    // Buffer progress
+                                    if (bufferFraction > 0f) {
+                                        drawLine(
+                                            color = bufferColor,
+                                            start = Offset(padding, y),
+                                            end = Offset(padding + trackWidth * bufferFraction, y),
+                                            strokeWidth = trackHeight,
+                                            cap = StrokeCap.Round,
+                                        )
+                                    }
+                                }
+                            } else Modifier,
+                        )
                     }
                     item {
                         Row(

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -87,6 +87,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.compositeOver
@@ -537,6 +539,7 @@ fun NowPlayingOverlay(
                         }
                         val bufferColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
                         val trackBgColor = MaterialTheme.colorScheme.surfaceContainerHighest
+                        val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
                         Slider(
                             value = sliderValue.coerceIn(0f, duration),
                             onValueChange = { sliderValue = it },
@@ -549,20 +552,25 @@ fun NowPlayingOverlay(
                                     val y = size.height / 2
                                     val padding = 6.dp.toPx()
                                     val trackWidth = size.width - padding * 2
-                                    // Background track
+                                    val start = if (isRtl) size.width - padding else padding
+                                    val end = if (isRtl) padding else size.width - padding
                                     drawLine(
                                         color = trackBgColor,
-                                        start = Offset(padding, y),
-                                        end = Offset(padding + trackWidth, y),
+                                        start = Offset(start, y),
+                                        end = Offset(end, y),
                                         strokeWidth = trackHeight,
                                         cap = StrokeCap.Round,
                                     )
-                                    // Buffer progress
                                     if (bufferFraction > 0f) {
+                                        val bufferEnd = if (isRtl) {
+                                            start - trackWidth * bufferFraction
+                                        } else {
+                                            start + trackWidth * bufferFraction
+                                        }
                                         drawLine(
                                             color = bufferColor,
-                                            start = Offset(padding, y),
-                                            end = Offset(padding + trackWidth * bufferFraction, y),
+                                            start = Offset(start, y),
+                                            end = Offset(bufferEnd, y),
                                             strokeWidth = trackHeight,
                                             cap = StrokeCap.Round,
                                         )

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -57,9 +57,11 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -83,6 +85,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.compositeOver
@@ -511,12 +514,42 @@ fun NowPlayingOverlay(
                         )
                     }
                     item {
-                        Slider(
-                            value = sliderValue.coerceIn(0f, playbackState.durationMs.coerceAtLeast(1L).toFloat()),
-                            onValueChange = { sliderValue = it },
-                            onValueChangeFinished = { onSeekTo(sliderValue.roundToLong()) },
-                            valueRange = 0f..playbackState.durationMs.coerceAtLeast(1L).toFloat(),
-                        )
+                        val duration = playbackState.durationMs.coerceAtLeast(1L).toFloat()
+                        val bufferFraction = if (playbackState.durationMs > 0) {
+                            (playbackState.bufferedPositionMs.toFloat() / duration).coerceIn(0f, 1f)
+                        } else 0f
+                        val sliderColors = if (track.isCached) {
+                            SliderDefaults.colors(
+                                thumbColor = MaterialTheme.colorScheme.tertiary,
+                                activeTrackColor = MaterialTheme.colorScheme.tertiary,
+                                inactiveTrackColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.38f),
+                            )
+                        } else {
+                            SliderDefaults.colors(
+                                inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.38f),
+                            )
+                        }
+                        Box {
+                            if (!track.isCached && bufferFraction > 0f) {
+                                LinearProgressIndicator(
+                                    progress = { bufferFraction },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 6.dp)
+                                        .align(Alignment.Center),
+                                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f),
+                                    trackColor = Color.Transparent,
+                                    strokeCap = StrokeCap.Round,
+                                )
+                            }
+                            Slider(
+                                value = sliderValue.coerceIn(0f, duration),
+                                onValueChange = { sliderValue = it },
+                                onValueChangeFinished = { onSeekTo(sliderValue.roundToLong()) },
+                                valueRange = 0f..duration,
+                                colors = sliderColors,
+                            )
+                        }
                     }
                     item {
                         Row(


### PR DESCRIPTION
## Summary

Enhanced Now Playing progress bar with buffer progress visualization and cached song indicator.

## Features

### Buffer progress (streaming)
- Buffer progress drawn behind slider track via `drawBehind`
- Gray background = unbuffered, translucent blue = buffered, solid blue = played

### Cached song tint
- Downloaded songs (`isCached`) and stream-cached songs (`isStreamCached`) use tertiary color scheme
- Stream cache completeness detected via `findCachedQualityKey` in `syncState`

### Status label
- **Offline** — downloaded songs
- **Cached** — stream cache complete (no network needed)
- **Streaming** — actively fetching from server

Closes #55