### PR TITLE
fix: remove serial buildArtworkUri calls from queue build

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -23,7 +23,6 @@ import com.anzupop.saki.android.domain.model.StreamQuality
 import com.anzupop.saki.android.domain.repository.PlaybackManager
 import com.anzupop.saki.android.domain.repository.PlaybackPreferencesRepository
 import com.anzupop.saki.android.domain.repository.StreamCacheRepository
-import com.anzupop.saki.android.domain.repository.SubsonicRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
@@ -53,7 +52,6 @@ class DefaultPlaybackManager @Inject constructor(
     @param:MainDispatcher private val mainDispatcher: CoroutineDispatcher,
     private val playbackPreferencesRepository: PlaybackPreferencesRepository,
     private val streamCacheRepository: StreamCacheRepository,
-    private val subsonicRepository: SubsonicRepository,
     private val networkTypeProvider: NetworkTypeProvider,
 ) : PlaybackManager {
     private val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
@@ -199,7 +197,7 @@ class DefaultPlaybackManager @Inject constructor(
                 serverId = serverId,
                 qualityLabel = quality.label,
                 streamCacheKey = streamCacheRepository.buildCacheKey(serverId, song.id, quality),
-                artworkUri = buildArtworkUri(serverId, song.coverArtId),
+                artworkUri = null,
                 maxBitRate = quality.maxBitRate,
                 format = quality.format,
             )
@@ -228,7 +226,7 @@ class DefaultPlaybackManager @Inject constructor(
                 serverId = serverId,
                 qualityLabel = quality.label,
                 streamCacheKey = streamCacheRepository.buildCacheKey(serverId, song.id, quality),
-                artworkUri = buildArtworkUri(serverId, song.coverArtId),
+                artworkUri = null,
                 maxBitRate = quality.maxBitRate,
                 format = quality.format,
             )
@@ -281,7 +279,7 @@ class DefaultPlaybackManager @Inject constructor(
                 serverId = serverId,
                 qualityLabel = quality.label,
                 streamCacheKey = streamCacheRepository.buildCacheKey(serverId, song.id, quality),
-                artworkUri = buildArtworkUri(serverId, song.coverArtId),
+                artworkUri = null,
                 maxBitRate = quality.maxBitRate,
                 format = quality.format,
             )
@@ -303,7 +301,7 @@ class DefaultPlaybackManager @Inject constructor(
             serverId = serverId,
             qualityLabel = quality.label,
             streamCacheKey = streamCacheRepository.buildCacheKey(serverId, song.id, quality),
-            artworkUri = buildArtworkUri(serverId, song.coverArtId),
+            artworkUri = null,
             maxBitRate = quality.maxBitRate,
             format = quality.format,
         )
@@ -492,20 +490,6 @@ class DefaultPlaybackManager @Inject constructor(
             }
             syncState(activeController)
         }
-    }
-
-    private suspend fun buildArtworkUri(
-        serverId: Long,
-        coverArtId: String?,
-    ): String? {
-        if (coverArtId.isNullOrBlank()) return null
-        return runCatching {
-            subsonicRepository.buildCoverArtRequest(
-                serverId = serverId,
-                coverArtId = coverArtId,
-                size = 720,
-            ).candidates.firstOrNull()?.url
-        }.getOrNull()
     }
 
     private suspend fun <T> withController(

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -316,15 +316,28 @@ class SakiPlaybackService : MediaSessionService() {
                 format = format,
             )
 
-            val finalRequest = if (effectiveQuality != null && effectiveQuality.maxBitRate != request.maxBitRate) {
-                request.copy(
+            // Resolve artwork URL if missing (queue was built without it for performance)
+            val resolvedArtworkUri = request.artworkUri ?: request.coverArtId?.let { coverArtId ->
+                runCatching {
+                    subsonicRepository.buildCoverArtRequest(request.serverId, coverArtId, 720)
+                        .candidates.firstOrNull()?.url
+                }.getOrNull()
+            }
+            val artworkRequest = if (resolvedArtworkUri != null && request.artworkUri == null) {
+                request.copy(artworkUri = resolvedArtworkUri)
+            } else {
+                request
+            }
+
+            val finalRequest = if (effectiveQuality != null && effectiveQuality.maxBitRate != artworkRequest.maxBitRate) {
+                artworkRequest.copy(
                     qualityLabel = effectiveQuality.label,
                     maxBitRate = effectiveQuality.maxBitRate,
                     format = effectiveQuality.format,
-                    streamCacheKey = streamCacheRepository.buildCacheKey(request.serverId, request.songId, effectiveQuality),
+                    streamCacheKey = streamCacheRepository.buildCacheKey(artworkRequest.serverId, artworkRequest.songId, effectiveQuality),
                 )
             } else {
-                request
+                artworkRequest
             }
 
             return finalRequest.toPlayableMediaItem(streamRequest)


### PR DESCRIPTION
Closes #75

## Problem

Playing from song list / album / playlist has noticeable lag. `playQueue()` calls `buildArtworkUri()` serially for every song — each call does a DB query + endpoint sorting. With 300+ songs this blocks playback start.

## Fix

Remove `buildArtworkUri` calls entirely — cover art URLs are now resolved at render time (PR #74). Also removes the now-unused `SubsonicRepository` dependency from `DefaultPlaybackManager`.