### PR TITLE
fix: suppress pager-driven skips after programmatic scroll

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -328,16 +328,19 @@ fun NowPlayingOverlay(
         )
         // Sync pager when track changes externally (button skip, queue tap)
         var lastTrackId by remember { mutableStateOf(track.songId) }
+        // Guard: suppress pager-driven skips after programmatic scroll
+        var pagerSkipSuppressedUntil by remember { mutableStateOf(0L) }
         // Buffer queue to avoid pager flash during shuffle toggle:
         // update queue snapshot only after pager has scrolled to correct page
         val targetPage = playbackState.currentIndex.coerceAtLeast(0)
         LaunchedEffect(targetPage, track.songId, playbackState.queue) {
             if (track.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
-                // Same song, index changed (shuffle toggle) — scroll first, then update queue
+                pagerSkipSuppressedUntil = withFrameNanos { it } + 500_000_000L
                 artworkPagerState.scrollToPage(targetPage)
             }
             stableQueue = playbackState.queue
             if (track.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
+                pagerSkipSuppressedUntil = withFrameNanos { it } + 500_000_000L
                 artworkPagerState.animateScrollToPage(targetPage)
             }
             lastTrackId = track.songId
@@ -349,6 +352,8 @@ fun NowPlayingOverlay(
             snapshotFlow { artworkPagerState.settledPage }
                 .distinctUntilChanged()
                 .collect { page ->
+                    val now = withFrameNanos { it }
+                    if (now < pagerSkipSuppressedUntil) return@collect
                     if (page != currentPlaybackIndex && page in 0 until currentQueueSize) {
                         onSkipToQueueItem(page)
                     }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -328,20 +328,20 @@ fun NowPlayingOverlay(
         )
         // Sync pager when track changes externally (button skip, queue tap)
         var lastTrackId by remember { mutableStateOf(track.songId) }
-        // Guard: suppress pager-driven skips after programmatic scroll
-        var pagerSkipSuppressedUntil by remember { mutableStateOf(0L) }
+        // Guard: suppress pager-driven skips during programmatic scroll
+        var suppressPagerSkip by remember { mutableStateOf(false) }
         // Buffer queue to avoid pager flash during shuffle toggle:
         // update queue snapshot only after pager has scrolled to correct page
         val targetPage = playbackState.currentIndex.coerceAtLeast(0)
         LaunchedEffect(targetPage, track.songId, playbackState.queue) {
             if (track.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
-                pagerSkipSuppressedUntil = withFrameNanos { it } + 500_000_000L
-                artworkPagerState.scrollToPage(targetPage)
+                suppressPagerSkip = true
+                try { artworkPagerState.scrollToPage(targetPage) } finally { suppressPagerSkip = false }
             }
             stableQueue = playbackState.queue
             if (track.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
-                pagerSkipSuppressedUntil = withFrameNanos { it } + 500_000_000L
-                artworkPagerState.animateScrollToPage(targetPage)
+                suppressPagerSkip = true
+                try { artworkPagerState.animateScrollToPage(targetPage) } finally { suppressPagerSkip = false }
             }
             lastTrackId = track.songId
         }
@@ -352,8 +352,7 @@ fun NowPlayingOverlay(
             snapshotFlow { artworkPagerState.settledPage }
                 .distinctUntilChanged()
                 .collect { page ->
-                    val now = withFrameNanos { it }
-                    if (now < pagerSkipSuppressedUntil) return@collect
+                    if (suppressPagerSkip) return@collect
                     if (page != currentPlaybackIndex && page in 0 until currentQueueSize) {
                         onSkipToQueueItem(page)
                     }


### PR DESCRIPTION
Closes #72

## Problem

Tapping a song in the Queue causes playback to ping-pong between two adjacent tracks. The artwork pager's `settledPage` lags behind `animateScrollToPage`, firing `skipToQueueItem` with the stale page index, creating an infinite loop.

## Fix

Add a 500ms suppression window after programmatic pager scrolls. During this window, `settledPage` changes are ignored, so only user-initiated swipes trigger track skips.