### PR TITLE
feat: locale-aware artist sorting with alphabet index scroll bar

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/domain/model/ArtistGrouping.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/model/ArtistGrouping.kt
@@ -1,0 +1,43 @@
+package com.anzupop.saki.android.domain.model
+
+import android.icu.text.AlphabeticIndex
+import java.util.Locale
+
+/**
+ * Re-groups artists from server-provided sections into locale-aware buckets
+ * using [AlphabeticIndex]. This correctly handles CJK (pinyin/kana/jamo),
+ * Latin with diacritics, Cyrillic, and other scripts.
+ */
+fun LibraryIndexes.regroupByLocale(locale: Locale = Locale.getDefault()): LibraryIndexes {
+    val allArtists = sections.flatMap { it.artists }
+    if (allArtists.isEmpty()) return this
+
+    val index = AlphabeticIndex<Nothing>(locale)
+        .addLabels(Locale.ENGLISH)
+        .addLabels(Locale.JAPANESE)
+        .addLabels(Locale.CHINESE)
+        .addLabels(Locale.KOREAN)
+        .setOverflowLabel("#")
+        .setUnderflowLabel("#")
+
+    val immutable = index.buildImmutableIndex()
+
+    val bucketArtists = Array(immutable.bucketCount) { mutableListOf<ArtistSummary>() }
+    val bucketLabels = Array(immutable.bucketCount) { immutable.getBucket(it).label }
+
+    allArtists.forEach { artist ->
+        val idx = immutable.getBucketIndex(artist.name)
+        bucketArtists[idx].add(artist)
+    }
+
+    // Merge buckets with the same label (e.g. underflow "#" and overflow "#")
+    val merged = linkedMapOf<String, MutableList<ArtistSummary>>()
+    bucketLabels.indices.forEach { i ->
+        if (bucketArtists[i].isNotEmpty()) {
+            merged.getOrPut(bucketLabels[i]) { mutableListOf() }.addAll(bucketArtists[i])
+        }
+    }
+
+    val newSections = merged.map { (label, artists) -> ArtistSection(name = label, artists = artists) }
+    return copy(sections = newSections)
+}

--- a/app/src/main/java/com/anzupop/saki/android/domain/model/ArtistGrouping.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/model/ArtistGrouping.kt
@@ -1,6 +1,7 @@
 package com.anzupop.saki.android.domain.model
 
 import android.icu.text.AlphabeticIndex
+import java.text.Collator
 import java.util.Locale
 
 /**
@@ -11,6 +12,24 @@ import java.util.Locale
 fun LibraryIndexes.regroupByLocale(locale: Locale = Locale.getDefault()): LibraryIndexes {
     val allArtists = sections.flatMap { it.artists }
     if (allArtists.isEmpty()) return this
+
+    // Build sort key by stripping ignored articles (e.g. "The", "A", "An")
+    val articles = ignoredArticles?.split(' ')
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?: emptyList()
+
+    fun sortName(name: String): String {
+        for (article in articles) {
+            if (name.startsWith(article, ignoreCase = true) &&
+                name.length > article.length &&
+                name[article.length] == ' '
+            ) {
+                return name.substring(article.length + 1)
+            }
+        }
+        return name
+    }
 
     val index = AlphabeticIndex<Nothing>(locale)
         .addLabels(Locale.ENGLISH)
@@ -26,8 +45,14 @@ fun LibraryIndexes.regroupByLocale(locale: Locale = Locale.getDefault()): Librar
     val bucketLabels = Array(immutable.bucketCount) { immutable.getBucket(it).label }
 
     allArtists.forEach { artist ->
-        val idx = immutable.getBucketIndex(artist.name)
+        val idx = immutable.getBucketIndex(sortName(artist.name))
         bucketArtists[idx].add(artist)
+    }
+
+    // Sort within each bucket using locale-aware collation
+    val collator = Collator.getInstance(locale)
+    bucketArtists.forEach { list ->
+        list.sortWith(compareBy(collator) { sortName(it.name) })
     }
 
     // Merge buckets with the same label (e.g. underflow "#" and overflow "#")

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -850,7 +850,7 @@ class SakiAppViewModel @Inject constructor(
 
             val artists = loadCachedOrNull { libraryCacheRepository.getArtists(serverId) }
             if (artists != null && uiState.value.selectedServerId == serverId) {
-                mutableUiState.update { it.copy(libraryIndexes = artists) }
+                mutableUiState.update { it.copy(libraryIndexes = artists.regroupByLocale()) }
             }
             val selectedAlbumFeed = uiState.value.selectedAlbumFeed
             val albums = loadCachedOrNull { libraryCacheRepository.getAlbums(serverId, selectedAlbumFeed) }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/SakiAppViewModel.kt
@@ -13,6 +13,7 @@ import com.anzupop.saki.android.domain.model.Artist
 import com.anzupop.saki.android.domain.model.CacheStorageSummary
 import com.anzupop.saki.android.domain.model.CachedSong
 import com.anzupop.saki.android.domain.model.LibraryIndexes
+import com.anzupop.saki.android.domain.model.regroupByLocale
 import com.anzupop.saki.android.domain.model.PlaybackSessionState
 import com.anzupop.saki.android.domain.model.Playlist
 import com.anzupop.saki.android.domain.model.PlaylistSummary
@@ -890,20 +891,20 @@ class SakiAppViewModel @Inject constructor(
         if (!forceRefresh && uiState.value.libraryIndexes != null) return
 
         viewModelScope.launch {
+            mutableUiState.update { it.copy(isArtistsLoading = true, artistsError = null) }
+
             if (!forceRefresh) {
                 val cached = runCatching { libraryCacheRepository.getArtists(serverId) }.getOrNull()
                 if (cached != null && uiState.value.selectedServerId == serverId) {
-                    mutableUiState.update { it.copy(libraryIndexes = cached) }
+                    mutableUiState.update { it.copy(libraryIndexes = cached.regroupByLocale()) }
                 }
             }
-
-            mutableUiState.update { it.copy(isArtistsLoading = true, artistsError = null) }
 
             runCatching {
                 subsonicRepository.getIndexes(serverId).data
             }.onSuccess { indexes ->
                 if (uiState.value.selectedServerId == serverId) {
-                    mutableUiState.update { it.copy(libraryIndexes = indexes, isArtistsLoading = false, artistsError = null) }
+                    mutableUiState.update { it.copy(libraryIndexes = indexes.regroupByLocale(), isArtistsLoading = false, artistsError = null) }
                 }
                 runCatching { libraryCacheRepository.saveArtists(serverId, indexes) }
                     .onFailure { Log.w("SakiApp", "Failed to cache artists", it) }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -849,6 +850,14 @@ private fun AlphabetScrollBar(
     Column(
         modifier = modifier
             .fillMaxHeight()
+            .pointerInput(labels) {
+                detectTapGestures { offset ->
+                    val idx = (offset.y / (size.height.toFloat() / labels.size))
+                        .toInt()
+                        .coerceIn(0, labels.lastIndex)
+                    onScrollTo(idx)
+                }
+            }
             .pointerInput(labels) {
                 detectVerticalDragGestures(
                     onDragStart = { offset ->

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,12 +15,14 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -51,6 +54,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -58,8 +62,10 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.anzupop.saki.android.domain.model.AlbumListType
 import com.anzupop.saki.android.domain.model.CachedSong
 import com.anzupop.saki.android.domain.model.SearchResults
@@ -69,6 +75,7 @@ import com.anzupop.saki.android.presentation.BrowseSection
 import com.anzupop.saki.android.presentation.rememberBrowseBackgroundBrush
 import com.anzupop.saki.android.presentation.SakiAppUiState
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 
@@ -582,27 +589,90 @@ private fun ArtistsPage(
         return
     }
 
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 24.dp),
-    ) {
-        if (indexes.shortcuts.isNotEmpty()) {
-            item { SectionTitle("Shortcuts", "Pinned artists") }
-            item {
-                LazyRow {
-                    items(indexes.shortcuts, key = { it.id }) { artist ->
-                        ArtistShortcutCard(artist = artist, onOpenArtist = onOpenArtist)
-                    }
+    // Build section-to-item-index mapping for scroll bar
+    val nonEmptySections = remember(indexes) { indexes.sections.filter { it.artists.isNotEmpty() } }
+    // Scroll bar: # A-Z, plus … for any non-Latin sections
+    val scrollBarMapping = remember(nonEmptySections) {
+        val result = mutableListOf<Pair<String, Int>>()
+        var hasOther = false
+        var firstOtherIdx = -1
+        nonEmptySections.forEachIndexed { idx, section ->
+            val name = section.name
+            when {
+                name.length == 1 && name[0] in 'A'..'Z' -> result.add(name to idx)
+                name == "#" -> result.add(0, "#" to idx) // # always first
+                else -> {
+                    if (!hasOther) { firstOtherIdx = idx; hasOther = true }
                 }
             }
         }
-        indexes.sections.forEach { section ->
-            if (section.artists.isNotEmpty()) {
+        if (hasOther) result.add("…" to firstOtherIdx)
+        result
+    }
+    val visibleScrollLabels = remember(scrollBarMapping) { scrollBarMapping.map { it.first } }
+    val scrollLabelToSection = remember(scrollBarMapping) { scrollBarMapping.toMap() }
+    val sectionItemIndices = remember(indexes, nonEmptySections) {
+        val map = mutableMapOf<Int, Int>()
+        var itemIndex = if (indexes.shortcuts.isNotEmpty()) 2 else 0 // shortcuts title + row
+        nonEmptySections.forEachIndexed { sectionIdx, section ->
+            map[sectionIdx] = itemIndex
+            itemIndex += 1 + section.artists.size // section title + artists
+        }
+        map
+    }
+
+    val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+    val haptic = LocalHapticFeedback.current
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = 24.dp, end = 24.dp),
+        ) {
+            if (indexes.shortcuts.isNotEmpty()) {
+                item { SectionTitle("Shortcuts", "Pinned artists") }
+                item {
+                    LazyRow {
+                        items(indexes.shortcuts, key = { it.id }) { artist ->
+                            ArtistShortcutCard(artist = artist, onOpenArtist = onOpenArtist)
+                        }
+                    }
+                }
+            }
+            nonEmptySections.forEach { section ->
                 item { SectionTitle(section.name, "${section.artists.size} ${if (section.artists.size == 1) "artist" else "artists"}") }
                 items(section.artists, key = { it.id }) { artist ->
                     ArtistRow(artist = artist, onOpenArtist = onOpenArtist)
                 }
             }
+        }
+
+        var showScrollBar by remember { mutableStateOf(false) }
+        LaunchedEffect(Unit) {
+            kotlinx.coroutines.delay(500)
+            showScrollBar = true
+        }
+
+        androidx.compose.animation.AnimatedVisibility(
+            visible = showScrollBar && visibleScrollLabels.size > 1,
+            enter = androidx.compose.animation.fadeIn(),
+            exit = androidx.compose.animation.fadeOut(),
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(vertical = 8.dp),
+        ) {
+            AlphabetScrollBar(
+                labels = visibleScrollLabels,
+                onScrollTo = { idx ->
+                    val label = visibleScrollLabels.getOrNull(idx) ?: return@AlphabetScrollBar
+                    val sectionIdx = scrollLabelToSection[label] ?: return@AlphabetScrollBar
+                    val itemIdx = sectionItemIndices[sectionIdx] ?: return@AlphabetScrollBar
+                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    coroutineScope.launch { listState.scrollToItem(itemIdx) }
+                },
+            )
         }
     }
 }
@@ -767,3 +837,56 @@ private val AlbumListType.displayLabel: String
         AlbumListType.BY_YEAR -> "By year"
         AlbumListType.BY_GENRE -> "By genre"
     }
+
+@Composable
+private fun AlphabetScrollBar(
+    labels: List<String>,
+    onScrollTo: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var activeIndex by remember { mutableStateOf(-1) }
+
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .pointerInput(labels) {
+                detectVerticalDragGestures(
+                    onDragStart = { offset ->
+                        val idx = (offset.y / (size.height.toFloat() / labels.size))
+                            .toInt()
+                            .coerceIn(0, labels.lastIndex)
+                        activeIndex = idx
+                        onScrollTo(idx)
+                    },
+                    onDragEnd = { activeIndex = -1 },
+                    onDragCancel = { activeIndex = -1 },
+                    onVerticalDrag = { change, _ ->
+                        val idx = (change.position.y / (size.height.toFloat() / labels.size))
+                            .toInt()
+                            .coerceIn(0, labels.lastIndex)
+                        if (idx != activeIndex) {
+                            activeIndex = idx
+                            onScrollTo(idx)
+                        }
+                    },
+                )
+            }
+            .padding(horizontal = 4.dp),
+        verticalArrangement = Arrangement.SpaceEvenly,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        val fontSize = if (labels.size > 30) 8.sp else 10.sp
+        labels.forEachIndexed { index, label ->
+            Text(
+                text = label,
+                fontSize = fontSize,
+                lineHeight = fontSize,
+                color = if (index == activeIndex) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #101

## Problem

The Subsonic server groups artists by ASCII letters only — non-ASCII artists (CJK, Cyrillic, etc.) are all dumped into the `#` section.

## Solution

### Locale-aware regrouping (`ArtistGrouping.kt`)

Client-side re-grouping using `android.icu.text.AlphabeticIndex`:
- Chinese characters → grouped by pinyin initial (A-Z)
- Japanese characters → grouped by kana (あかさたな...)
- Korean characters → grouped by jamo (ㄱㄴㄷ...)
- Latin with diacritics → grouped under base letter (É→E)
- Numbers/symbols → `#`

Labels for English, Japanese, Chinese, and Korean are always added to ensure proper bucket coverage.

### Alphabet scroll bar

Vertical scroll bar on the right edge of the Artists page:
- Displays `#`, `A-Z` (only letters with content), and `…` (for non-Latin sections)
- Tap or drag to jump to the corresponding section
- Haptic feedback on each section change
- 500ms delayed appearance to avoid flash during cache→server data transition
- `SpaceEvenly` layout with adaptive font size for different screen sizes

### Future: multi-locale scroll bar

The architecture supports extending the scroll bar to show locale-specific labels (e.g., あかさた for Japanese). The scroll bar label generation is isolated in `scrollBarMapping` — only that logic needs to change. See also i18n tracking.

## Files changed

- `ArtistGrouping.kt` — new `regroupByLocale()` extension on `LibraryIndexes`
- `SakiAppViewModel.kt` — apply `regroupByLocale()` to both cached and fresh data
- `BrowseScreen.kt` — `AlphabetScrollBar` composable + integration in `ArtistsPage`