### PR TITLE
fix: adaptive quality shuffle + cover art crash on network switch

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/data/remote/CoverArtEndpointInterceptor.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/CoverArtEndpointInterceptor.kt
@@ -1,5 +1,6 @@
 package com.anzupop.saki.android.data.remote
 
+import java.io.IOException
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -66,6 +67,11 @@ class CoverArtEndpointInterceptor(
             .encodedPath(bestBasePath + relativePath)
             .build()
 
-        return chain.proceed(request.newBuilder().url(newUrl).build())
+        return try {
+            chain.proceed(request.newBuilder().url(newUrl).build())
+        } catch (e: IllegalStateException) {
+            // Stale connection after network switch — rethrow as IOException so OkHttp retries
+            throw IOException("Stale connection after endpoint rewrite", e)
+        }
     }
 }

--- a/app/src/main/java/com/anzupop/saki/android/data/remote/CoverArtEndpointInterceptor.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/remote/CoverArtEndpointInterceptor.kt
@@ -30,33 +30,33 @@ class CoverArtEndpointInterceptor(
         val endpointSelector = endpointSelectorProvider()
 
         val matchedServerId = endpointSelector.findServerByHostPort(url.host, url.port)
-            ?: return chain.proceed(request)
+            ?: return proceedSafely(chain, request)
 
         // Only rewrite if this request uses the canonical (first-by-order) endpoint.
         // Non-canonical requests come from SubsonicRepository fallback and should not be rewritten.
         val canonicalEndpoint = endpointSelector.getCanonicalEndpoint(matchedServerId)
-            ?: return chain.proceed(request)
+            ?: return proceedSafely(chain, request)
         val canonicalBase = canonicalEndpoint.baseUrl.trimEnd('/').toHttpUrlOrNull()
-            ?: return chain.proceed(request)
+            ?: return proceedSafely(chain, request)
         if (url.host != canonicalBase.host || url.port != canonicalBase.port || url.scheme != canonicalBase.scheme) {
-            return chain.proceed(request)
+            return proceedSafely(chain, request)
         }
 
         val bestEndpointId = endpointSelector.getActiveEndpointId(matchedServerId)
-            ?: return chain.proceed(request)
+            ?: return proceedSafely(chain, request)
         if (canonicalEndpoint.id == bestEndpointId) {
-            return chain.proceed(request)
+            return proceedSafely(chain, request)
         }
 
         val results = endpointSelector.getLastProbeResults(matchedServerId)
         val bestEndpoint = results.find { it.endpoint.id == bestEndpointId }?.endpoint
-            ?: return chain.proceed(request)
+            ?: return proceedSafely(chain, request)
         val bestBase = bestEndpoint.baseUrl.trimEnd('/').toHttpUrlOrNull()
-            ?: return chain.proceed(request)
+            ?: return proceedSafely(chain, request)
 
         // Extract the relative path after /rest/ and rebuild with best endpoint's base path
         val restIndex = url.encodedPath.indexOf("/rest/")
-        if (restIndex == -1) return chain.proceed(request)
+        if (restIndex == -1) return proceedSafely(chain, request)
         val relativePath = url.encodedPath.substring(restIndex)
 
         val bestBasePath = bestBase.encodedPath.trimEnd('/')
@@ -67,11 +67,14 @@ class CoverArtEndpointInterceptor(
             .encodedPath(bestBasePath + relativePath)
             .build()
 
-        return try {
-            chain.proceed(request.newBuilder().url(newUrl).build())
-        } catch (e: IllegalStateException) {
-            // Stale connection after network switch — rethrow as IOException so OkHttp retries
-            throw IOException("Stale connection after endpoint rewrite", e)
-        }
+        return proceedSafely(chain, request.newBuilder().url(newUrl).build())
     }
+
+    /** Proceed with the request, converting stale-connection [IllegalStateException] to [IOException]. */
+    private fun proceedSafely(chain: Interceptor.Chain, request: okhttp3.Request): Response =
+        try {
+            chain.proceed(request)
+        } catch (e: IllegalStateException) {
+            throw IOException("Stale connection during cover art request", e)
+        }
 }

--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -100,9 +100,25 @@ class DefaultPlaybackManager @Inject constructor(
             val upcoming = shuffleDisplayOrder?.let { order ->
                 val pos = order.indexOf(current)
                 if (pos == -1) return@let null
-                order.drop(pos + 1).take(10)
-            } ?: ((current + 1) until (current + 11).coerceAtMost(count)).toList()
+                val tail = order.drop(pos + 1)
+                // Wrap around for repeat-all so tracks after the end are also rebuilt
+                if (tail.size < 10 && activeController.repeatMode == Player.REPEAT_MODE_ALL) {
+                    (tail + order.take(10 - tail.size)).take(10)
+                } else {
+                    tail.take(10)
+                }
+            } ?: run {
+                val next = (current + 1).coerceAtMost(count)
+                val end = (current + 11).coerceAtMost(count)
+                val tail = (next until end).toList()
+                if (tail.size < 10 && activeController.repeatMode == Player.REPEAT_MODE_ALL) {
+                    (tail + (0 until (10 - tail.size).coerceAtMost(next))).take(10)
+                } else {
+                    tail
+                }
+            }
 
+            var replaced = false
             for (i in upcoming) {
                 if (i !in 0 until count) continue
                 val item = activeController.getMediaItemAt(i)
@@ -127,11 +143,12 @@ class DefaultPlaybackManager @Inject constructor(
                         .build()
                 }
                 activeController.replaceMediaItem(i, rebuilt)
+                replaced = true
             }
 
             // replaceMediaItem internally does remove+insert which corrupts ExoPlayer's
             // ShuffleOrder. Re-send our deterministic order to restore it.
-            if (shuffleDisplayOrder != null) {
+            if (replaced && shuffleDisplayOrder != null) {
                 sendShuffleOrderToService(activeController, activeController.mediaItemCount, shuffleSeed, shuffleAnchorIndex)
             }
         }

--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -95,8 +95,16 @@ class DefaultPlaybackManager @Inject constructor(
         withController { activeController ->
             val current = activeController.currentMediaItemIndex
             if (current == C.INDEX_UNSET) return@withController
-            val end = (current + 11).coerceAtMost(activeController.mediaItemCount)
-            for (i in (current + 1) until end) {
+            val count = activeController.mediaItemCount
+
+            val upcoming = shuffleDisplayOrder?.let { order ->
+                val pos = order.indexOf(current)
+                if (pos == -1) return@let null
+                order.drop(pos + 1).take(10)
+            } ?: ((current + 1) until (current + 11).coerceAtMost(count)).toList()
+
+            for (i in upcoming) {
+                if (i !in 0 until count) continue
                 val item = activeController.getMediaItemAt(i)
                 val request = item.toPlaybackRequestOrNull() ?: continue
                 if (request.isCached) continue
@@ -119,6 +127,12 @@ class DefaultPlaybackManager @Inject constructor(
                         .build()
                 }
                 activeController.replaceMediaItem(i, rebuilt)
+            }
+
+            // replaceMediaItem internally does remove+insert which corrupts ExoPlayer's
+            // ShuffleOrder. Re-send our deterministic order to restore it.
+            if (shuffleDisplayOrder != null) {
+                sendShuffleOrderToService(activeController, activeController.mediaItemCount, shuffleSeed, shuffleAnchorIndex)
             }
         }
     }


### PR DESCRIPTION
Closes #86, fixes #95

## Problem

Adaptive quality doesn't switch correctly in shuffle mode after network change. Two root causes:

### 1. Wrong rebuild indices (#86)

`rebuildUpcomingItems()` iterated physical indices `current+1..+10`, which in shuffle mode are **not** the next tracks to play. The actual next tracks (determined by `SakiShuffleOrder`) were never rebuilt.

### 2. `replaceMediaItem` corrupts ShuffleOrder (#86)

`replaceMediaItem()` internally does remove+insert, which calls `ShuffleOrder.cloneAndRemove().cloneAndInsert()`. Each replaced item gets appended to the **end** of the shuffle order. After 10 replacements, ExoPlayer's shuffle order is completely different from ours, so "next track" plays an un-rebuilt item.

### 3. CoverArtEndpointInterceptor crash (#95)

Network switch kills TCP connections, but OkHttp's connection pool holds stale ones. The interceptor's `chain.proceed()` throws `IllegalStateException` (not `IOException`), bypassing OkHttp's retry logic and crashing the app.

## Fix

- `rebuildUpcomingItems()` now follows `shuffleDisplayOrder` to find the correct next 10 tracks in shuffle mode
- After all `replaceMediaItem` calls, re-sends the deterministic `ShuffleOrder` to the service to restore the correct playback order
- `CoverArtEndpointInterceptor` wraps the rewritten request's `chain.proceed()` in try-catch, converting `IllegalStateException` to `IOException`

## Tested

- Shuffle + cellular → WiFi: next track plays at Original quality ✅
- Shuffle + WiFi → cellular: next track plays at 320kbps ✅
- Sequential playback: unchanged behavior ✅
- Network switch no longer crashes the app ✅