### PR TITLE
fix: replace bufferedPosition heuristic with findCachedQualityKey

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -560,8 +560,9 @@ class DefaultPlaybackManager @Inject constructor(
 
         val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
         val streamCached = currentRequest != null && !currentRequest.isCached &&
-            player.bufferedPosition.coerceKnownTime() >= (player.duration.coerceKnownTime() - 1000L) &&
-            player.duration.coerceKnownTime() > 0L
+            streamCacheRepository.findCachedQualityKey(
+                currentRequest.serverId, currentRequest.songId, effectiveQuality(),
+            ) != null
 
         mutablePlaybackState.update { state ->
             state.copy(

--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -89,6 +89,7 @@ class DefaultPlaybackManager @Inject constructor(
 
     private var controller: MediaController? = null
     private val mutablePlaybackState = MutableStateFlow(PlaybackSessionState())
+    @Volatile private var cacheReady = false
 
     override val playbackState: StateFlow<PlaybackSessionState> = mutablePlaybackState.asStateFlow()
 
@@ -140,6 +141,9 @@ class DefaultPlaybackManager @Inject constructor(
     }
 
     init {
+        scope.launch {
+            streamCacheRepository.observeCacheVersion().collect { if (it > 0L) cacheReady = true }
+        }
         scope.launch {
             playbackPreferencesRepository.observePreferences().collect { preferences ->
                 mutablePlaybackState.update { state ->
@@ -560,6 +564,7 @@ class DefaultPlaybackManager @Inject constructor(
 
         val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
         val streamCached = currentRequest != null && !currentRequest.isCached &&
+            cacheReady &&
             streamCacheRepository.findCachedQualityKey(
                 currentRequest.serverId, currentRequest.songId, effectiveQuality(),
             ) != null


### PR DESCRIPTION
Closes #63

## Problem

`isStreamCached` used `bufferedPosition >= duration - 1000` which gave false positives when seeking near end of track, and flipped back to "Streaming" when seeking backward.

## Fix

Replace the `bufferedPosition` heuristic with `findCachedQualityKey` — the same real cache completeness check used by the song list. This ensures Now Playing and song list agree on cached status.