### PR TITLE
fix: catch JSONException in connection test when server returns HTML

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/data/remote/SubsonicConnectionTester.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/SubsonicConnectionTester.kt
@@ -101,8 +101,11 @@ class SubsonicConnectionTester @Inject constructor(
                         endpointUrl = endpointUrl,
                         message = "The server returned an empty response.",
                     )
-                val subsonicResponse = JSONObject(body).optJSONObject("subsonic-response")
-                    ?: return@withContext ConnectionTestResult.Failure(
+                val subsonicResponse = try {
+                    JSONObject(body).optJSONObject("subsonic-response")
+                } catch (_: org.json.JSONException) {
+                    null
+                } ?: return@withContext ConnectionTestResult.Failure(
                         endpointUrl = endpointUrl,
                         message = "Unexpected response from the server.",
                     )


### PR DESCRIPTION
Closes #70

## Problem

`SubsonicConnectionTester.testConnection()` crashes with `JSONException` when the server returns HTML (reverse proxy login page, web UI, etc.) instead of JSON.

## Fix

Wrap `JSONObject(body)` in try-catch for `JSONException`, fall through to "Unexpected response" failure result.