### PR TITLE
feat: shuffle by virtual index mapping with seed-based persistence

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DataStorePlaybackPreferencesRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DataStorePlaybackPreferencesRepository.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.anzupop.saki.android.domain.model.DEFAULT_STREAM_CACHE_SIZE_MB
 import com.anzupop.saki.android.domain.model.MAX_STREAM_CACHE_SIZE_MB
@@ -67,6 +68,29 @@ class DataStorePlaybackPreferencesRepository @Inject constructor(
         dataStore.edit { it[KEY_BLUETOOTH_LYRICS] = enabled }
     }
 
+    override suspend fun updateShuffleState(seed: Long, anchorIndex: Int) {
+        dataStore.edit {
+            it[KEY_SHUFFLE_SEED] = seed
+            it[KEY_SHUFFLE_ANCHOR] = anchorIndex
+        }
+    }
+
+    override suspend fun clearShuffleState() {
+        dataStore.edit {
+            it.remove(KEY_SHUFFLE_SEED)
+            it.remove(KEY_SHUFFLE_ANCHOR)
+        }
+    }
+
+    override suspend fun getShuffleState(): Pair<Long, Int>? {
+        val prefs = dataStore.data
+            .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
+            .first()
+        val seed = prefs[KEY_SHUFFLE_SEED] ?: return null
+        val anchor = prefs[KEY_SHUFFLE_ANCHOR] ?: return null
+        return seed to anchor
+    }
+
     companion object {
         val KEY_STREAM_QUALITY = stringPreferencesKey("stream_quality")
         val KEY_ADAPTIVE_QUALITY = booleanPreferencesKey("adaptive_quality_enabled")
@@ -75,6 +99,8 @@ class DataStorePlaybackPreferencesRepository @Inject constructor(
         val KEY_SOUND_BALANCING_MODE = stringPreferencesKey("sound_balancing_mode")
         val KEY_STREAM_CACHE_SIZE_MB = intPreferencesKey("stream_cache_size_mb")
         val KEY_BLUETOOTH_LYRICS = booleanPreferencesKey("bluetooth_lyrics_enabled")
+        val KEY_SHUFFLE_SEED = longPreferencesKey("shuffle_seed")
+        val KEY_SHUFFLE_ANCHOR = intPreferencesKey("shuffle_anchor_index")
     }
 }
 

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultPlaybackPreferencesRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultPlaybackPreferencesRepository.kt
@@ -66,8 +66,7 @@ class DefaultPlaybackPreferencesRepository @Inject constructor(
         }
     }
 
-    override suspend fun updateShuffleState(seed: Long, anchorIndex: Int) =
-        error("Room-backed repository does not support shuffle state. Use DataStore implementation.")
+    override suspend fun updateShuffleState(seed: Long, anchorIndex: Int) = Unit
     override suspend fun clearShuffleState() = Unit
     override suspend fun getShuffleState(): Pair<Long, Int>? = null
 

--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultPlaybackPreferencesRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultPlaybackPreferencesRepository.kt
@@ -66,6 +66,11 @@ class DefaultPlaybackPreferencesRepository @Inject constructor(
         }
     }
 
+    override suspend fun updateShuffleState(seed: Long, anchorIndex: Int) =
+        error("Room-backed repository does not support shuffle state. Use DataStore implementation.")
+    override suspend fun clearShuffleState() = Unit
+    override suspend fun getShuffleState(): Pair<Long, Int>? = null
+
     private suspend fun updatePreferences(
         transform: (PlaybackPreferencesEntity) -> PlaybackPreferencesEntity,
     ) {

--- a/app/src/main/java/com/anzupop/saki/android/domain/repository/PlaybackPreferencesRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/repository/PlaybackPreferencesRepository.kt
@@ -23,4 +23,11 @@ interface PlaybackPreferencesRepository {
     suspend fun updateStreamCacheSizeMb(sizeMb: Int)
 
     suspend fun updateBluetoothLyrics(enabled: Boolean)
+
+    suspend fun updateShuffleState(seed: Long, anchorIndex: Int)
+
+    suspend fun clearShuffleState()
+
+    /** Returns (seed, anchorIndex) or null if no shuffle state saved. */
+    suspend fun getShuffleState(): Pair<Long, Int>?
 }

--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -164,6 +164,7 @@ class DefaultPlaybackManager @Inject constructor(
         startIndex: Int,
     ) {
         require(songs.isNotEmpty()) { "Playback queue cannot be empty." }
+        originalQueue = null
         val mediaItems = songs.map { song ->
             val quality = resolveQualityForSong(serverId, song.id)
             song.toPlaybackRequestMediaItem(
@@ -192,6 +193,7 @@ class DefaultPlaybackManager @Inject constructor(
         positionMs: Long,
     ) {
         if (songs.isEmpty()) return
+        originalQueue = null
         val mediaItems = songs.map { song ->
             val quality = resolveQualityForSong(serverId, song.id)
             song.toPlaybackRequestMediaItem(
@@ -217,6 +219,7 @@ class DefaultPlaybackManager @Inject constructor(
         startIndex: Int,
     ) {
         require(songs.isNotEmpty()) { "Playback queue cannot be empty." }
+        originalQueue = null
         val mediaItems = songs.map(CachedSong::toCachedMediaItem)
 
         withController { activeController ->
@@ -349,9 +352,40 @@ class DefaultPlaybackManager @Inject constructor(
         }
     }
 
+    private var originalQueue: List<MediaItem>? = null
+
     override suspend fun toggleShuffle() {
         withController { activeController ->
-            activeController.shuffleModeEnabled = !activeController.shuffleModeEnabled
+            val count = activeController.mediaItemCount
+            if (count <= 1) return@withController
+
+            if (originalQueue == null) {
+                // Shuffle ON: save original order, shuffle remaining items
+                val currentIndex = activeController.currentMediaItemIndex
+                val items = (0 until count).map(activeController::getMediaItemAt)
+                originalQueue = items
+
+                val currentItem = items[currentIndex]
+                val rest = items.toMutableList().apply { removeAt(currentIndex) }.shuffled()
+                val shuffled = listOf(currentItem) + rest
+
+                activeController.clearMediaItems()
+                activeController.setMediaItems(shuffled, 0, activeController.currentPosition)
+                activeController.prepare()
+            } else {
+                // Shuffle OFF: restore original order
+                val currentMediaId = activeController.currentMediaItem?.mediaId
+                val position = activeController.currentPosition
+                val original = originalQueue!!
+                originalQueue = null
+
+                val restoredIndex = original.indexOfFirst { it.mediaId == currentMediaId }.coerceAtLeast(0)
+                activeController.clearMediaItems()
+                activeController.setMediaItems(original, restoredIndex, position)
+                activeController.prepare()
+            }
+
+            mutablePlaybackState.update { it.copy(shuffleEnabled = originalQueue != null) }
             syncState(activeController)
         }
     }
@@ -445,7 +479,7 @@ class DefaultPlaybackManager @Inject constructor(
                 bufferedPositionMs = player.bufferedPosition.coerceKnownTime(),
                 isStreamCached = streamCached,
                 repeatMode = player.repeatMode.toRepeatModeSetting(),
-                shuffleEnabled = player.shuffleModeEnabled,
+                shuffleEnabled = originalQueue != null,
                 runtimeInfo = player.currentAudioRuntimeInfoOrNull(),
             )
         }

--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -58,9 +58,26 @@ class DefaultPlaybackManager @Inject constructor(
 ) : PlaybackManager {
     private val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
     private val controllerMutex = Mutex()
+    private var lastVirtualIndex: Int = -1
+
     private val controllerListener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) {
             syncState(player)
+        }
+
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            val order = shuffleOrder ?: return
+            val ctrl = controller ?: return
+            if (reason != Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) return
+
+            // Media3 auto-advanced in original order. Redirect to shuffled next.
+            val nextVirtual = lastVirtualIndex + 1
+            if (nextVirtual < order.size) {
+                val targetPlayer = virtualToPlayer(nextVirtual)
+                if (ctrl.currentMediaItemIndex != targetPlayer) {
+                    ctrl.seekToDefaultPosition(targetPlayer)
+                }
+            }
         }
     }
 
@@ -164,7 +181,8 @@ class DefaultPlaybackManager @Inject constructor(
         startIndex: Int,
     ) {
         require(songs.isNotEmpty()) { "Playback queue cannot be empty." }
-        originalQueue = null
+        shuffleOrder = null
+        persistShuffleState()
         val mediaItems = songs.map { song ->
             val quality = resolveQualityForSong(serverId, song.id)
             song.toPlaybackRequestMediaItem(
@@ -193,7 +211,7 @@ class DefaultPlaybackManager @Inject constructor(
         positionMs: Long,
     ) {
         if (songs.isEmpty()) return
-        originalQueue = null
+        shuffleOrder = null
         val mediaItems = songs.map { song ->
             val quality = resolveQualityForSong(serverId, song.id)
             song.toPlaybackRequestMediaItem(
@@ -210,6 +228,15 @@ class DefaultPlaybackManager @Inject constructor(
             val safeStartIndex = startIndex.coerceIn(mediaItems.indices)
             activeController.setMediaItems(mediaItems, safeStartIndex, positionMs)
             activeController.prepare()
+
+            // Restore shuffle state if previously saved
+            val saved = playbackPreferencesRepository.getShuffleState()
+            if (saved != null && mediaItems.size > 1) {
+                shuffleSeed = saved.first
+                shuffleAnchorIndex = saved.second.coerceIn(0, mediaItems.size - 1)
+                shuffleOrder = buildShuffleOrder(mediaItems.size, shuffleAnchorIndex, shuffleSeed)
+            }
+
             syncState(activeController)
         }
     }
@@ -219,7 +246,8 @@ class DefaultPlaybackManager @Inject constructor(
         startIndex: Int,
     ) {
         require(songs.isNotEmpty()) { "Playback queue cannot be empty." }
-        originalQueue = null
+        shuffleOrder = null
+        persistShuffleState()
         val mediaItems = songs.map(CachedSong::toCachedMediaItem)
 
         withController { activeController ->
@@ -295,41 +323,60 @@ class DefaultPlaybackManager @Inject constructor(
 
     override suspend fun skipToNext() {
         withController { activeController ->
-            val nextIndex = activeController.currentMediaItemIndex + 1
-            if (nextIndex < activeController.mediaItemCount) {
-                val nextItem = activeController.getMediaItemAt(nextIndex)
-                val request = nextItem.toPlaybackRequestOrNull()
-                if (request != null && !request.isCached) {
-                    val quality = resolveQualityForSong(request.serverId, request.songId)
-                    if (quality.maxBitRate != request.maxBitRate) {
-                        val rebuilt = request.copy(
-                            qualityLabel = quality.label,
-                            streamCacheKey = streamCacheRepository.buildCacheKey(request.serverId, request.songId, quality),
-                            maxBitRate = quality.maxBitRate,
-                            format = quality.format,
-                        ).let { updated ->
-                            MediaItem.Builder()
-                                .setMediaId(updated.songId)
-                                .setMediaMetadata(updated.toMediaMetadata())
-                                .setRequestMetadata(
-                                    MediaItem.RequestMetadata.Builder()
-                                        .setExtras(updated.toBundle())
-                                        .build(),
-                                )
-                                .build()
+            if (shuffleOrder != null) {
+                val currentVirtual = playerToVirtual(activeController.currentMediaItemIndex)
+                val nextVirtual = currentVirtual + 1
+                if (nextVirtual < activeController.mediaItemCount) {
+                    val nextPlayer = virtualToPlayer(nextVirtual)
+                    activeController.seekToDefaultPosition(nextPlayer)
+                    activeController.play()
+                }
+            } else {
+                val nextIndex = activeController.currentMediaItemIndex + 1
+                if (nextIndex < activeController.mediaItemCount) {
+                    val nextItem = activeController.getMediaItemAt(nextIndex)
+                    val request = nextItem.toPlaybackRequestOrNull()
+                    if (request != null && !request.isCached) {
+                        val quality = resolveQualityForSong(request.serverId, request.songId)
+                        if (quality.maxBitRate != request.maxBitRate) {
+                            val rebuilt = request.copy(
+                                qualityLabel = quality.label,
+                                streamCacheKey = streamCacheRepository.buildCacheKey(request.serverId, request.songId, quality),
+                                maxBitRate = quality.maxBitRate,
+                                format = quality.format,
+                            ).let { updated ->
+                                MediaItem.Builder()
+                                    .setMediaId(updated.songId)
+                                    .setMediaMetadata(updated.toMediaMetadata())
+                                    .setRequestMetadata(
+                                        MediaItem.RequestMetadata.Builder()
+                                            .setExtras(updated.toBundle())
+                                            .build(),
+                                    )
+                                    .build()
+                            }
+                            activeController.replaceMediaItem(nextIndex, rebuilt)
                         }
-                        activeController.replaceMediaItem(nextIndex, rebuilt)
                     }
                 }
+                activeController.seekToNext()
             }
-            activeController.seekToNext()
             syncState(activeController)
         }
     }
 
     override suspend fun skipToPrevious() {
         withController { activeController ->
-            activeController.seekToPrevious()
+            if (shuffleOrder != null) {
+                val currentVirtual = playerToVirtual(activeController.currentMediaItemIndex)
+                val prevVirtual = currentVirtual - 1
+                if (prevVirtual >= 0) {
+                    activeController.seekToDefaultPosition(virtualToPlayer(prevVirtual))
+                    activeController.play()
+                }
+            } else {
+                activeController.seekToPrevious()
+            }
             syncState(activeController)
         }
     }
@@ -352,48 +399,58 @@ class DefaultPlaybackManager @Inject constructor(
         }
     }
 
-    private var originalQueue: List<MediaItem>? = null
+    // Shuffle mapping: virtual index → player index. Null when shuffle is off.
+    private var shuffleOrder: List<Int>? = null
+    private var shuffleSeed: Long = 0L
+    private var shuffleAnchorIndex: Int = 0 // player index of the track that was playing when shuffle was toggled
+
+    private fun buildShuffleOrder(count: Int, anchorPlayerIndex: Int, seed: Long): List<Int> {
+        val rest = (0 until count).filter { it != anchorPlayerIndex }.shuffled(kotlin.random.Random(seed))
+        return listOf(anchorPlayerIndex) + rest
+    }
+
+    private fun persistShuffleState() {
+        scope.launch {
+            if (shuffleOrder != null) {
+                playbackPreferencesRepository.updateShuffleState(shuffleSeed, shuffleAnchorIndex)
+            } else {
+                playbackPreferencesRepository.clearShuffleState()
+            }
+        }
+    }
+
+    private fun virtualToPlayer(virtualIndex: Int): Int =
+        shuffleOrder?.getOrNull(virtualIndex) ?: virtualIndex
+
+    private fun playerToVirtual(playerIndex: Int): Int =
+        shuffleOrder?.indexOf(playerIndex)?.takeIf { it >= 0 } ?: playerIndex
 
     override suspend fun toggleShuffle() {
         withController { activeController ->
             val count = activeController.mediaItemCount
             if (count <= 1) return@withController
 
-            if (originalQueue == null) {
-                // Shuffle ON: save original order, shuffle remaining items
-                val currentIndex = activeController.currentMediaItemIndex
-                val items = (0 until count).map(activeController::getMediaItemAt)
-                originalQueue = items
-
-                val currentItem = items[currentIndex]
-                val rest = items.toMutableList().apply { removeAt(currentIndex) }.shuffled()
-                val shuffled = listOf(currentItem) + rest
-
-                activeController.clearMediaItems()
-                activeController.setMediaItems(shuffled, 0, activeController.currentPosition)
-                activeController.prepare()
+            if (shuffleOrder == null) {
+                // Shuffle ON
+                val currentPlayerIndex = activeController.currentMediaItemIndex
+                shuffleSeed = System.nanoTime()
+                shuffleAnchorIndex = currentPlayerIndex
+                shuffleOrder = buildShuffleOrder(count, currentPlayerIndex, shuffleSeed)
             } else {
-                // Shuffle OFF: restore original order
-                val currentMediaId = activeController.currentMediaItem?.mediaId
-                val position = activeController.currentPosition
-                val original = originalQueue!!
-                originalQueue = null
-
-                val restoredIndex = original.indexOfFirst { it.mediaId == currentMediaId }.coerceAtLeast(0)
-                activeController.clearMediaItems()
-                activeController.setMediaItems(original, restoredIndex, position)
-                activeController.prepare()
+                // Shuffle OFF
+                shuffleOrder = null
             }
 
-            mutablePlaybackState.update { it.copy(shuffleEnabled = originalQueue != null) }
+            persistShuffleState()
             syncState(activeController)
         }
     }
 
     override suspend fun skipToQueueItem(index: Int) {
         withController { activeController ->
-            if (index !in 0 until activeController.mediaItemCount) return@withController
-            activeController.seekToDefaultPosition(index)
+            val playerIndex = virtualToPlayer(index)
+            if (playerIndex !in 0 until activeController.mediaItemCount) return@withController
+            activeController.seekToDefaultPosition(playerIndex)
             activeController.play()
             syncState(activeController)
         }
@@ -401,8 +458,13 @@ class DefaultPlaybackManager @Inject constructor(
 
     override suspend fun removeQueueItem(index: Int) {
         withController { activeController ->
-            if (index !in 0 until activeController.mediaItemCount) return@withController
-            activeController.removeMediaItem(index)
+            val playerIndex = virtualToPlayer(index)
+            if (playerIndex !in 0 until activeController.mediaItemCount) return@withController
+            activeController.removeMediaItem(playerIndex)
+            // Update shuffle order: remove and adjust indices
+            shuffleOrder = shuffleOrder?.let { order ->
+                order.filter { it != playerIndex }.map { if (it > playerIndex) it - 1 else it }
+            }
             syncState(activeController)
         }
     }
@@ -456,9 +518,18 @@ class DefaultPlaybackManager @Inject constructor(
         val queue = (0 until player.mediaItemCount)
             .map(player::getMediaItemAt)
             .mapNotNull(MediaItem::toQueueItemOrNull)
-        val currentIndex = player.currentMediaItemIndex
+        val playerIndex = player.currentMediaItemIndex
             .takeUnless { it == C.INDEX_UNSET }
             ?: -1
+
+        // Expose queue in shuffled order if shuffle is active
+        val (displayQueue, displayIndex) = if (shuffleOrder != null && queue.isNotEmpty()) {
+            val shuffled = shuffleOrder!!.mapNotNull { queue.getOrNull(it) }
+            shuffled to playerToVirtual(playerIndex)
+        } else {
+            queue to playerIndex
+        }
+        lastVirtualIndex = displayIndex
 
         val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
         val streamCached = currentRequest != null && !currentRequest.isCached &&
@@ -469,9 +540,9 @@ class DefaultPlaybackManager @Inject constructor(
             state.copy(
                 isConnected = true,
                 isPlaying = player.isPlaying,
-                currentItem = queue.getOrNull(currentIndex),
-                currentIndex = currentIndex,
-                queue = queue,
+                currentItem = displayQueue.getOrNull(displayIndex),
+                currentIndex = displayIndex,
+                queue = displayQueue,
                 positionMs = player.currentPosition.coerceKnownTime(),
                 durationMs = player.duration.coerceKnownTime().takeIf { it > 0 }
                     ?: player.currentMediaItem?.metadataDurationMs()
@@ -479,7 +550,7 @@ class DefaultPlaybackManager @Inject constructor(
                 bufferedPositionMs = player.bufferedPosition.coerceKnownTime(),
                 isStreamCached = streamCached,
                 repeatMode = player.repeatMode.toRepeatModeSetting(),
-                shuffleEnabled = originalQueue != null,
+                shuffleEnabled = shuffleOrder != null,
                 runtimeInfo = player.currentAudioRuntimeInfoOrNull(),
             )
         }

--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -72,8 +72,14 @@ class DefaultPlaybackManager @Inject constructor(
 
             // Media3 auto-advanced in original order. Redirect to shuffled next.
             val nextVirtual = lastVirtualIndex + 1
-            if (nextVirtual < order.size) {
-                val targetPlayer = virtualToPlayer(nextVirtual)
+            val targetVirtual = when {
+                nextVirtual < order.size -> nextVirtual
+                ctrl.repeatMode == Player.REPEAT_MODE_ALL -> 0
+                ctrl.repeatMode == Player.REPEAT_MODE_ONE -> lastVirtualIndex
+                else -> null
+            }
+            if (targetVirtual != null) {
+                val targetPlayer = virtualToPlayer(targetVirtual)
                 if (ctrl.currentMediaItemIndex != targetPlayer) {
                     ctrl.seekToDefaultPosition(targetPlayer)
                 }
@@ -264,6 +270,7 @@ class DefaultPlaybackManager @Inject constructor(
         songs: List<Song>,
     ) {
         if (songs.isEmpty()) return
+        if (shuffleOrder != null) { shuffleOrder = null; persistShuffleState() }
         val mediaItems = songs.map { song ->
             val quality = resolveQualityForSong(serverId, song.id)
             song.toPlaybackRequestMediaItem(
@@ -286,6 +293,7 @@ class DefaultPlaybackManager @Inject constructor(
         serverId: Long,
         song: Song,
     ) {
+        if (shuffleOrder != null) { shuffleOrder = null; persistShuffleState() }
         val quality = resolveQualityForSong(serverId, song.id)
         val mediaItem = song.toPlaybackRequestMediaItem(
             serverId = serverId,
@@ -324,11 +332,17 @@ class DefaultPlaybackManager @Inject constructor(
     override suspend fun skipToNext() {
         withController { activeController ->
             if (shuffleOrder != null) {
+                val count = activeController.mediaItemCount
                 val currentVirtual = playerToVirtual(activeController.currentMediaItemIndex)
                 val nextVirtual = currentVirtual + 1
-                if (nextVirtual < activeController.mediaItemCount) {
-                    val nextPlayer = virtualToPlayer(nextVirtual)
-                    activeController.seekToDefaultPosition(nextPlayer)
+                val targetVirtual = when {
+                    nextVirtual < count -> nextVirtual
+                    activeController.repeatMode == Player.REPEAT_MODE_ALL -> 0
+                    activeController.repeatMode == Player.REPEAT_MODE_ONE -> currentVirtual
+                    else -> null
+                }
+                if (targetVirtual != null) {
+                    activeController.seekToDefaultPosition(virtualToPlayer(targetVirtual))
                     activeController.play()
                 }
             } else {
@@ -368,10 +382,17 @@ class DefaultPlaybackManager @Inject constructor(
     override suspend fun skipToPrevious() {
         withController { activeController ->
             if (shuffleOrder != null) {
+                val count = activeController.mediaItemCount
                 val currentVirtual = playerToVirtual(activeController.currentMediaItemIndex)
                 val prevVirtual = currentVirtual - 1
-                if (prevVirtual >= 0) {
-                    activeController.seekToDefaultPosition(virtualToPlayer(prevVirtual))
+                val targetVirtual = when {
+                    prevVirtual >= 0 -> prevVirtual
+                    activeController.repeatMode == Player.REPEAT_MODE_ALL -> count - 1
+                    activeController.repeatMode == Player.REPEAT_MODE_ONE -> currentVirtual
+                    else -> null
+                }
+                if (targetVirtual != null) {
+                    activeController.seekToDefaultPosition(virtualToPlayer(targetVirtual))
                     activeController.play()
                 }
             } else {
@@ -461,9 +482,9 @@ class DefaultPlaybackManager @Inject constructor(
             val playerIndex = virtualToPlayer(index)
             if (playerIndex !in 0 until activeController.mediaItemCount) return@withController
             activeController.removeMediaItem(playerIndex)
-            // Update shuffle order: remove and adjust indices
-            shuffleOrder = shuffleOrder?.let { order ->
-                order.filter { it != playerIndex }.map { if (it > playerIndex) it - 1 else it }
+            if (shuffleOrder != null) {
+                shuffleOrder = null
+                persistShuffleState()
             }
             syncState(activeController)
         }
@@ -523,6 +544,12 @@ class DefaultPlaybackManager @Inject constructor(
             ?: -1
 
         // Expose queue in shuffled order if shuffle is active
+        val order = shuffleOrder
+        if (order != null && order.size != queue.size) {
+            // Mapping is stale, clear it
+            shuffleOrder = null
+            persistShuffleState()
+        }
         val (displayQueue, displayIndex) = if (shuffleOrder != null && queue.isNotEmpty()) {
             val shuffled = shuffleOrder!!.mapNotNull { queue.getOrNull(it) }
             shuffled to playerToVirtual(playerIndex)

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -312,16 +312,26 @@ fun NowPlayingOverlay(
         }
 
         // Artwork pager state synced with playback queue
+        var stableQueue by remember { mutableStateOf(playbackState.queue) }
         val artworkPagerState = rememberPagerState(
             initialPage = playbackState.currentIndex.coerceAtLeast(0),
-            pageCount = { playbackState.queue.size.coerceAtLeast(1) },
+            pageCount = { stableQueue.size.coerceAtLeast(1) },
         )
         // Sync pager when track changes externally (button skip, queue tap)
-        LaunchedEffect(playbackState.currentIndex) {
-            val target = playbackState.currentIndex.coerceAtLeast(0)
-            if (artworkPagerState.currentPage != target) {
-                artworkPagerState.animateScrollToPage(target)
+        var lastTrackId by remember { mutableStateOf(track.songId) }
+        // Buffer queue to avoid pager flash during shuffle toggle:
+        // update queue snapshot only after pager has scrolled to correct page
+        val targetPage = playbackState.currentIndex.coerceAtLeast(0)
+        LaunchedEffect(targetPage, track.songId, playbackState.queue) {
+            if (track.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
+                // Same song, index changed (shuffle toggle) — scroll first, then update queue
+                artworkPagerState.scrollToPage(targetPage)
             }
+            stableQueue = playbackState.queue
+            if (track.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
+                artworkPagerState.animateScrollToPage(targetPage)
+            }
+            lastTrackId = track.songId
         }
         // When user swipes pager, trigger skip
         val currentPlaybackIndex by rememberUpdatedState(playbackState.currentIndex)
@@ -450,7 +460,7 @@ fun NowPlayingOverlay(
                                     modifier = Modifier.fillMaxWidth(),
                                     contentAlignment = Alignment.Center,
                                 ) {
-                                    val queueItem = playbackState.queue.getOrNull(page)
+                                    val queueItem = stableQueue.getOrNull(page)
                                     ArtworkCard(
                                         model = queueItem?.queueArtworkModel(),
                                         contentDescription = queueItem?.title,


### PR DESCRIPTION
## Summary

Replace Media3's built-in shuffle with virtual index mapping for consistent UX and zero audio interruption.

## Approach

**Player queue stays untouched.** We maintain a `shuffleOrder: List<Int>` mapping (virtual index → player index) and translate all queue operations through it.

### Shuffle ON
1. Generate random seed via `System.nanoTime()`
2. Build deterministic shuffle order: `[currentTrack] + rest.shuffled(Random(seed))`
3. Store seed + anchor index to DataStore (12 bytes total)

### Shuffle OFF
1. Clear `shuffleOrder`
2. Clear DataStore shuffle state

### Auto-advance handling
Media3 auto-advances in original queue order. `onMediaItemTransition(REASON_AUTO)` intercepts this and redirects to the correct shuffled next track using `lastVirtualIndex`.

### Pager flash prevention
Queue updates are buffered via `stableQueue` — pager scrolls to correct page first, then queue snapshot updates. This prevents the cover art from briefly showing the wrong track.

### Persistence
- Seed (`Long`) + anchor index (`Int`) stored in DataStore
- On `restoreQueue`, rebuild identical shuffle order from saved seed
- Cleared on new `playQueue` / `playCachedQueue`

## What's translated through the mapping
- `skipToNext` / `skipToPrevious`
- `skipToQueueItem` / `removeQueueItem`
- `syncState` (queue order + currentIndex exposed to UI)

## Result
- Zero audio interruption on shuffle toggle ✅
- Swipe direction matches shuffled order ✅
- Cover art animates correctly ✅
- Queue view shows shuffled order ✅
- Shuffle state survives app restart ✅

Closes #47