### PR TITLE
feat: manual endpoint selection in Now Playing status dialog

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -44,6 +44,7 @@ class EndpointSelector @Inject constructor(
     private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
     private val bestEndpoints = ConcurrentHashMap<Long, Long>()
+    private val forcedEndpoints = ConcurrentHashMap<Long, Long>()
     private val lastProbeResults = ConcurrentHashMap<Long, List<EndpointProbeResult>>()
     private val serverConfigs = ConcurrentHashMap<Long, ServerConfig>()
 
@@ -86,12 +87,14 @@ class EndpointSelector @Inject constructor(
     fun unregisterServer(serverId: Long) {
         serverConfigs.remove(serverId)
         bestEndpoints.remove(serverId)
+        forcedEndpoints.remove(serverId)
         lastProbeResults.remove(serverId)
     }
 
     private var reprobeJob: kotlinx.coroutines.Job? = null
 
     private fun onNetworkChanged() {
+        forcedEndpoints.clear()
         reprobeJob?.cancel()
         reprobeJob = scope.launch {
             val delays = longArrayOf(0, 3_000, 6_000, 12_000)
@@ -118,10 +121,12 @@ class EndpointSelector @Inject constructor(
             val ep = endpoints.first()
             val latency = pingEndpoint(ep, server)
             lastProbeResults[serverId] = listOf(EndpointProbeResult(ep, latency, latency != null))
-            if (latency != null) {
-                bestEndpoints[serverId] = ep.id
-            } else {
-                bestEndpoints.remove(serverId)
+            if (forcedEndpoints[serverId] == null) {
+                if (latency != null) {
+                    bestEndpoints[serverId] = ep.id
+                } else {
+                    bestEndpoints.remove(serverId)
+                }
             }
             _probeVersion.update { it + 1 }
             return if (latency != null) ep else null
@@ -138,10 +143,12 @@ class EndpointSelector @Inject constructor(
                 val latency = pingEndpoint(endpoint, server)
                 if (latency != null) {
                     probeResults[endpoint.id] = latency
-                    val currentBestId = bestEndpoints[serverId]
-                    val currentBestLatency = currentBestId?.let { probeResults[it] }
-                    if (currentBestLatency == null || latency < currentBestLatency) {
-                        bestEndpoints[serverId] = endpoint.id
+                    if (forcedEndpoints[serverId] == null) {
+                        val currentBestId = bestEndpoints[serverId]
+                        val currentBestLatency = currentBestId?.let { probeResults[it] }
+                        if (currentBestLatency == null || latency < currentBestLatency) {
+                            bestEndpoints[serverId] = endpoint.id
+                        }
                     }
                 }
                 // Update this endpoint's result incrementally
@@ -158,7 +165,9 @@ class EndpointSelector @Inject constructor(
         val parentJob = scope.launch {
             jobs.forEach { it.join() }
             firstReachable.complete(null) // all failed
-            if (probeResults.isEmpty()) bestEndpoints.remove(serverId)
+            if (probeResults.isEmpty() && forcedEndpoints[serverId] == null) {
+                bestEndpoints.remove(serverId)
+            }
             _probeVersion.update { it + 1 }
         }
         activeProbeJobs[serverId] = parentJob
@@ -173,6 +182,7 @@ class EndpointSelector @Inject constructor(
     }
 
     fun invalidate(serverId: Long, failedEndpointId: Long) {
+        forcedEndpoints.remove(serverId, failedEndpointId)
         if (bestEndpoints.remove(serverId, failedEndpointId)) {
             _probeVersion.update { it + 1 }
         }
@@ -182,6 +192,20 @@ class EndpointSelector @Inject constructor(
 
     fun getLastProbeResults(serverId: Long): List<EndpointProbeResult> =
         lastProbeResults[serverId] ?: emptyList()
+
+    fun forceEndpoint(serverId: Long, endpointId: Long) {
+        forcedEndpoints[serverId] = endpointId
+        bestEndpoints[serverId] = endpointId
+        _probeVersion.update { it + 1 }
+    }
+
+    fun clearForce(serverId: Long) {
+        forcedEndpoints.remove(serverId)
+        bestEndpoints.remove(serverId)
+        _probeVersion.update { it + 1 }
+    }
+
+    fun isForced(serverId: Long): Boolean = forcedEndpoints.containsKey(serverId)
 
     private suspend fun pingEndpoint(endpoint: ServerEndpoint, server: ServerConfig): Long? {
         val authQuery = SubsonicAuth.baseQuery(server)

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -143,6 +143,7 @@ fun SakiApp(
                         onRemoveQueueItem = viewModel::removeQueueItem,
                         endpointStatus = endpointStatus,
                         onReprobeEndpoints = viewModel::reprobeEndpoints,
+                        onForceEndpoint = viewModel::forceEndpoint,
                     )
                 }
             }
@@ -209,6 +210,7 @@ private fun RootShell(
     onRemoveQueueItem: (Int) -> Unit,
     endpointStatus: EndpointStatus = EndpointStatus(),
     onReprobeEndpoints: () -> Unit = {},
+    onForceEndpoint: (Long) -> Unit = {},
 ) {
     val currentOrQueuedTrack = uiState.playbackState.currentItem ?: uiState.playbackState.queue.firstOrNull()
     val shellBackgroundBrush = rememberBrowseBackgroundBrush()
@@ -344,9 +346,11 @@ private fun RootShell(
             servers = uiState.servers,
             activeEndpointLabel = endpointStatus.activeEndpointLabel,
             activeEndpointId = endpointStatus.activeEndpointId,
+            isEndpointForced = endpointStatus.isForced,
             endpointProbeResults = endpointStatus.probeResults,
             isProbing = endpointStatus.isProbing,
             onReprobeEndpoints = onReprobeEndpoints,
+            onForceEndpoint = onForceEndpoint,
             lyrics = uiState.currentLyrics,
         )
     }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -1104,6 +1104,7 @@ class SakiAppViewModel @Inject constructor(
             current.copy(
                 activeEndpointLabel = results.find { it.endpoint.id == activeId }?.endpoint?.label,
                 activeEndpointId = activeId,
+                isForced = endpointSelector.isForced(serverId),
                 probeResults = results.map { r ->
                     EndpointProbeInfo(
                         id = r.endpoint.id,
@@ -1114,6 +1115,15 @@ class SakiAppViewModel @Inject constructor(
                     )
                 },
             )
+        }
+    }
+
+    fun forceEndpoint(endpointId: Long) {
+        val serverId = uiState.value.selectedServerId ?: return
+        if (endpointSelector.getActiveEndpointId(serverId) == endpointId && endpointSelector.isForced(serverId)) {
+            endpointSelector.clearForce(serverId)
+        } else {
+            endpointSelector.forceEndpoint(serverId, endpointId)
         }
     }
 
@@ -1179,6 +1189,7 @@ class SakiAppViewModel @Inject constructor(
 data class EndpointStatus(
     val activeEndpointLabel: String? = null,
     val activeEndpointId: Long? = null,
+    val isForced: Boolean = false,
     val probeResults: List<EndpointProbeInfo> = emptyList(),
     val isProbing: Boolean = false,
 )

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -232,9 +232,11 @@ fun NowPlayingOverlay(
     servers: List<ServerConfig> = emptyList(),
     activeEndpointLabel: String? = null,
     activeEndpointId: Long? = null,
+    isEndpointForced: Boolean = false,
     endpointProbeResults: List<EndpointProbeInfo> = emptyList(),
     isProbing: Boolean = false,
     onReprobeEndpoints: () -> Unit = {},
+    onForceEndpoint: (Long) -> Unit = {},
     lyrics: SongLyrics? = null,
 ) {
     val serversById = remember(servers) { servers.associateBy { it.id } }
@@ -798,11 +800,13 @@ fun NowPlayingOverlay(
                         endpointProbeResults.forEach { result ->
                             val isActive = result.id == activeEndpointId
                             Surface(
+                                onClick = { onForceEndpoint(result.id) },
+                                enabled = result.reachable || (isActive && isEndpointForced),
                                 shape = MaterialTheme.shapes.medium,
-                                color = if (isActive) {
-                                    MaterialTheme.colorScheme.primaryContainer
-                                } else {
-                                    MaterialTheme.colorScheme.surfaceVariant
+                                color = when {
+                                    isActive -> MaterialTheme.colorScheme.primaryContainer
+                                    !result.reachable -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                                    else -> MaterialTheme.colorScheme.surfaceVariant
                                 },
                             ) {
                                 Row(
@@ -814,13 +818,26 @@ fun NowPlayingOverlay(
                                 ) {
                                     Column(modifier = Modifier.weight(1f)) {
                                         Text(
-                                            text = result.label + if (isActive) " ✓" else "",
+                                            text = result.label + when {
+                                                isActive && isEndpointForced -> " 📌"
+                                                isActive -> " ✓"
+                                                else -> ""
+                                            },
                                             style = MaterialTheme.typography.bodyLarge,
+                                            color = if (!result.reachable) {
+                                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                            } else {
+                                                MaterialTheme.colorScheme.onSurface
+                                            },
                                         )
                                         Text(
                                             text = result.baseUrl,
                                             style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            color = if (!result.reachable) {
+                                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                                            } else {
+                                                MaterialTheme.colorScheme.onSurfaceVariant
+                                            },
                                         )
                                     }
                                     Text(
@@ -829,7 +846,7 @@ fun NowPlayingOverlay(
                                         color = if (result.reachable) {
                                             MaterialTheme.colorScheme.onSurface
                                         } else {
-                                            MaterialTheme.colorScheme.error
+                                            MaterialTheme.colorScheme.error.copy(alpha = 0.6f)
                                         },
                                     )
                                 }


### PR DESCRIPTION
Closes #82

Depends on #81

## Feature

Tap a reachable endpoint in the Now Playing endpoint status dialog to force it as active. Tap again to cancel and return to automatic selection.

## Behavior

- Reachable endpoints are clickable, unreachable ones are grayed out / disabled
- Forced endpoint shows 📌 indicator
- Force persists until:
  - Network change (`onNetworkChanged` clears it)
  - Request failure on that endpoint (`invalidate` clears it, normal fallback resumes)
- Probe continues running to update latency/reachability UI but does not override forced selection

## Changes

- `EndpointSelector`: `forcedEndpoints` map, `forceEndpoint()`, `clearForce()`, `isForced()`, guarded `probe()`/`invalidate()`/`onNetworkChanged()`
- `SakiAppViewModel`: toggle logic in `forceEndpoint()`, `isForced` in `EndpointStatus`
- `PlayerChrome`: `Surface(onClick)` with `enabled = result.reachable`, disabled styling