### PR TITLE
fix: Now Playing album/artist tap navigates correctly from Settings

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiApp.kt
@@ -331,12 +331,14 @@ private fun RootShell(
             onDismiss = onDismissNowPlaying,
             canOpenArtist = canOpenArtistFromNowPlaying,
             onOpenArtist = {
-                onDismissNowPlaying()
+                showSettings = false
                 onOpenArtistFromPlayback(track.serverId, track.artistId)
+                onDismissNowPlaying()
             },
             onOpenAlbum = {
-                onDismissNowPlaying()
+                showSettings = false
                 onOpenAlbumFromPlayback(track.serverId, track.albumId)
+                onDismissNowPlaying()
             },
             onPlayPause = {
                 if (uiState.playbackState.isPlaying) onPausePlayback() else onResumePlayback()


### PR DESCRIPTION
Closes #99

## Problem

When opening Now Playing from Settings and tapping album/artist, the user was navigated back to Settings instead of the detail page. This happened because `showSettings` was never set to `false`, so `BrowseScreen` (which renders album/artist detail) was not displayed.

## Fix

In the `onOpenAlbum` and `onOpenArtist` callbacks of `NowPlayingOverlay`:
1. Set `showSettings = false` to switch underlying screen to Browse
2. Set the target album/artist state
3. Dismiss Now Playing overlay **last**

This ordering ensures the bottom screen is already showing the correct detail page when the overlay animates away — single smooth transition instead of two visible steps.

## Scope

Scanned all navigation callbacks from Now Playing and other overlays. Only album and artist taps are affected — queue sheet, lyrics, song details, and endpoint status have no outbound navigation.