### PR TITLE
feat: pre-buffer 10s of adjacent queue tracks

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -105,6 +105,8 @@ class SakiPlaybackService : MediaSessionService() {
             .setWakeMode(C.WAKE_MODE_NETWORK)
             .build()
             .apply {
+                preloadConfiguration =
+                    ExoPlayer.PreloadConfiguration(/* targetPreloadDurationUs = */ 10_000_000L)
                 addListener(PlaybackRecoveryListener())
                 addListener(PlayQueueSaveListener())
             }

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -106,7 +106,7 @@ class SakiPlaybackService : MediaSessionService() {
             .build()
             .apply {
                 preloadConfiguration =
-                    ExoPlayer.PreloadConfiguration(/* targetPreloadDurationUs = */ 10_000_000L)
+                    ExoPlayer.PreloadConfiguration(10 * C.MICROS_PER_SECOND)
                 addListener(PlaybackRecoveryListener())
                 addListener(PlayQueueSaveListener())
             }


### PR DESCRIPTION
Closes #15

## Change

Enable Media3's `PreloadConfiguration` to pre-buffer 10 seconds of adjacent playlist items. This allows next/previous track skips to start playback instantly without waiting for the stream to connect and buffer.

One line: `preloadConfiguration = ExoPlayer.PreloadConfiguration(10_000_000L)`

10 seconds balances responsiveness with bandwidth — enough for instant skip starts without aggressively downloading full tracks.