### PR TITLE
fix: truncate file before writing config export

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -1145,7 +1145,7 @@ class SakiAppViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 val json = configBackupManager.exportToJson()
-                appContext.contentResolver.openOutputStream(uri)?.use { it.write(json.toByteArray()) }
+                appContext.contentResolver.openOutputStream(uri, "wt")?.use { it.write(json.toByteArray()) }
                     ?: error("Cannot open output stream")
             }
                 .onSuccess { snackbarMessages.tryEmit("Backup exported") }


### PR DESCRIPTION
Closes #91

`openOutputStream(uri)` → `openOutputStream(uri, "wt")` to truncate the file before writing. Without this, exporting to an existing file leaves leftover bytes when the new JSON is shorter than the old.