### PR TITLE
fix: detect stream cache for transcoded streams without Content-Length

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultStreamCacheRepository.kt
+++ b/app/src/main/java/com/anzupop/saki/android/data/repository/DefaultStreamCacheRepository.kt
@@ -146,7 +146,15 @@ class DefaultStreamCacheRepository @Inject constructor(
             bytesByServer[parsed.serverId] = (bytesByServer[parsed.serverId] ?: 0L) + cachedBytes
 
             val contentLength = ContentMetadata.getContentLength(streamCache.getContentMetadata(key))
-            if (contentLength != C.LENGTH_UNSET.toLong() && contentLength > 0L && streamCache.isCached(key, 0, contentLength)) {
+            val isFullyCached = if (contentLength != C.LENGTH_UNSET.toLong() && contentLength > 0L) {
+                streamCache.isCached(key, 0, contentLength)
+            } else {
+                // No Content-Length (e.g. transcoded stream): consider cached if there is
+                // a single contiguous span starting at 0 with meaningful size
+                val spans = streamCache.getCachedSpans(key)
+                spans.size == 1 && spans.first().position == 0L && cachedBytes > 0L
+            }
+            if (isFullyCached) {
                 cachedSongIdsByServerAndQuality
                     .getOrPut(parsed.serverId) { mutableMapOf() }
                     .getOrPut(parsed.qualityKey) { mutableSetOf() }


### PR DESCRIPTION
Closes #109

## Problem

Transcoded streams (320 kbps, 256 kbps, etc.) were never detected as stream-cached. The UI never showed "Cached" for these tracks, `findCachedQualityKey()` couldn't find them, and the stream cache count in Settings was undercounted.

## Root cause

`buildSnapshot()` required a known `Content-Length` to verify full caching via `isCached(key, 0, contentLength)`. Subsonic uses chunked transfer encoding for transcoded streams — no Content-Length header — so the check was always skipped.

## Fix

When Content-Length is unknown, fall back to checking if the cache has a single contiguous span starting at position 0 with non-zero size. This indicates the entire stream was written sequentially and completely.

One file changed, 9 insertions.