### PR TITLE
fix: resolve cover art URL at render time instead of queue build time

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -341,6 +341,7 @@ private fun RootShell(
             onSkipToQueueItem = onSkipToQueueItem,
             onRemoveQueueItem = onRemoveQueueItem,
             currentServer = uiState.servers.firstOrNull { it.id == track.serverId },
+            servers = uiState.servers,
             activeEndpointLabel = endpointStatus.activeEndpointLabel,
             activeEndpointId = endpointStatus.activeEndpointId,
             endpointProbeResults = endpointStatus.probeResults,

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -295,6 +295,9 @@ private fun RootShell(
                 NowPlayingCapsule(
                     track = currentOrQueuedTrack,
                     isPlaying = uiState.playbackState.isPlaying,
+                    currentServer = currentOrQueuedTrack?.serverId?.let { sid ->
+                        uiState.servers.firstOrNull { it.id == sid }
+                    },
                     onExpand = onOpenNowPlaying,
                     onPlayPause = {
                         if (uiState.playbackState.isPlaying) onPausePlayback() else onResumePlayback()

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -229,6 +229,7 @@ fun NowPlayingOverlay(
     onSkipToQueueItem: (Int) -> Unit,
     onRemoveQueueItem: (Int) -> Unit,
     currentServer: ServerConfig?,
+    servers: List<ServerConfig> = emptyList(),
     activeEndpointLabel: String? = null,
     activeEndpointId: Long? = null,
     endpointProbeResults: List<EndpointProbeInfo> = emptyList(),
@@ -236,6 +237,7 @@ fun NowPlayingOverlay(
     onReprobeEndpoints: () -> Unit = {},
     lyrics: SongLyrics? = null,
 ) {
+    val serversById = remember(servers) { servers.associateBy { it.id } }
     val artwork = rememberArtworkPresentation(
         fallbackModel = track.queueArtworkModel(currentServer),
     )
@@ -250,13 +252,15 @@ fun NowPlayingOverlay(
     val currentIdx = playbackState.currentIndex
     val prevSongId = queue.getOrNull(currentIdx - 1)?.songId
     val nextSongId = queue.getOrNull(currentIdx + 1)?.songId
-    LaunchedEffect(track.songId, prevSongId, nextSongId) {
+    LaunchedEffect(track.songId, prevSongId, nextSongId, currentServer) {
         val adjacentIndices = listOfNotNull(
             if (currentIdx > 0) currentIdx - 1 else null,
             if (currentIdx < queue.lastIndex) currentIdx + 1 else null,
         )
         for (i in adjacentIndices) {
-            val model = queue[i].queueArtworkModel(currentServer) ?: continue
+            val item = queue[i]
+            val server = item.serverId?.let { serversById[it] }
+            val model = item.queueArtworkModel(server) ?: continue
             val request = ImageRequest.Builder(context)
                 .data(model)
                 .size(coil3.size.Size.ORIGINAL)
@@ -475,7 +479,7 @@ fun NowPlayingOverlay(
                             ) {
                                 val queueItem = stableQueue.getOrNull(page)
                                 ArtworkCard(
-                                    model = queueItem?.queueArtworkModel(currentServer),
+                                    model = queueItem?.queueArtworkModel(queueItem.serverId?.let { serversById[it] }),
                                     contentDescription = queueItem?.title,
                                     modifier = Modifier.size(artworkSize),
                                     cornerRadiusDp = 34,
@@ -728,7 +732,7 @@ fun NowPlayingOverlay(
                             QueueRow(
                                 item = item,
                                 isCurrent = index == playbackState.currentIndex,
-                                currentServer = currentServer,
+                                currentServer = item.serverId?.let { serversById[it] },
                                 onClick = { onSkipToQueueItem(index) },
                                 onRemove = { onRemoveQueueItem(index) },
                             )
@@ -1016,7 +1020,9 @@ private fun DetailLine(label: String, value: String?) {
 private fun PlaybackQueueItem.queueArtworkModel(server: ServerConfig?): Any? {
     return when {
         !coverArtPath.isNullOrBlank() -> File(coverArtPath)
-        else -> resolveArtworkModel(server, coverArtId, null)
+        server != null -> resolveArtworkModel(server, coverArtId, null)
+        !artworkUri.isNullOrBlank() -> artworkUri
+        else -> null
     }
 }
 

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -129,6 +129,7 @@ import kotlinx.coroutines.withContext
 fun NowPlayingCapsule(
     track: PlaybackQueueItem?,
     isPlaying: Boolean,
+    currentServer: ServerConfig?,
     onExpand: () -> Unit,
     onPlayPause: () -> Unit,
     onSkipToPrevious: () -> Unit,
@@ -163,7 +164,7 @@ fun NowPlayingCapsule(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             AnimatedContent(
-                targetState = Pair(track?.queueArtworkModel(), track?.title),
+                targetState = Pair(track?.queueArtworkModel(currentServer), track?.title),
                 transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(300)) },
                 label = "capsule-artwork",
             ) { (model, title) ->
@@ -236,7 +237,7 @@ fun NowPlayingOverlay(
     lyrics: SongLyrics? = null,
 ) {
     val artwork = rememberArtworkPresentation(
-        fallbackModel = track.queueArtworkModel(),
+        fallbackModel = track.queueArtworkModel(currentServer),
     )
     var showDetails by remember(track.songId) { mutableStateOf(false) }
     var showMenu by remember(track.songId) { mutableStateOf(false) }
@@ -255,7 +256,7 @@ fun NowPlayingOverlay(
             if (currentIdx < queue.lastIndex) currentIdx + 1 else null,
         )
         for (i in adjacentIndices) {
-            val model = queue[i].queueArtworkModel() ?: continue
+            val model = queue[i].queueArtworkModel(currentServer) ?: continue
             val request = ImageRequest.Builder(context)
                 .data(model)
                 .size(coil3.size.Size.ORIGINAL)
@@ -474,7 +475,7 @@ fun NowPlayingOverlay(
                             ) {
                                 val queueItem = stableQueue.getOrNull(page)
                                 ArtworkCard(
-                                    model = queueItem?.queueArtworkModel(),
+                                    model = queueItem?.queueArtworkModel(currentServer),
                                     contentDescription = queueItem?.title,
                                     modifier = Modifier.size(artworkSize),
                                     cornerRadiusDp = 34,
@@ -727,6 +728,7 @@ fun NowPlayingOverlay(
                             QueueRow(
                                 item = item,
                                 isCurrent = index == playbackState.currentIndex,
+                                currentServer = currentServer,
                                 onClick = { onSkipToQueueItem(index) },
                                 onRemove = { onRemoveQueueItem(index) },
                             )
@@ -948,6 +950,7 @@ private fun MetadataLinkRow(
 private fun QueueRow(
     item: PlaybackQueueItem,
     isCurrent: Boolean,
+    currentServer: ServerConfig?,
     onClick: () -> Unit,
     onRemove: () -> Unit,
 ) {
@@ -968,7 +971,7 @@ private fun QueueRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             ArtworkCard(
-                model = item.queueArtworkModel(),
+                model = item.queueArtworkModel(currentServer),
                 contentDescription = item.title,
                 modifier = Modifier.size(48.dp),
                 cornerRadiusDp = 16,
@@ -1010,11 +1013,10 @@ private fun DetailLine(label: String, value: String?) {
     )
 }
 
-private fun PlaybackQueueItem.queueArtworkModel(): Any? {
+private fun PlaybackQueueItem.queueArtworkModel(server: ServerConfig?): Any? {
     return when {
         !coverArtPath.isNullOrBlank() -> File(coverArtPath)
-        !artworkUri.isNullOrBlank() -> artworkUri
-        else -> null
+        else -> resolveArtworkModel(server, coverArtId, null)
     }
 }
 


### PR DESCRIPTION
Closes #62

## Problem

Cover art in Now Playing fails to load when the pre-built `artworkUri` points to an unreachable endpoint. The URL was baked into `PlaybackQueueItem` at queue build time using `candidates.firstOrNull()?.url`, which could pick an endpoint that hasn't been probed yet or has become unreachable.

## Fix

Replace pre-built `artworkUri` with render-time resolution via `resolveArtworkModel(server, coverArtId, null)`. This uses the current `ServerConfig` to build the cover art URL on each render, matching the pattern already used by song list artwork.

Changes:
- `queueArtworkModel()` now takes `ServerConfig?` and delegates to `resolveArtworkModel`
- Added `currentServer` param to `NowPlayingCapsule` and `QueueRow`
- All 5 call sites updated