### PR TITLE
feat: resolve stream URLs at play time via ResolvingDataSource

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/DefaultPlaybackManager.kt
@@ -91,69 +91,6 @@ class DefaultPlaybackManager @Inject constructor(
         return if (cachedKey != null) StreamQuality.fromStorageKey(cachedKey) else preferred
     }
 
-    private suspend fun rebuildUpcomingItems() {
-        withController { activeController ->
-            val current = activeController.currentMediaItemIndex
-            if (current == C.INDEX_UNSET) return@withController
-            val count = activeController.mediaItemCount
-
-            val upcoming = shuffleDisplayOrder?.let { order ->
-                val pos = order.indexOf(current)
-                if (pos == -1) return@let null
-                val tail = order.drop(pos + 1)
-                // Wrap around for repeat-all so tracks after the end are also rebuilt
-                if (tail.size < 10 && activeController.repeatMode == Player.REPEAT_MODE_ALL) {
-                    (tail + order.take(10 - tail.size)).take(10)
-                } else {
-                    tail.take(10)
-                }
-            } ?: run {
-                val next = (current + 1).coerceAtMost(count)
-                val end = (current + 11).coerceAtMost(count)
-                val tail = (next until end).toList()
-                if (tail.size < 10 && activeController.repeatMode == Player.REPEAT_MODE_ALL) {
-                    (tail + (0 until (10 - tail.size).coerceAtMost(next))).take(10)
-                } else {
-                    tail
-                }
-            }
-
-            var replaced = false
-            for (i in upcoming) {
-                if (i !in 0 until count) continue
-                val item = activeController.getMediaItemAt(i)
-                val request = item.toPlaybackRequestOrNull() ?: continue
-                if (request.isCached) continue
-                val quality = resolveQualityForSong(request.serverId, request.songId)
-                if (quality.maxBitRate == request.maxBitRate) continue
-                val rebuilt = request.copy(
-                    qualityLabel = quality.label,
-                    streamCacheKey = streamCacheRepository.buildCacheKey(request.serverId, request.songId, quality),
-                    maxBitRate = quality.maxBitRate,
-                    format = quality.format,
-                ).let { updated ->
-                    MediaItem.Builder()
-                        .setMediaId(updated.songId)
-                        .setMediaMetadata(updated.toMediaMetadata())
-                        .setRequestMetadata(
-                            MediaItem.RequestMetadata.Builder()
-                                .setExtras(updated.toBundle())
-                                .build(),
-                        )
-                        .build()
-                }
-                activeController.replaceMediaItem(i, rebuilt)
-                replaced = true
-            }
-
-            // replaceMediaItem internally does remove+insert which corrupts ExoPlayer's
-            // ShuffleOrder. Re-send our deterministic order to restore it.
-            if (replaced && shuffleDisplayOrder != null) {
-                sendShuffleOrderToService(activeController, activeController.mediaItemCount, shuffleSeed, shuffleAnchorIndex)
-            }
-        }
-    }
-
     init {
         scope.launch {
             streamCacheRepository.observeCacheVersion().collect { if (it > 0L) cacheReady = true }
@@ -162,13 +99,6 @@ class DefaultPlaybackManager @Inject constructor(
             playbackPreferencesRepository.observePreferences().collect { preferences ->
                 mutablePlaybackState.update { state ->
                     state.copy(preferences = preferences)
-                }
-            }
-        }
-        scope.launch {
-            networkTypeProvider.networkType.collect { _ ->
-                if (playbackState.value.preferences.adaptiveQualityEnabled) {
-                    rebuildUpcomingItems()
                 }
             }
         }
@@ -559,17 +489,31 @@ class DefaultPlaybackManager @Inject constructor(
         }
 
         val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
-        val streamCached = currentRequest != null && !currentRequest.isCached &&
-            cacheReady &&
+        val cachedQualityKey = if (currentRequest != null && !currentRequest.isCached && cacheReady) {
             streamCacheRepository.findCachedQualityKey(
                 currentRequest.serverId, currentRequest.songId, effectiveQuality(),
-            ) != null
+            )
+        } else null
+        val streamCached = cachedQualityKey != null
 
         mutablePlaybackState.update { state ->
+            val currentDisplayItem = displayQueue.getOrNull(displayIndex)?.let { item ->
+                if (item.isCached) return@let item
+                if (state.preferences.adaptiveQualityEnabled) {
+                    val label = if (streamCached) {
+                        com.anzupop.saki.android.domain.model.StreamQuality.fromStorageKey(cachedQualityKey!!).label
+                    } else {
+                        effectiveQuality().label
+                    }
+                    item.copy(qualityLabel = label)
+                } else {
+                    item
+                }
+            }
             state.copy(
                 isConnected = true,
                 isPlaying = player.isPlaying,
-                currentItem = displayQueue.getOrNull(displayIndex),
+                currentItem = currentDisplayItem,
                 currentIndex = displayIndex,
                 queue = displayQueue,
                 positionMs = player.currentPosition.coerceKnownTime(),

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -166,6 +166,11 @@ class SakiPlaybackService : MediaSessionService() {
                 }
         }
 
+        // Keep playback prefs in memory for the non-suspend ResolvingDataSource resolver
+        playerScope.launch {
+            playbackPreferencesRepository.observePreferences().collect { cachedPlaybackPrefs = it }
+        }
+
         playerScope.launch {
             combine(
                 playbackPreferencesRepository.observePreferences()
@@ -216,6 +221,10 @@ class SakiPlaybackService : MediaSessionService() {
         }
     }
 
+    /** Latest playback preferences, kept in memory to avoid blocking reads in the resolver. */
+    @Volatile
+    private var cachedPlaybackPrefs: com.anzupop.saki.android.domain.model.PlaybackPreferences? = null
+
     /**
      * Resolves placeholder `saki://stream` URIs to real Subsonic stream URLs at the moment
      * ExoPlayer actually opens the data source. This ensures the quality and endpoint are
@@ -225,11 +234,13 @@ class SakiPlaybackService : MediaSessionService() {
         val uri = dataSpec.uri
         if (uri.scheme != "saki" || uri.host != "stream") return dataSpec
 
-        val serverId = uri.getQueryParameter("serverId")?.toLongOrNull() ?: return dataSpec
-        val songId = uri.getQueryParameter("songId") ?: return dataSpec
+        val serverId = uri.getQueryParameter("serverId")?.toLongOrNull()
+            ?: throw IOException("Missing serverId in stream placeholder URI")
+        val songId = uri.getQueryParameter("songId")
+            ?: throw IOException("Missing songId in stream placeholder URI")
 
-        // Resolve quality based on current network
-        val prefs = runBlocking { playbackPreferencesRepository.getPreferences() }
+        // Use cached prefs to avoid blocking; fall back to blocking read if not yet available
+        val prefs = cachedPlaybackPrefs ?: runBlocking { playbackPreferencesRepository.getPreferences() }
         val quality = if (prefs.adaptiveQualityEnabled) {
             val preferred = when (networkTypeProvider.networkType.value) {
                 com.anzupop.saki.android.data.remote.NetworkType.WIFI -> prefs.wifiStreamQuality
@@ -239,19 +250,16 @@ class SakiPlaybackService : MediaSessionService() {
             if (cachedKey != null) com.anzupop.saki.android.domain.model.StreamQuality.fromStorageKey(cachedKey) else preferred
         } else {
             val maxBitRate = uri.getQueryParameter("maxBitRate")?.toIntOrNull()
-            val format = uri.getQueryParameter("format")
-            if (maxBitRate != null || format != null) {
-                com.anzupop.saki.android.domain.model.StreamQuality.entries.find { it.maxBitRate == maxBitRate }
-                    ?: com.anzupop.saki.android.domain.model.StreamQuality.ORIGINAL
-            } else {
-                com.anzupop.saki.android.domain.model.StreamQuality.ORIGINAL
-            }
+            com.anzupop.saki.android.domain.model.StreamQuality.entries.find { it.maxBitRate == maxBitRate }
+                ?: com.anzupop.saki.android.domain.model.StreamQuality.ORIGINAL
         }
 
         val streamRequest = runBlocking {
             subsonicRepository.buildStreamRequest(serverId, songId, quality.maxBitRate, quality.format)
         }
-        if (streamRequest.candidates.isEmpty()) return dataSpec
+        if (streamRequest.candidates.isEmpty()) {
+            throw IOException("No stream candidates for song $songId on server $serverId")
+        }
 
         val realUrl = streamRequest.candidates.first().url
         val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, quality)
@@ -457,11 +465,10 @@ class SakiPlaybackService : MediaSessionService() {
                 return
             }
 
-            val replacement = activePlayer.currentMediaItem?.nextStreamCandidateOrNull() ?: return
+            // Re-prepare to retry — ResolvingDataSource will resolve the URL again,
+            // and EndpointSelector will have deprioritized the failed endpoint.
             val resumePositionMs = activePlayer.currentPosition.coerceAtLeast(0L)
             val wasPlaying = activePlayer.playWhenReady
-
-            activePlayer.replaceMediaItem(currentIndex, replacement)
             activePlayer.prepare()
             activePlayer.seekTo(currentIndex, resumePositionMs)
             activePlayer.playWhenReady = wasPlaying

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -10,7 +10,10 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import android.net.Uri
+import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.datasource.okhttp.OkHttpDataSource
@@ -47,6 +50,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 
 @AndroidEntryPoint
@@ -105,10 +109,13 @@ class SakiPlaybackService : MediaSessionService() {
             OkHttpDataSource.Factory(okHttpClient)
                 .setUserAgent(HTTP_USER_AGENT),
         )
-        val dataSourceFactory = CacheDataSource.Factory()
+        val cacheFactory = CacheDataSource.Factory()
             .setCache(streamCache)
             .setUpstreamDataSourceFactory(upstreamDataSourceFactory)
             .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+        val dataSourceFactory = ResolvingDataSource.Factory(cacheFactory) { dataSpec ->
+            resolveStreamDataSpec(dataSpec)
+        }
 
         val exoPlayer = ExoPlayer.Builder(this)
             .setAudioAttributes(audioAttributes, true)
@@ -207,6 +214,52 @@ class SakiPlaybackService : MediaSessionService() {
                     }
                 }
         }
+    }
+
+    /**
+     * Resolves placeholder `saki://stream` URIs to real Subsonic stream URLs at the moment
+     * ExoPlayer actually opens the data source. This ensures the quality and endpoint are
+     * determined by the current network state, not the queue build time.
+     */
+    private fun resolveStreamDataSpec(dataSpec: DataSpec): DataSpec {
+        val uri = dataSpec.uri
+        if (uri.scheme != "saki" || uri.host != "stream") return dataSpec
+
+        val serverId = uri.getQueryParameter("serverId")?.toLongOrNull() ?: return dataSpec
+        val songId = uri.getQueryParameter("songId") ?: return dataSpec
+
+        // Resolve quality based on current network
+        val prefs = runBlocking { playbackPreferencesRepository.getPreferences() }
+        val quality = if (prefs.adaptiveQualityEnabled) {
+            val preferred = when (networkTypeProvider.networkType.value) {
+                com.anzupop.saki.android.data.remote.NetworkType.WIFI -> prefs.wifiStreamQuality
+                com.anzupop.saki.android.data.remote.NetworkType.MOBILE -> prefs.mobileStreamQuality
+            }
+            val cachedKey = streamCacheRepository.findCachedQualityKey(serverId, songId, preferred)
+            if (cachedKey != null) com.anzupop.saki.android.domain.model.StreamQuality.fromStorageKey(cachedKey) else preferred
+        } else {
+            val maxBitRate = uri.getQueryParameter("maxBitRate")?.toIntOrNull()
+            val format = uri.getQueryParameter("format")
+            if (maxBitRate != null || format != null) {
+                com.anzupop.saki.android.domain.model.StreamQuality.entries.find { it.maxBitRate == maxBitRate }
+                    ?: com.anzupop.saki.android.domain.model.StreamQuality.ORIGINAL
+            } else {
+                com.anzupop.saki.android.domain.model.StreamQuality.ORIGINAL
+            }
+        }
+
+        val streamRequest = runBlocking {
+            subsonicRepository.buildStreamRequest(serverId, songId, quality.maxBitRate, quality.format)
+        }
+        if (streamRequest.candidates.isEmpty()) return dataSpec
+
+        val realUrl = streamRequest.candidates.first().url
+        val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, quality)
+
+        return dataSpec.buildUpon()
+            .setUri(realUrl)
+            .setKey(cacheKey)
+            .build()
     }
 
     override fun onGetSession(
@@ -348,28 +401,17 @@ class SakiPlaybackService : MediaSessionService() {
                 "Missing Subsonic playback request metadata for ${mediaItem.mediaId}"
             }
 
-            // Resolve effective quality at play time for adaptive quality
-            val prefs = playbackPreferencesRepository.getPreferences()
-            val effectiveQuality = if (prefs.adaptiveQualityEnabled) {
-                val preferred = when (networkTypeProvider.networkType.value) {
-                    com.anzupop.saki.android.data.remote.NetworkType.WIFI -> prefs.wifiStreamQuality
-                    com.anzupop.saki.android.data.remote.NetworkType.MOBILE -> prefs.mobileStreamQuality
+            // Build placeholder URI — real stream URL resolved at play time by ResolvingDataSource
+            val placeholderUri = Uri.Builder()
+                .scheme("saki")
+                .authority("stream")
+                .appendQueryParameter("serverId", request.serverId.toString())
+                .appendQueryParameter("songId", request.songId)
+                .apply {
+                    request.maxBitRate?.let { appendQueryParameter("maxBitRate", it.toString()) }
+                    request.format?.let { appendQueryParameter("format", it) }
                 }
-                val cachedKey = streamCacheRepository.findCachedQualityKey(request.serverId, request.songId, preferred)
-                if (cachedKey != null) com.anzupop.saki.android.domain.model.StreamQuality.fromStorageKey(cachedKey) else preferred
-            } else {
-                null
-            }
-
-            val maxBitRate = effectiveQuality?.maxBitRate ?: request.maxBitRate
-            val format = effectiveQuality?.format ?: request.format
-
-            val streamRequest = subsonicRepository.buildStreamRequest(
-                serverId = request.serverId,
-                songId = request.songId,
-                maxBitRate = maxBitRate,
-                format = format,
-            )
+                .build()
 
             // Resolve artwork URL if missing (queue was built without it for performance)
             val resolvedArtworkUri = request.artworkUri ?: request.coverArtId?.let { coverArtId ->
@@ -378,24 +420,24 @@ class SakiPlaybackService : MediaSessionService() {
                         .candidates.firstOrNull()?.url
                 }.getOrNull()
             }
-            val artworkRequest = if (resolvedArtworkUri != null && request.artworkUri == null) {
+            val finalRequest = if (resolvedArtworkUri != null && request.artworkUri == null) {
                 request.copy(artworkUri = resolvedArtworkUri)
             } else {
                 request
             }
 
-            val finalRequest = if (effectiveQuality != null && effectiveQuality.maxBitRate != artworkRequest.maxBitRate) {
-                artworkRequest.copy(
-                    qualityLabel = effectiveQuality.label,
-                    maxBitRate = effectiveQuality.maxBitRate,
-                    format = effectiveQuality.format,
-                    streamCacheKey = streamCacheRepository.buildCacheKey(artworkRequest.serverId, artworkRequest.songId, effectiveQuality),
+            return MediaItem.Builder()
+                .setMediaId(finalRequest.songId)
+                .setUri(placeholderUri)
+                .setMimeType(finalRequest.mimeType)
+                .setMediaMetadata(finalRequest.toMediaMetadata())
+                .setRequestMetadata(
+                    MediaItem.RequestMetadata.Builder()
+                        .setMediaUri(placeholderUri)
+                        .setExtras(finalRequest.toBundle())
+                        .build(),
                 )
-            } else {
-                artworkRequest
-            }
-
-            return finalRequest.toPlayableMediaItem(streamRequest)
+                .build()
         }
     }
 

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -85,6 +85,9 @@ class SakiPlaybackService : MediaSessionService() {
     @Inject
     lateinit var streamCacheRepository: com.anzupop.saki.android.domain.repository.StreamCacheRepository
 
+    @Inject
+    lateinit var endpointSelector: com.anzupop.saki.android.data.remote.EndpointSelector
+
     private val serviceScope = CoroutineScope(SupervisorJob())
     private val playerScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
@@ -250,8 +253,25 @@ class SakiPlaybackService : MediaSessionService() {
             if (cachedKey != null) com.anzupop.saki.android.domain.model.StreamQuality.fromStorageKey(cachedKey) else preferred
         } else {
             val maxBitRate = uri.getQueryParameter("maxBitRate")?.toIntOrNull()
-            com.anzupop.saki.android.domain.model.StreamQuality.entries.find { it.maxBitRate == maxBitRate }
+            val format = uri.getQueryParameter("format")
+            val matched = com.anzupop.saki.android.domain.model.StreamQuality.entries.find { it.maxBitRate == maxBitRate }
                 ?: com.anzupop.saki.android.domain.model.StreamQuality.ORIGINAL
+            // If the placeholder has a specific format, pass it through to buildStreamRequest
+            if (format != null && format != matched.format) {
+                // Use maxBitRate/format directly instead of going through StreamQuality enum
+                val streamRequest = runBlocking {
+                    subsonicRepository.buildStreamRequest(serverId, songId, maxBitRate, format)
+                }
+                if (streamRequest.candidates.isEmpty()) {
+                    throw IOException("No stream candidates for song $songId on server $serverId")
+                }
+                val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, matched)
+                return dataSpec.buildUpon()
+                    .setUri(streamRequest.candidates.first().url)
+                    .setKey(cacheKey)
+                    .build()
+            }
+            matched
         }
 
         val streamRequest = runBlocking {
@@ -465,8 +485,15 @@ class SakiPlaybackService : MediaSessionService() {
                 return
             }
 
-            // Re-prepare to retry — ResolvingDataSource will resolve the URL again,
-            // and EndpointSelector will have deprioritized the failed endpoint.
+            // Invalidate the failed endpoint so the resolver picks a different one on retry
+            val request = activePlayer.currentMediaItem?.toPlaybackRequestOrNull()
+            if (request != null) {
+                val activeEndpointId = endpointSelector.getActiveEndpointId(request.serverId)
+                if (activeEndpointId != null) {
+                    endpointSelector.invalidate(request.serverId, activeEndpointId)
+                }
+            }
+
             val resumePositionMs = activePlayer.currentPosition.coerceAtLeast(0L)
             val wasPlaying = activePlayer.playWhenReady
             activePlayer.prepare()


### PR DESCRIPTION
Closes #86

## Problem

Adaptive quality doesn't switch correctly after network change, especially in shuffle mode. See #86 and the investigation in #97 for full details.

### Root cause

Stream URLs (with baked-in `maxBitRate` parameter) were resolved once at queue build time in `onAddMediaItems`. After a network switch, the only way to update them was `replaceMediaItem`, which internally does remove+insert and **corrupts ExoPlayer's ShuffleOrder** in shuffle mode. The previous fix (#96) attempted to resync ShuffleOrder after replacement, but the async IPC timing made this unreliable.

## Solution

Move URL resolution from queue build time to **play time** using Media3's `ResolvingDataSource`.

### How it works

1. `resolvePlayableItem` now builds a **placeholder URI** (`saki://stream?serverId=1&songId=abc`) instead of a real stream URL
2. `ResolvingDataSource.Resolver` intercepts these placeholders when ExoPlayer actually opens the data source, resolving them to real Subsonic stream URLs based on the **current** network type
3. `CacheDataSource` sits inside `ResolvingDataSource`, so cache lookups use the resolved URL and cache key

### Pipeline

```
ResolvingDataSource (placeholder → real URL + cache key)
  → CacheDataSource (cache lookup with correct key)
    → OkHttp (on cache miss)
```

### What's removed

- `rebuildUpcomingItems()` — no longer needed, quality is resolved at play time
- `networkType` collector in `DefaultPlaybackManager.init` — no longer needed
- All `replaceMediaItem` calls for quality updates — no playlist manipulation needed

### UI quality label

`syncState` now derives the quality label from:
- `effectiveQuality()` for streaming songs (reflects current network)
- Actual cached quality key for stream-cached songs (shows what's really cached)
- Original `qualityLabel` for downloaded songs

## Related

- #86 — Original bug report
- #96 — Previous fix attempt (shuffle index + ShuffleOrder resync) — merged but insufficient
- #95 — CoverArtEndpointInterceptor crash (fixed in #96)

## Tested

- Shuffle + WiFi → cellular → skip next: quality switches to 320kbps ✅
- Shuffle + cellular → WiFi → skip next: quality switches to Original ✅
- Sequential playback: same behavior ✅
- Stream cache: songs cache correctly, show correct cached quality ✅
- Cached songs on different network: show cached quality, not network quality ✅