### PR TITLE
fix: non-blocking startup with first-reachable endpoint

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -104,8 +105,12 @@ class EndpointSelector @Inject constructor(
     /**
      * Probe endpoints: returns as soon as the first reachable endpoint is found.
      * Remaining probes continue in background to find the optimal endpoint.
+     * Cancels any previous in-flight probe for the same server.
      */
+    private val activeProbeJobs = ConcurrentHashMap<Long, Job>()
+
     suspend fun probe(serverId: Long, server: ServerConfig): ServerEndpoint? {
+        activeProbeJobs.remove(serverId)?.cancel()
         serverConfigs[serverId] = server
         val endpoints = server.endpoints
         if (endpoints.isEmpty()) return null
@@ -123,7 +128,10 @@ class EndpointSelector @Inject constructor(
         }
 
         val probeResults = ConcurrentHashMap<Long, Long>()
-        val firstReachable = kotlinx.coroutines.CompletableDeferred<ServerEndpoint?>()
+        // Initialize all endpoints as unreachable
+        lastProbeResults[serverId] = endpoints.map { EndpointProbeResult(it, null, false) }
+
+        val firstReachable = CompletableDeferred<ServerEndpoint?>()
 
         val jobs = endpoints.map { endpoint ->
             scope.launch {
@@ -134,34 +142,28 @@ class EndpointSelector @Inject constructor(
                     val currentBestLatency = currentBestId?.let { probeResults[it] }
                     if (currentBestLatency == null || latency < currentBestLatency) {
                         bestEndpoints[serverId] = endpoint.id
-                        _probeVersion.update { it + 1 }
                     }
-                    firstReachable.complete(endpoint)
                 }
+                // Update this endpoint's result incrementally
+                lastProbeResults[serverId] = endpoints.map { ep ->
+                    val lat = probeResults[ep.id]
+                    EndpointProbeResult(ep, lat, lat != null)
+                }
+                _probeVersion.update { it + 1 }
+                if (latency != null) firstReachable.complete(endpoint)
             }
         }
 
-        // Wait for first reachable or all probes to finish
-        scope.launch {
+        // Single background coroutine: wait for all jobs, then finalize
+        val parentJob = scope.launch {
             jobs.forEach { it.join() }
             firstReachable.complete(null) // all failed
-        }
-        val result = firstReachable.await()
-
-        // Update probe results with what we have so far; background jobs update the rest
-        scope.launch {
-            jobs.forEach { it.join() }
-            lastProbeResults[serverId] = endpoints.map { ep ->
-                val lat = probeResults[ep.id]
-                EndpointProbeResult(ep, lat, lat != null)
-            }
-            if (probeResults.isEmpty()) {
-                bestEndpoints.remove(serverId)
-            }
+            if (probeResults.isEmpty()) bestEndpoints.remove(serverId)
             _probeVersion.update { it + 1 }
         }
+        activeProbeJobs[serverId] = parentJob
 
-        return result
+        return firstReachable.await()
     }
 
     fun sortedEndpoints(serverId: Long, endpoints: List<ServerEndpoint>): List<ServerEndpoint> {

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -15,10 +15,10 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -101,6 +101,10 @@ class EndpointSelector @Inject constructor(
         }
     }
 
+    /**
+     * Probe endpoints: returns as soon as the first reachable endpoint is found.
+     * Remaining probes continue in background to find the optimal endpoint.
+     */
     suspend fun probe(serverId: Long, server: ServerConfig): ServerEndpoint? {
         serverConfigs[serverId] = server
         val endpoints = server.endpoints
@@ -119,32 +123,45 @@ class EndpointSelector @Inject constructor(
         }
 
         val probeResults = ConcurrentHashMap<Long, Long>()
-        kotlinx.coroutines.coroutineScope {
-            endpoints.map { endpoint ->
-                async {
-                    val latency = pingEndpoint(endpoint, server)
-                    if (latency != null) {
-                        probeResults[endpoint.id] = latency
-                        val currentBestId = bestEndpoints[serverId]
-                        val currentBestLatency = currentBestId?.let { probeResults[it] }
-                        if (currentBestLatency == null || latency < currentBestLatency) {
-                            bestEndpoints[serverId] = endpoint.id
-                            _probeVersion.update { it + 1 }
-                        }
+        val firstReachable = kotlinx.coroutines.CompletableDeferred<ServerEndpoint?>()
+
+        val jobs = endpoints.map { endpoint ->
+            scope.launch {
+                val latency = pingEndpoint(endpoint, server)
+                if (latency != null) {
+                    probeResults[endpoint.id] = latency
+                    val currentBestId = bestEndpoints[serverId]
+                    val currentBestLatency = currentBestId?.let { probeResults[it] }
+                    if (currentBestLatency == null || latency < currentBestLatency) {
+                        bestEndpoints[serverId] = endpoint.id
+                        _probeVersion.update { it + 1 }
                     }
+                    firstReachable.complete(endpoint)
                 }
-            }.forEach { it.await() }
+            }
         }
 
-        lastProbeResults[serverId] = endpoints.map { ep ->
-            val lat = probeResults[ep.id]
-            EndpointProbeResult(ep, lat, lat != null)
+        // Wait for first reachable or all probes to finish
+        scope.launch {
+            jobs.forEach { it.join() }
+            firstReachable.complete(null) // all failed
         }
-        if (probeResults.isEmpty()) {
-            bestEndpoints.remove(serverId)
+        val result = firstReachable.await()
+
+        // Update probe results with what we have so far; background jobs update the rest
+        scope.launch {
+            jobs.forEach { it.join() }
+            lastProbeResults[serverId] = endpoints.map { ep ->
+                val lat = probeResults[ep.id]
+                EndpointProbeResult(ep, lat, lat != null)
+            }
+            if (probeResults.isEmpty()) {
+                bestEndpoints.remove(serverId)
+            }
+            _probeVersion.update { it + 1 }
         }
-        _probeVersion.update { it + 1 }
-        return endpoints.find { it.id == bestEndpoints[serverId] }
+
+        return result
     }
 
     fun sortedEndpoints(serverId: Long, endpoints: List<ServerEndpoint>): List<ServerEndpoint> {

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -740,15 +740,17 @@ class SakiAppViewModel @Inject constructor(
         }
 
         if (selectedServerId != null && (serverChanged || lastLoadedServerId != selectedServerId)) {
-            loadServerContent(selectedServerId, forceRefresh = serverChanged)
-            servers.find { it.id == selectedServerId }?.let { server ->
-                viewModelScope.launch {
+            // Show cached content immediately, then probe + network refresh
+            loadCachedContent(selectedServerId)
+            viewModelScope.launch {
+                servers.find { it.id == selectedServerId }?.let { server ->
                     endpointSelector.probe(selectedServerId, server)
                     refreshEndpointStatus()
                 }
-            }
-            if (uiState.value.playbackState.currentItem == null) {
-                restorePlayQueue(selectedServerId)
+                if (uiState.value.playbackState.currentItem == null) {
+                    restorePlayQueue(selectedServerId)
+                }
+                refreshServerContent(selectedServerId, forceRefresh = serverChanged)
             }
         }
     }
@@ -798,6 +800,32 @@ class SakiAppViewModel @Inject constructor(
                 if (e is CancellationException) throw e
             }
         }
+    }
+
+    private fun loadCachedContent(serverId: Long) {
+        lastLoadedServerId = serverId
+        viewModelScope.launch {
+            val artists = runCatching { libraryCacheRepository.getArtists(serverId) }.getOrNull()
+            if (artists != null && uiState.value.selectedServerId == serverId) {
+                mutableUiState.update { it.copy(libraryIndexes = artists) }
+            }
+            val albums = runCatching { libraryCacheRepository.getAlbums(serverId, uiState.value.selectedAlbumFeed) }.getOrNull()
+            if (!albums.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
+                mutableUiState.update { it.copy(albums = albums) }
+            }
+            val playlists = runCatching { libraryCacheRepository.getPlaylists(serverId) }.getOrNull()
+            if (!playlists.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
+                mutableUiState.update { it.copy(playlists = playlists) }
+            }
+            val songs = runCatching { libraryCacheRepository.getSongs(serverId) }.getOrNull()
+            if (!songs.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
+                mutableUiState.update { it.copy(songs = songs) }
+            }
+        }
+    }
+
+    private fun refreshServerContent(serverId: Long, forceRefresh: Boolean = false) {
+        loadServerContent(serverId, forceRefresh)
     }
 
     private fun loadServerContent(

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -747,10 +747,12 @@ class SakiAppViewModel @Inject constructor(
                     endpointSelector.probe(selectedServerId, server)
                     refreshEndpointStatus()
                 }
-                if (uiState.value.playbackState.currentItem == null) {
-                    restorePlayQueue(selectedServerId)
+                if (endpointSelector.getActiveEndpointId(selectedServerId) != null) {
+                    if (uiState.value.playbackState.currentItem == null) {
+                        restorePlayQueue(selectedServerId)
+                    }
+                    refreshServerContent(selectedServerId, forceRefresh = serverChanged)
                 }
-                refreshServerContent(selectedServerId, forceRefresh = serverChanged)
             }
         }
     }
@@ -805,19 +807,29 @@ class SakiAppViewModel @Inject constructor(
     private fun loadCachedContent(serverId: Long) {
         lastLoadedServerId = serverId
         viewModelScope.launch {
-            val artists = runCatching { libraryCacheRepository.getArtists(serverId) }.getOrNull()
+            suspend fun <T> loadCachedOrNull(block: suspend () -> T): T? = try {
+                block()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                null
+            }
+
+            val artists = loadCachedOrNull { libraryCacheRepository.getArtists(serverId) }
             if (artists != null && uiState.value.selectedServerId == serverId) {
                 mutableUiState.update { it.copy(libraryIndexes = artists) }
             }
-            val albums = runCatching { libraryCacheRepository.getAlbums(serverId, uiState.value.selectedAlbumFeed) }.getOrNull()
-            if (!albums.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
+            val selectedAlbumFeed = uiState.value.selectedAlbumFeed
+            val albums = loadCachedOrNull { libraryCacheRepository.getAlbums(serverId, selectedAlbumFeed) }
+            if (!albums.isNullOrEmpty() && uiState.value.selectedServerId == serverId &&
+                uiState.value.selectedAlbumFeed == selectedAlbumFeed) {
                 mutableUiState.update { it.copy(albums = albums) }
             }
-            val playlists = runCatching { libraryCacheRepository.getPlaylists(serverId) }.getOrNull()
+            val playlists = loadCachedOrNull { libraryCacheRepository.getPlaylists(serverId) }
             if (!playlists.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
                 mutableUiState.update { it.copy(playlists = playlists) }
             }
-            val songs = runCatching { libraryCacheRepository.getSongs(serverId) }.getOrNull()
+            val songs = loadCachedOrNull { libraryCacheRepository.getSongs(serverId) }
             if (!songs.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
                 mutableUiState.update { it.copy(songs = songs) }
             }


### PR DESCRIPTION
Closes #61

## Problem

Startup blocks for a long time because:
1. `probe()` waits for **all** endpoints to finish (including unreachable ones timing out at 1.5s each)
2. `restorePlayQueue` fires network requests without waiting for probe, hitting unreachable endpoints with 10s connect timeout
3. `loadServerContent` network requests also don't benefit from probe results

## Fix

### `probe()` — first-reachable-wins
- Returns as soon as the **first reachable endpoint** is found
- Remaining probes continue in background via `scope.launch` to find the optimal endpoint
- `probeVersion` updates incrementally so `sortedEndpoints` improves over time

### Startup sequence
1. **`loadCachedContent`** — immediately populates UI from `LibraryCacheRepository` (artists, albums, playlists, songs)
2. **`probe()`** — returns quickly once any endpoint responds
3. **`restorePlayQueue`** — now runs after probe, uses best known endpoint
4. **`refreshServerContent`** — network refresh with optimal endpoint order

### Network change reprobe
`onNetworkChanged` already calls `probe()` with exponential backoff delays (0s, 3s, 6s, 12s). The new `probe()` behavior means each round returns faster too.