### PR TITLE
refactor: rewrite shuffle using Media3 native ShuffleOrder API

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -2,6 +2,7 @@ package com.anzupop.saki.android.playback
 
 import android.content.ComponentName
 import android.content.Context
+import android.os.Bundle
 import android.os.Looper
 import androidx.core.content.ContextCompat
 import androidx.media3.common.C
@@ -9,6 +10,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
+import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.ListenableFuture
 import com.anzupop.saki.android.data.remote.NetworkType
@@ -56,32 +58,15 @@ class DefaultPlaybackManager @Inject constructor(
 ) : PlaybackManager {
     private val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
     private val controllerMutex = Mutex()
-    private var lastVirtualIndex: Int = -1
+
+    // Shuffle state: seed + anchor for deterministic rebuild, display order for UI
+    private var shuffleSeed: Long = 0L
+    private var shuffleAnchorIndex: Int = 0
+    private var shuffleDisplayOrder: List<Int>? = null // player indices in shuffle display order
 
     private val controllerListener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) {
             syncState(player)
-        }
-
-        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-            val order = shuffleOrder ?: return
-            val ctrl = controller ?: return
-            if (reason != Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) return
-
-            // Media3 auto-advanced in original order. Redirect to shuffled next.
-            val nextVirtual = lastVirtualIndex + 1
-            val targetVirtual = when {
-                nextVirtual < order.size -> nextVirtual
-                ctrl.repeatMode == Player.REPEAT_MODE_ALL -> 0
-                ctrl.repeatMode == Player.REPEAT_MODE_ONE -> lastVirtualIndex
-                else -> null
-            }
-            if (targetVirtual != null) {
-                val targetPlayer = virtualToPlayer(targetVirtual)
-                if (ctrl.currentMediaItemIndex != targetPlayer) {
-                    ctrl.seekToDefaultPosition(targetPlayer)
-                }
-            }
         }
     }
 
@@ -189,7 +174,7 @@ class DefaultPlaybackManager @Inject constructor(
         startIndex: Int,
     ) {
         require(songs.isNotEmpty()) { "Playback queue cannot be empty." }
-        shuffleOrder = null
+        shuffleDisplayOrder = null
         persistShuffleState()
         val mediaItems = songs.map { song ->
             val quality = resolveQualityForSong(serverId, song.id)
@@ -205,6 +190,7 @@ class DefaultPlaybackManager @Inject constructor(
 
         withController { activeController ->
             val safeStartIndex = startIndex.coerceIn(mediaItems.indices)
+            activeController.shuffleModeEnabled = false
             activeController.setMediaItems(mediaItems, safeStartIndex, C.TIME_UNSET)
             activeController.prepare()
             activeController.play()
@@ -219,7 +205,7 @@ class DefaultPlaybackManager @Inject constructor(
         positionMs: Long,
     ) {
         if (songs.isEmpty()) return
-        shuffleOrder = null
+        shuffleDisplayOrder = null
         val mediaItems = songs.map { song ->
             val quality = resolveQualityForSong(serverId, song.id)
             song.toPlaybackRequestMediaItem(
@@ -242,7 +228,11 @@ class DefaultPlaybackManager @Inject constructor(
             if (saved != null && mediaItems.size > 1) {
                 shuffleSeed = saved.first
                 shuffleAnchorIndex = saved.second.coerceIn(0, mediaItems.size - 1)
-                shuffleOrder = buildShuffleOrder(mediaItems.size, shuffleAnchorIndex, shuffleSeed)
+                sendShuffleOrderToService(activeController, mediaItems.size, shuffleSeed, shuffleAnchorIndex)
+                activeController.shuffleModeEnabled = true
+                shuffleDisplayOrder = SakiShuffleOrder(mediaItems.size, shuffleSeed, shuffleAnchorIndex).toDisplayOrder()
+            } else {
+                activeController.shuffleModeEnabled = false
             }
 
             syncState(activeController)
@@ -254,12 +244,13 @@ class DefaultPlaybackManager @Inject constructor(
         startIndex: Int,
     ) {
         require(songs.isNotEmpty()) { "Playback queue cannot be empty." }
-        shuffleOrder = null
+        shuffleDisplayOrder = null
         persistShuffleState()
         val mediaItems = songs.map(CachedSong::toCachedMediaItem)
 
         withController { activeController ->
             val safeStartIndex = startIndex.coerceIn(mediaItems.indices)
+            activeController.shuffleModeEnabled = false
             activeController.setMediaItems(mediaItems, safeStartIndex, C.TIME_UNSET)
             activeController.prepare()
             activeController.play()
@@ -272,7 +263,7 @@ class DefaultPlaybackManager @Inject constructor(
         songs: List<Song>,
     ) {
         if (songs.isEmpty()) return
-        if (shuffleOrder != null) { shuffleOrder = null; persistShuffleState() }
+        clearShuffleIfActive()
         val mediaItems = songs.map { song ->
             val quality = resolveQualityForSong(serverId, song.id)
             song.toPlaybackRequestMediaItem(
@@ -295,7 +286,7 @@ class DefaultPlaybackManager @Inject constructor(
         serverId: Long,
         song: Song,
     ) {
-        if (shuffleOrder != null) { shuffleOrder = null; persistShuffleState() }
+        clearShuffleIfActive()
         val quality = resolveQualityForSong(serverId, song.id)
         val mediaItem = song.toPlaybackRequestMediaItem(
             serverId = serverId,
@@ -333,73 +324,42 @@ class DefaultPlaybackManager @Inject constructor(
 
     override suspend fun skipToNext() {
         withController { activeController ->
-            if (shuffleOrder != null) {
-                val count = activeController.mediaItemCount
-                val currentVirtual = playerToVirtual(activeController.currentMediaItemIndex)
-                val nextVirtual = currentVirtual + 1
-                val targetVirtual = when {
-                    nextVirtual < count -> nextVirtual
-                    activeController.repeatMode == Player.REPEAT_MODE_ALL -> 0
-                    activeController.repeatMode == Player.REPEAT_MODE_ONE -> currentVirtual
-                    else -> null
-                }
-                if (targetVirtual != null) {
-                    activeController.seekToDefaultPosition(virtualToPlayer(targetVirtual))
-                    activeController.play()
-                }
-            } else {
-                val nextIndex = activeController.currentMediaItemIndex + 1
-                if (nextIndex < activeController.mediaItemCount) {
-                    val nextItem = activeController.getMediaItemAt(nextIndex)
-                    val request = nextItem.toPlaybackRequestOrNull()
-                    if (request != null && !request.isCached) {
-                        val quality = resolveQualityForSong(request.serverId, request.songId)
-                        if (quality.maxBitRate != request.maxBitRate) {
-                            val rebuilt = request.copy(
-                                qualityLabel = quality.label,
-                                streamCacheKey = streamCacheRepository.buildCacheKey(request.serverId, request.songId, quality),
-                                maxBitRate = quality.maxBitRate,
-                                format = quality.format,
-                            ).let { updated ->
-                                MediaItem.Builder()
-                                    .setMediaId(updated.songId)
-                                    .setMediaMetadata(updated.toMediaMetadata())
-                                    .setRequestMetadata(
-                                        MediaItem.RequestMetadata.Builder()
-                                            .setExtras(updated.toBundle())
-                                            .build(),
-                                    )
-                                    .build()
-                            }
-                            activeController.replaceMediaItem(nextIndex, rebuilt)
+            // With native ShuffleOrder, seekToNext respects shuffle mode
+            val nextIndex = activeController.currentMediaItemIndex + 1
+            if (!activeController.shuffleModeEnabled && nextIndex < activeController.mediaItemCount) {
+                val nextItem = activeController.getMediaItemAt(nextIndex)
+                val request = nextItem.toPlaybackRequestOrNull()
+                if (request != null && !request.isCached) {
+                    val quality = resolveQualityForSong(request.serverId, request.songId)
+                    if (quality.maxBitRate != request.maxBitRate) {
+                        val rebuilt = request.copy(
+                            qualityLabel = quality.label,
+                            streamCacheKey = streamCacheRepository.buildCacheKey(request.serverId, request.songId, quality),
+                            maxBitRate = quality.maxBitRate,
+                            format = quality.format,
+                        ).let { updated ->
+                            MediaItem.Builder()
+                                .setMediaId(updated.songId)
+                                .setMediaMetadata(updated.toMediaMetadata())
+                                .setRequestMetadata(
+                                    MediaItem.RequestMetadata.Builder()
+                                        .setExtras(updated.toBundle())
+                                        .build(),
+                                )
+                                .build()
                         }
+                        activeController.replaceMediaItem(nextIndex, rebuilt)
                     }
                 }
-                activeController.seekToNext()
             }
+            activeController.seekToNext()
             syncState(activeController)
         }
     }
 
     override suspend fun skipToPrevious() {
         withController { activeController ->
-            if (shuffleOrder != null) {
-                val count = activeController.mediaItemCount
-                val currentVirtual = playerToVirtual(activeController.currentMediaItemIndex)
-                val prevVirtual = currentVirtual - 1
-                val targetVirtual = when {
-                    prevVirtual >= 0 -> prevVirtual
-                    activeController.repeatMode == Player.REPEAT_MODE_ALL -> count - 1
-                    activeController.repeatMode == Player.REPEAT_MODE_ONE -> currentVirtual
-                    else -> null
-                }
-                if (targetVirtual != null) {
-                    activeController.seekToDefaultPosition(virtualToPlayer(targetVirtual))
-                    activeController.play()
-                }
-            } else {
-                activeController.seekToPrevious()
-            }
+            activeController.seekToPrevious()
             syncState(activeController)
         }
     }
@@ -422,19 +382,9 @@ class DefaultPlaybackManager @Inject constructor(
         }
     }
 
-    // Shuffle mapping: virtual index → player index. Null when shuffle is off.
-    private var shuffleOrder: List<Int>? = null
-    private var shuffleSeed: Long = 0L
-    private var shuffleAnchorIndex: Int = 0 // player index of the track that was playing when shuffle was toggled
-
-    private fun buildShuffleOrder(count: Int, anchorPlayerIndex: Int, seed: Long): List<Int> {
-        val rest = (0 until count).filter { it != anchorPlayerIndex }.shuffled(kotlin.random.Random(seed))
-        return listOf(anchorPlayerIndex) + rest
-    }
-
     private fun persistShuffleState() {
         scope.launch {
-            if (shuffleOrder != null) {
+            if (shuffleDisplayOrder != null) {
                 playbackPreferencesRepository.updateShuffleState(shuffleSeed, shuffleAnchorIndex)
             } else {
                 playbackPreferencesRepository.clearShuffleState()
@@ -442,26 +392,49 @@ class DefaultPlaybackManager @Inject constructor(
         }
     }
 
-    private fun virtualToPlayer(virtualIndex: Int): Int =
-        shuffleOrder?.getOrNull(virtualIndex) ?: virtualIndex
+    private suspend fun clearShuffleIfActive() {
+        if (shuffleDisplayOrder == null) return
+        shuffleDisplayOrder = null
+        persistShuffleState()
+        withController { it.shuffleModeEnabled = false }
+    }
 
-    private fun playerToVirtual(playerIndex: Int): Int =
-        shuffleOrder?.indexOf(playerIndex)?.takeIf { it >= 0 } ?: playerIndex
+    private fun sendShuffleOrderToService(controller: MediaController, count: Int, seed: Long, anchor: Int) {
+        val args = Bundle().apply {
+            putLong(SakiPlaybackService.EXTRA_SHUFFLE_SEED, seed)
+            putInt(SakiPlaybackService.EXTRA_SHUFFLE_ANCHOR, anchor)
+            putInt(SakiPlaybackService.EXTRA_SHUFFLE_COUNT, count)
+        }
+        controller.sendCustomCommand(
+            SessionCommand(SakiPlaybackService.ACTION_SET_SHUFFLE_ORDER, Bundle.EMPTY),
+            args,
+        )
+    }
+
+    /** Map display index (in shuffle order) to player index. */
+    private fun displayToPlayer(displayIndex: Int): Int =
+        shuffleDisplayOrder?.getOrNull(displayIndex) ?: displayIndex
+
+    /** Map player index to display index (in shuffle order). */
+    private fun playerToDisplay(playerIndex: Int): Int =
+        shuffleDisplayOrder?.indexOf(playerIndex)?.takeIf { it >= 0 } ?: playerIndex
 
     override suspend fun toggleShuffle() {
         withController { activeController ->
             val count = activeController.mediaItemCount
             if (count <= 1) return@withController
 
-            if (shuffleOrder == null) {
+            if (shuffleDisplayOrder == null) {
                 // Shuffle ON
-                val currentPlayerIndex = activeController.currentMediaItemIndex
                 shuffleSeed = System.nanoTime()
-                shuffleAnchorIndex = currentPlayerIndex
-                shuffleOrder = buildShuffleOrder(count, currentPlayerIndex, shuffleSeed)
+                shuffleAnchorIndex = activeController.currentMediaItemIndex
+                sendShuffleOrderToService(activeController, count, shuffleSeed, shuffleAnchorIndex)
+                activeController.shuffleModeEnabled = true
+                shuffleDisplayOrder = SakiShuffleOrder(count, shuffleSeed, shuffleAnchorIndex).toDisplayOrder()
             } else {
                 // Shuffle OFF
-                shuffleOrder = null
+                shuffleDisplayOrder = null
+                activeController.shuffleModeEnabled = false
             }
 
             persistShuffleState()
@@ -471,7 +444,7 @@ class DefaultPlaybackManager @Inject constructor(
 
     override suspend fun skipToQueueItem(index: Int) {
         withController { activeController ->
-            val playerIndex = virtualToPlayer(index)
+            val playerIndex = displayToPlayer(index)
             if (playerIndex !in 0 until activeController.mediaItemCount) return@withController
             activeController.seekToDefaultPosition(playerIndex)
             activeController.play()
@@ -481,12 +454,26 @@ class DefaultPlaybackManager @Inject constructor(
 
     override suspend fun removeQueueItem(index: Int) {
         withController { activeController ->
-            val playerIndex = virtualToPlayer(index)
+            val playerIndex = displayToPlayer(index)
             if (playerIndex !in 0 until activeController.mediaItemCount) return@withController
             activeController.removeMediaItem(playerIndex)
-            if (shuffleOrder != null) {
-                shuffleOrder = null
-                persistShuffleState()
+            if (shuffleDisplayOrder != null) {
+                val newCount = activeController.mediaItemCount
+                if (newCount <= 1) {
+                    shuffleDisplayOrder = null
+                    activeController.shuffleModeEnabled = false
+                    persistShuffleState()
+                } else {
+                    // Mirror ExoPlayer's cloneAndRemove: filter out removed index, shift down
+                    shuffleDisplayOrder = shuffleDisplayOrder!!
+                        .filter { it != playerIndex }
+                        .map { if (it > playerIndex) it - 1 else it }
+                    if (shuffleAnchorIndex == playerIndex) {
+                        shuffleAnchorIndex = 0
+                    } else if (shuffleAnchorIndex > playerIndex) {
+                        shuffleAnchorIndex--
+                    }
+                }
             }
             syncState(activeController)
         }
@@ -532,19 +519,13 @@ class DefaultPlaybackManager @Inject constructor(
             ?: -1
 
         // Expose queue in shuffled order if shuffle is active
-        val order = shuffleOrder
-        if (order != null && order.size != queue.size) {
-            // Mapping is stale, clear it
-            shuffleOrder = null
-            persistShuffleState()
-        }
-        val (displayQueue, displayIndex) = if (shuffleOrder != null && queue.isNotEmpty()) {
-            val shuffled = shuffleOrder!!.mapNotNull { queue.getOrNull(it) }
-            shuffled to playerToVirtual(playerIndex)
+        val displayOrder = shuffleDisplayOrder
+        val (displayQueue, displayIndex) = if (displayOrder != null && queue.isNotEmpty()) {
+            val shuffled = displayOrder.mapNotNull { queue.getOrNull(it) }
+            shuffled to playerToDisplay(playerIndex)
         } else {
             queue to playerIndex
         }
-        lastVirtualIndex = displayIndex
 
         val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
         val streamCached = currentRequest != null && !currentRequest.isCached &&
@@ -567,7 +548,7 @@ class DefaultPlaybackManager @Inject constructor(
                 bufferedPositionMs = player.bufferedPosition.coerceKnownTime(),
                 isStreamCached = streamCached,
                 repeatMode = player.repeatMode.toRepeatModeSetting(),
-                shuffleEnabled = shuffleOrder != null,
+                shuffleEnabled = shuffleDisplayOrder != null,
                 runtimeInfo = player.currentAudioRuntimeInfoOrNull(),
             )
         }

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -3,6 +3,7 @@ package com.anzupop.saki.android.playback
 import android.app.PendingIntent
 import android.content.Intent
 import android.media.audiofx.LoudnessEnhancer
+import android.os.Bundle
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
@@ -19,6 +20,8 @@ import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSession.ConnectionResult
 import androidx.media3.session.MediaSessionService
 import androidx.media3.session.MediaSession.ControllerInfo
+import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionResult
 import com.anzupop.saki.android.MainActivity
 import com.anzupop.saki.android.data.remote.HTTP_USER_AGENT
 import com.anzupop.saki.android.domain.model.LyricLine
@@ -49,6 +52,14 @@ import okhttp3.OkHttpClient
 @AndroidEntryPoint
 @UnstableApi
 class SakiPlaybackService : MediaSessionService() {
+    companion object {
+        const val ACTION_SET_SHUFFLE_ORDER = "saki.action.SET_SHUFFLE_ORDER"
+        const val EXTRA_SHUFFLE_SEED = "saki.extra.SHUFFLE_SEED"
+        const val EXTRA_SHUFFLE_ANCHOR = "saki.extra.SHUFFLE_ANCHOR"
+        const val EXTRA_SHUFFLE_COUNT = "saki.extra.SHUFFLE_COUNT"
+    }
+
+    private var pendingShuffleOrder: Triple<Long, Int, Int>? = null // seed, anchor, count
     @Inject
     lateinit var okHttpClient: OkHttpClient
 
@@ -110,6 +121,16 @@ class SakiPlaybackService : MediaSessionService() {
                     ExoPlayer.PreloadConfiguration(10 * C.MICROS_PER_SECOND)
                 addListener(PlaybackRecoveryListener())
                 addListener(PlayQueueSaveListener())
+                addListener(object : Player.Listener {
+                    override fun onTimelineChanged(timeline: androidx.media3.common.Timeline, reason: Int) {
+                        val pending = pendingShuffleOrder ?: return
+                        val (seed, anchor, count) = pending
+                        if (mediaItemCount == count) {
+                            setShuffleOrder(SakiShuffleOrder(count, seed, anchor))
+                            pendingShuffleOrder = null
+                        }
+                    }
+                })
             }
 
         val sessionActivity = PendingIntent.getActivity(
@@ -251,7 +272,12 @@ class SakiPlaybackService : MediaSessionService() {
         ): ConnectionResult {
             val baseResult = ConnectionResult.AcceptedResultBuilder(session)
             if (controller.packageName == packageName || controller.isTrusted) {
-                return baseResult.build()
+                val sessionCommands = ConnectionResult.DEFAULT_SESSION_COMMANDS.buildUpon()
+                    .add(SessionCommand(ACTION_SET_SHUFFLE_ORDER, Bundle.EMPTY))
+                    .build()
+                return baseResult
+                    .setAvailableSessionCommands(sessionCommands)
+                    .build()
             }
 
             val filteredPlayerCommands = Player.Commands.Builder()
@@ -284,6 +310,31 @@ class SakiPlaybackService : MediaSessionService() {
             }
 
             return future
+        }
+
+        override fun onCustomCommand(
+            session: MediaSession,
+            controller: ControllerInfo,
+            customCommand: SessionCommand,
+            args: Bundle,
+        ): ListenableFuture<SessionResult> {
+            if (customCommand.customAction == ACTION_SET_SHUFFLE_ORDER) {
+                val seed = args.getLong(EXTRA_SHUFFLE_SEED)
+                val anchor = args.getInt(EXTRA_SHUFFLE_ANCHOR)
+                val count = args.getInt(EXTRA_SHUFFLE_COUNT)
+                val exoPlayer = player as? ExoPlayer
+                if (exoPlayer != null && count > 0 && count == exoPlayer.mediaItemCount) {
+                    val order = SakiShuffleOrder(count, seed, anchor)
+                    exoPlayer.setShuffleOrder(order)
+                    pendingShuffleOrder = null
+                } else {
+                    pendingShuffleOrder = Triple(seed, anchor, count)
+                }
+                return SettableFuture.create<SessionResult>().apply {
+                    set(SessionResult(SessionResult.RESULT_SUCCESS))
+                }
+            }
+            return super.onCustomCommand(session, controller, customCommand, args)
         }
 
         private suspend fun resolvePlayableItem(

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiShuffleOrder.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiShuffleOrder.kt
@@ -1,0 +1,88 @@
+package com.anzupop.saki.android.playback
+
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.source.ShuffleOrder
+
+/**
+ * A [ShuffleOrder] that places [anchorIndex] first, then shuffles the rest
+ * deterministically using [seed]. Same seed + count + anchor always produces
+ * the same order.
+ */
+@UnstableApi
+class SakiShuffleOrder(
+    private val shuffled: IntArray,
+    private val indexInShuffled: IntArray,
+) : ShuffleOrder {
+
+    constructor(length: Int, seed: Long, anchorIndex: Int) : this(
+        buildShuffledArray(length, seed, anchorIndex.coerceIn(0, (length - 1).coerceAtLeast(0))),
+    )
+
+    private constructor(shuffled: IntArray) : this(
+        shuffled = shuffled,
+        indexInShuffled = IntArray(shuffled.size).also { inv ->
+            for (i in shuffled.indices) inv[shuffled[i]] = i
+        },
+    )
+
+    override fun getLength(): Int = shuffled.size
+
+    override fun getFirstIndex(): Int =
+        if (shuffled.isEmpty()) C.INDEX_UNSET else shuffled[0]
+
+    override fun getLastIndex(): Int =
+        if (shuffled.isEmpty()) C.INDEX_UNSET else shuffled[shuffled.lastIndex]
+
+    override fun getNextIndex(index: Int): Int {
+        val pos = indexInShuffled.getOrElse(index) { return C.INDEX_UNSET }
+        return if (pos + 1 < shuffled.size) shuffled[pos + 1] else C.INDEX_UNSET
+    }
+
+    override fun getPreviousIndex(index: Int): Int {
+        val pos = indexInShuffled.getOrElse(index) { return C.INDEX_UNSET }
+        return if (pos > 0) shuffled[pos - 1] else C.INDEX_UNSET
+    }
+
+    override fun cloneAndInsert(insertionIndex: Int, insertionCount: Int): ShuffleOrder {
+        val newLength = shuffled.size + insertionCount
+        val newShuffled = IntArray(newLength)
+        var destPos = 0
+        // Copy existing, shifting indices >= insertionIndex
+        for (originalIndex in shuffled) {
+            newShuffled[destPos++] = if (originalIndex >= insertionIndex) originalIndex + insertionCount else originalIndex
+        }
+        // Append new indices at the end of shuffle order
+        for (i in 0 until insertionCount) {
+            newShuffled[destPos++] = insertionIndex + i
+        }
+        return SakiShuffleOrder(newShuffled)
+    }
+
+    override fun cloneAndRemove(indexFrom: Int, indexToExclusive: Int): ShuffleOrder {
+        val removeCount = indexToExclusive - indexFrom
+        val newShuffled = shuffled
+            .filter { it < indexFrom || it >= indexToExclusive }
+            .map { if (it >= indexToExclusive) it - removeCount else it }
+            .toIntArray()
+        return SakiShuffleOrder(newShuffled)
+    }
+
+    override fun cloneAndClear(): ShuffleOrder = SakiShuffleOrder(IntArray(0))
+
+    /** Traverses the shuffle order and returns the list of player indices in display order. */
+    fun toDisplayOrder(): List<Int> {
+        return shuffled.toList()
+    }
+
+    companion object {
+        private fun buildShuffledArray(length: Int, seed: Long, anchorIndex: Int): IntArray {
+            if (length == 0) return IntArray(0)
+            val rest = (0 until length).filter { it != anchorIndex }
+                .shuffled(kotlin.random.Random(seed))
+            return IntArray(length) { i ->
+                if (i == 0) anchorIndex else rest[i - 1]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #88, supersedes #85

## Problem

The previous shuffle implementation used a virtual index mapping on top of Media3's playlist, then redirected in `onMediaItemTransition` when ExoPlayer auto-advanced to the wrong track. This caused:

1. **Audio bleed** (~4ms of wrong track audible before redirect)
2. **Shuffle order silently cleared** on queue size mismatch during preload

## Solution

Replace with Media3's native `ShuffleOrder` API. ExoPlayer now handles shuffle auto-advance internally — it never plays the wrong track.

## Changes

- **`SakiShuffleOrder`**: Custom `ShuffleOrder` implementation that places the anchor (current track) first, then shuffles the rest deterministically using a seed
- **`SakiPlaybackService`**: Custom `SessionCommand` handler to set `ShuffleOrder` on the `ExoPlayer` instance. Pending order cached and applied on timeline change (handles async `setMediaItems`)
- **`DefaultPlaybackManager`**: 
  - `toggleShuffle` sends seed via custom command + sets `shuffleModeEnabled`
  - Removed: `virtualToPlayer`, `playerToVirtual`, `lastVirtualIndex`, `onMediaItemTransition` redirect
  - Simplified: `skipToNext`/`skipToPrevious` (ExoPlayer handles shuffle natively)
  - `syncState` uses `shuffleDisplayOrder` for UI queue reordering
  - `restoreQueue` sends saved seed to service for shuffle restoration

## Tested

- Shuffle on/off toggle ✅
- Auto-advance follows shuffle order (no audio bleed) ✅
- Manual skip (next/prev/queue tap) respects shuffle ✅
- Queue display shows correct shuffle order ✅
- Shuffle persistence across restart ✅