### PR TITLE
fix: re-probe endpoints when server config changes

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -754,6 +754,14 @@ class SakiAppViewModel @Inject constructor(
                     refreshServerContent(selectedServerId, forceRefresh = serverChanged)
                 }
             }
+        } else if (selectedServerId != null) {
+            // Server didn't change but config may have (e.g. endpoints added/removed) — re-probe
+            viewModelScope.launch {
+                servers.find { it.id == selectedServerId }?.let { server ->
+                    endpointSelector.registerServer(server)
+                    endpointSelector.probe(selectedServerId, server)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #93

When the selected server's config changes (endpoints added/removed/edited) without a server ID change, re-register and re-probe the server with `EndpointSelector` so new endpoints take effect immediately.