### PR TITLE
fix: use active endpoint for cover art URL after network switch

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/data/remote/CoverArtEndpointInterceptor.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/CoverArtEndpointInterceptor.kt
@@ -1,0 +1,71 @@
+package com.anzupop.saki.android.data.remote
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * OkHttp interceptor that rewrites Coil cover art request URLs to use the best available endpoint.
+ *
+ * Coil generates cover art URLs with a fixed base (first endpoint by order) for stable caching.
+ * When the actual HTTP request is made (cache miss), this interceptor replaces the base URL
+ * with the current best endpoint so the request reaches a reachable server.
+ *
+ * Only rewrites requests whose host+port matches the canonical (first-by-order) endpoint,
+ * so repository-generated multi-endpoint fallback requests are not affected.
+ */
+class CoverArtEndpointInterceptor(
+    private val endpointSelectorProvider: () -> EndpointSelector,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val url = request.url
+
+        if (!url.encodedPath.contains("getCoverArt.view")) {
+            return chain.proceed(request)
+        }
+
+        val endpointSelector = endpointSelectorProvider()
+
+        val matchedServerId = endpointSelector.findServerByHostPort(url.host, url.port)
+            ?: return chain.proceed(request)
+
+        // Only rewrite if this request uses the canonical (first-by-order) endpoint.
+        // Non-canonical requests come from SubsonicRepository fallback and should not be rewritten.
+        val canonicalEndpoint = endpointSelector.getCanonicalEndpoint(matchedServerId)
+            ?: return chain.proceed(request)
+        val canonicalBase = canonicalEndpoint.baseUrl.trimEnd('/').toHttpUrlOrNull()
+            ?: return chain.proceed(request)
+        if (url.host != canonicalBase.host || url.port != canonicalBase.port || url.scheme != canonicalBase.scheme) {
+            return chain.proceed(request)
+        }
+
+        val bestEndpointId = endpointSelector.getActiveEndpointId(matchedServerId)
+            ?: return chain.proceed(request)
+        if (canonicalEndpoint.id == bestEndpointId) {
+            return chain.proceed(request)
+        }
+
+        val results = endpointSelector.getLastProbeResults(matchedServerId)
+        val bestEndpoint = results.find { it.endpoint.id == bestEndpointId }?.endpoint
+            ?: return chain.proceed(request)
+        val bestBase = bestEndpoint.baseUrl.trimEnd('/').toHttpUrlOrNull()
+            ?: return chain.proceed(request)
+
+        // Extract the relative path after /rest/ and rebuild with best endpoint's base path
+        val restIndex = url.encodedPath.indexOf("/rest/")
+        if (restIndex == -1) return chain.proceed(request)
+        val relativePath = url.encodedPath.substring(restIndex)
+
+        val bestBasePath = bestBase.encodedPath.trimEnd('/')
+        val newUrl = url.newBuilder()
+            .scheme(bestBase.scheme)
+            .host(bestBase.host)
+            .port(bestBase.port)
+            .encodedPath(bestBasePath + relativePath)
+            .build()
+
+        return chain.proceed(request.newBuilder().url(newUrl).build())
+    }
+}

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/EndpointSelector.kt
@@ -207,6 +207,30 @@ class EndpointSelector @Inject constructor(
 
     fun isForced(serverId: Long): Boolean = forcedEndpoints.containsKey(serverId)
 
+    fun findServerByHostPort(host: String, port: Int): Long? {
+        var matchedServerId: Long? = null
+        for ((serverId, config) in serverConfigs) {
+            for (ep in config.endpoints) {
+                val url = ep.baseUrl.trimEnd('/').toHttpUrlOrNull() ?: continue
+                if (url.host == host && url.port == port) {
+                    if (matchedServerId == null) {
+                        matchedServerId = serverId
+                    } else if (matchedServerId != serverId) {
+                        return null // ambiguous
+                    }
+                }
+            }
+        }
+        return matchedServerId
+    }
+
+    /** Returns the first endpoint by order for the given server (used as canonical base for Coil URLs). */
+    fun getCanonicalEndpoint(serverId: Long): ServerEndpoint? {
+        return serverConfigs[serverId]?.endpoints
+            ?.sortedBy(ServerEndpoint::order)
+            ?.firstOrNull()
+    }
+
     private suspend fun pingEndpoint(endpoint: ServerEndpoint, server: ServerConfig): Long? {
         val authQuery = SubsonicAuth.baseQuery(server)
         val urlBuilder = endpoint.baseUrl.trimEnd('/').toHttpUrlOrNull()

--- a/app/src/main/java/com/anzupop/saki/android/di/NetworkModule.kt
+++ b/app/src/main/java/com/anzupop/saki/android/di/NetworkModule.kt
@@ -1,6 +1,8 @@
 package com.anzupop.saki.android.di
 
 import com.anzupop.saki.android.BuildConfig
+import com.anzupop.saki.android.data.remote.CoverArtEndpointInterceptor
+import com.anzupop.saki.android.data.remote.EndpointSelector
 import com.anzupop.saki.android.data.remote.HTTP_USER_AGENT
 import com.anzupop.saki.android.data.remote.subsonic.SubsonicApiService
 import com.squareup.moshi.Moshi
@@ -46,15 +48,25 @@ object NetworkModule {
 
     @Provides
     @Singleton
+    fun provideCoverArtEndpointInterceptor(
+        endpointSelector: dagger.Lazy<EndpointSelector>,
+    ): CoverArtEndpointInterceptor {
+        return CoverArtEndpointInterceptor { endpointSelector.get() }
+    }
+
+    @Provides
+    @Singleton
     fun provideOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
         userAgentInterceptor: Interceptor,
+        coverArtEndpointInterceptor: CoverArtEndpointInterceptor,
     ): OkHttpClient {
         return OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .addInterceptor(userAgentInterceptor)
+            .addInterceptor(coverArtEndpointInterceptor)
             .addInterceptor(loggingInterceptor)
             .build()
     }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/Artwork.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/Artwork.kt
@@ -83,10 +83,15 @@ fun resolveArtworkModel(
     return server?.buildCoverArtUrl(coverArtId)
 }
 
+/**
+ * Builds a deterministic cover art URL using the first endpoint by order and a salt derived
+ * from the cover art ID. Stable for a fixed server configuration and coverArtId, enabling
+ * Coil's disk cache to reuse entries. At request time, [CoverArtEndpointInterceptor] rewrites
+ * the base URL to the current best endpoint.
+ */
 private fun ServerConfig.buildCoverArtUrl(coverArtId: String?): String? {
     if (coverArtId.isNullOrBlank()) return null
-    val endpoint = endpoints.sortedBy(ServerEndpoint::order)
-        .firstOrNull() ?: return null
+    val endpoint = endpoints.sortedBy(ServerEndpoint::order).firstOrNull() ?: return null
     val baseUrl = endpoint.baseUrl.toHttpUrlOrNull() ?: return null
     val salt = md5(coverArtId).take(8)
     val hash = md5("$password$salt")


### PR DESCRIPTION
Closes #87

## Problem

Cover art fails to load after network switch. Two issues:

1. **Wrong endpoint**: `buildCoverArtUrl` generates a URL with the first endpoint by order, which may be unreachable after network change
2. **Cache duplication**: If the URL changes per endpoint, Coil caches the same image multiple times (once per endpoint)

## Solution

Two-layer approach — stable cache key + dynamic endpoint at request time:

**Artwork.kt** — Generates a stable URL using the first endpoint + deterministic salt (derived from coverArtId, not random). This URL never changes for the same image, so Coil's disk/memory cache works correctly with a single copy.

**CoverArtEndpointInterceptor** (OkHttp) — On cache miss, when Coil actually makes an HTTP request, this interceptor rewrites the URL's scheme+host+port to the current best endpoint from `EndpointSelector`. On cache hit, no network request is made and the interceptor is never called.

**EndpointSelector.findServerByHostPort** — Looks up which server a request belongs to by matching the URL's host+port against registered endpoints.

## Result

- Same image cached once regardless of endpoint changes ✅
- Network switch → new images load via best endpoint ✅  
- Cached images load instantly without network ✅
- No UI component changes needed ✅

## Files changed

- `CoverArtEndpointInterceptor.kt` — New OkHttp interceptor, rewrites cover art requests to best endpoint
- `EndpointSelector.kt` — Added `findServerByHostPort()`
- `NetworkModule.kt` — Register interceptor with `dagger.Lazy` to avoid dependency cycle
- `Artwork.kt` — Added doc comment on `buildCoverArtUrl` explaining stable URL strategy"