### PR TITLE
fix: seek bar no longer fights with playback progress during drag

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -322,9 +322,12 @@ fun NowPlayingOverlay(
         var sliderValue by remember(track.songId) {
             mutableFloatStateOf(playbackState.positionMs.toFloat())
         }
+        var isDragging by remember { mutableStateOf(false) }
 
         LaunchedEffect(playbackState.positionMs, track.songId) {
-            sliderValue = playbackState.positionMs.toFloat()
+            if (!isDragging) {
+                sliderValue = playbackState.positionMs.toFloat()
+            }
         }
 
         // Artwork pager state synced with playback queue
@@ -569,8 +572,8 @@ fun NowPlayingOverlay(
                     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
                     Slider(
                         value = sliderValue.coerceIn(0f, duration),
-                        onValueChange = { sliderValue = it },
-                        onValueChangeFinished = { onSeekTo(sliderValue.roundToLong()) },
+                        onValueChange = { isDragging = true; sliderValue = it },
+                        onValueChangeFinished = { isDragging = false; onSeekTo(sliderValue.roundToLong()) },
                         valueRange = 0f..duration,
                         colors = sliderColors,
                         modifier = if (!isCachedTrack) {

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -322,7 +322,7 @@ fun NowPlayingOverlay(
         var sliderValue by remember(track.songId) {
             mutableFloatStateOf(playbackState.positionMs.toFloat())
         }
-        var isDragging by remember { mutableStateOf(false) }
+        var isDragging by remember(track.songId) { mutableStateOf(false) }
 
         LaunchedEffect(playbackState.positionMs, track.songId) {
             if (!isDragging) {
@@ -572,8 +572,14 @@ fun NowPlayingOverlay(
                     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
                     Slider(
                         value = sliderValue.coerceIn(0f, duration),
-                        onValueChange = { isDragging = true; sliderValue = it },
-                        onValueChangeFinished = { isDragging = false; onSeekTo(sliderValue.roundToLong()) },
+                        onValueChange = {
+                            isDragging = true
+                            sliderValue = it
+                        },
+                        onValueChangeFinished = {
+                            isDragging = false
+                            onSeekTo(sliderValue.roundToLong())
+                        },
                         valueRange = 0f..duration,
                         colors = sliderColors,
                         modifier = if (!isCachedTrack) {


### PR DESCRIPTION
Closes #103

The seek bar slider value was bound to `positionMs` via a `LaunchedEffect` that fired continuously — even while the user was dragging. This caused the thumb to jump between the drag position and the real playback position.

Fix: add an `isDragging` flag that suppresses position updates during drag. Set on `onValueChange`, cleared on `onValueChangeFinished`.