### PR TITLE
fix: notification artwork resilient to network/endpoint changes

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/playback/CoilBitmapLoader.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/CoilBitmapLoader.kt
@@ -1,0 +1,80 @@
+package com.anzupop.saki.android.playback
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.BitmapLoader
+import coil3.SingletonImageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.toBitmap
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * A [BitmapLoader] that uses Coil to load artwork bitmaps. This ensures notification
+ * artwork goes through our OkHttp pipeline (including [CoverArtEndpointInterceptor]),
+ * so artwork loads correctly after network/endpoint changes.
+ */
+@UnstableApi
+class CoilBitmapLoader(private val context: Context) : BitmapLoader {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val bitmapCache = android.util.LruCache<String, Bitmap>(20)
+
+    override fun supportsMimeType(mimeType: String): Boolean = mimeType.startsWith("image/")
+
+    override fun decodeBitmap(data: ByteArray): ListenableFuture<Bitmap> {
+        val future = SettableFuture.create<Bitmap>()
+        try {
+            val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size)
+            if (bitmap != null) future.set(bitmap) else future.setException(IllegalArgumentException("Failed to decode bitmap"))
+        } catch (e: Exception) {
+            future.setException(e)
+        }
+        return future
+    }
+
+    override fun loadBitmap(uri: Uri): ListenableFuture<Bitmap> {
+        val key = uri.toString()
+        bitmapCache.get(key)?.let { return Futures.immediateFuture(it) }
+
+        val future = SettableFuture.create<Bitmap>()
+        scope.launch {
+            try {
+                val bitmap = loadWithCoil(key) ?: run {
+                    // Retry once after a short delay — EndpointSelector may need time to reprobe
+                    kotlinx.coroutines.delay(2000)
+                    loadWithCoil(key)
+                }
+                if (bitmap != null) {
+                    bitmapCache.put(key, bitmap)
+                    future.set(bitmap)
+                } else {
+                    future.setException(IllegalStateException("Coil failed to load $uri"))
+                }
+            } catch (e: Exception) {
+                future.setException(e)
+            }
+        }
+        return future
+    }
+
+    private suspend fun loadWithCoil(url: String): Bitmap? {
+        val result = SingletonImageLoader.get(context)
+            .execute(
+                ImageRequest.Builder(context)
+                    .data(url)
+                    .size(600)
+                    .build(),
+            )
+        return if (result is SuccessResult) result.image.toBitmap() else null
+    }
+}

--- a/app/src/main/java/com/anzupop/saki/android/playback/CoilBitmapLoader.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/CoilBitmapLoader.kt
@@ -15,7 +15,10 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
@@ -24,22 +27,27 @@ import kotlinx.coroutines.launch
  * so artwork loads correctly after network/endpoint changes.
  */
 @UnstableApi
-class CoilBitmapLoader(private val context: Context) : BitmapLoader {
+class CoilBitmapLoader(context: Context) : BitmapLoader {
 
+    private val appContext = context.applicationContext
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private val bitmapCache = android.util.LruCache<String, Bitmap>(20)
+
+    // Cache sized by memory (max 8 MB), not entry count
+    private val bitmapCache = object : android.util.LruCache<String, Bitmap>(8 * 1024 * 1024) {
+        override fun sizeOf(key: String, value: Bitmap): Int = value.byteCount
+    }
+
+    fun release() { scope.cancel() }
 
     override fun supportsMimeType(mimeType: String): Boolean = mimeType.startsWith("image/")
 
     override fun decodeBitmap(data: ByteArray): ListenableFuture<Bitmap> {
-        val future = SettableFuture.create<Bitmap>()
-        try {
-            val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size)
-            if (bitmap != null) future.set(bitmap) else future.setException(IllegalArgumentException("Failed to decode bitmap"))
-        } catch (e: Exception) {
-            future.setException(e)
+        val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size)
+        return if (bitmap != null) {
+            Futures.immediateFuture(bitmap)
+        } else {
+            Futures.immediateFailedFuture(IllegalArgumentException("Failed to decode bitmap"))
         }
-        return future
     }
 
     override fun loadBitmap(uri: Uri): ListenableFuture<Bitmap> {
@@ -47,30 +55,27 @@ class CoilBitmapLoader(private val context: Context) : BitmapLoader {
         bitmapCache.get(key)?.let { return Futures.immediateFuture(it) }
 
         val future = SettableFuture.create<Bitmap>()
-        scope.launch {
-            try {
-                val bitmap = loadWithCoil(key) ?: run {
-                    // Retry once after a short delay — EndpointSelector may need time to reprobe
-                    kotlinx.coroutines.delay(2000)
-                    loadWithCoil(key)
-                }
-                if (bitmap != null) {
-                    bitmapCache.put(key, bitmap)
-                    future.set(bitmap)
-                } else {
-                    future.setException(IllegalStateException("Coil failed to load $uri"))
-                }
-            } catch (e: Exception) {
-                future.setException(e)
+        val job = scope.launch {
+            val bitmap = loadWithCoil(key) ?: run {
+                delay(2000)
+                loadWithCoil(key)
+            }
+            if (future.isCancelled) return@launch
+            if (bitmap != null) {
+                bitmapCache.put(key, bitmap)
+                future.set(bitmap)
+            } else {
+                future.setException(IllegalStateException("Coil failed to load $uri"))
             }
         }
+        future.addListener({ if (future.isCancelled) job.cancel() }, Runnable::run)
         return future
     }
 
     private suspend fun loadWithCoil(url: String): Bitmap? {
-        val result = SingletonImageLoader.get(context)
+        val result = SingletonImageLoader.get(appContext)
             .execute(
-                ImageRequest.Builder(context)
+                ImageRequest.Builder(appContext)
                     .data(url)
                     .size(600)
                     .build(),

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -178,6 +178,7 @@ class SakiPlaybackService : MediaSessionService() {
         mediaSession = MediaSession.Builder(this, exoPlayer)
             .setSessionActivity(sessionActivity)
             .setCallback(SakiMediaSessionCallback())
+            .setBitmapLoader(CoilBitmapLoader(this))
             .build()
 
         playerScope.launch {
@@ -463,11 +464,17 @@ class SakiPlaybackService : MediaSessionService() {
                 }
                 .build()
 
-            // Resolve artwork URL if missing (queue was built without it for performance)
+            // Resolve artwork URL using canonical endpoint (first by order) so
+            // CoverArtEndpointInterceptor can rewrite it to the current best endpoint at load time
             val resolvedArtworkUri = request.artworkUri ?: request.coverArtId?.let { coverArtId ->
                 runCatching {
-                    subsonicRepository.buildCoverArtRequest(request.serverId, coverArtId, 720)
-                        .candidates.firstOrNull()?.url
+                    val canonical = endpointSelector.getCanonicalEndpoint(request.serverId)
+                    val candidates = subsonicRepository.buildCoverArtRequest(request.serverId, coverArtId, 720).candidates
+                    // Prefer the canonical endpoint URL for stable caching + interceptor rewriting
+                    if (canonical != null) {
+                        candidates.find { it.url.contains(canonical.baseUrl.trimEnd('/').substringAfter("://")) }?.url
+                    } else null
+                        ?: candidates.firstOrNull()?.url
                 }.getOrNull()
             }
             val finalRequest = if (resolvedArtworkUri != null && request.artworkUri == null) {

--- a/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SakiPlaybackService.kt
@@ -470,11 +470,11 @@ class SakiPlaybackService : MediaSessionService() {
                 runCatching {
                     val canonical = endpointSelector.getCanonicalEndpoint(request.serverId)
                     val candidates = subsonicRepository.buildCoverArtRequest(request.serverId, coverArtId, 720).candidates
-                    // Prefer the canonical endpoint URL for stable caching + interceptor rewriting
-                    if (canonical != null) {
-                        candidates.find { it.url.contains(canonical.baseUrl.trimEnd('/').substringAfter("://")) }?.url
-                    } else null
-                        ?: candidates.firstOrNull()?.url
+                    val canonicalUrl = canonical?.let { c ->
+                        val host = c.baseUrl.trimEnd('/').substringAfter("://")
+                        candidates.find { it.url.contains(host) }?.url
+                    }
+                    canonicalUrl ?: candidates.firstOrNull()?.url
                 }.getOrNull()
             }
             val finalRequest = if (resolvedArtworkUri != null && request.artworkUri == null) {


### PR DESCRIPTION
Closes #117

## Problem

Notification/lock screen cover art failed to load after network or endpoint changes. In-app artwork worked fine.

The system's media notification renderer loaded `artworkUri` (a baked HTTP URL tied to a specific endpoint) directly, bypassing our OkHttp pipeline and `CoverArtEndpointInterceptor`. After network switch, the URL became unreachable.

## Solution

### 1. `CoilBitmapLoader` (new)
Custom `BitmapLoader` set on `MediaSession.Builder.setBitmapLoader`. Media3 now loads notification artwork through Coil → OkHttp → `CoverArtEndpointInterceptor`, which rewrites the URL to the current best endpoint.

- In-memory LRU cache (20 bitmaps) for instant repeat loads
- Retry with 2s delay on failure to allow `EndpointSelector` reprobe after network change

### 2. Canonical endpoint for `artworkUri`
`resolvePlayableItem` now builds `artworkUri` using the canonical endpoint (first by order) instead of the current best endpoint. This ensures `CoverArtEndpointInterceptor` recognizes and rewrites the URL regardless of which endpoint was active at queue build time.

### Data flow
```
artworkUri (canonical endpoint, stable)
  → CoilBitmapLoader.loadBitmap()
    → Coil (memory cache → disk cache → network)
      → OkHttp + CoverArtEndpointInterceptor (rewrites to current best endpoint)
        → notification bitmap
```

## Failed approaches (documented in #117)
- Embedding bitmap in `onAddMediaItems` → blocked queue addition
- `replaceMediaItem` with `artworkData` → corrupted ShuffleOrder
- `artworkUri(null)` + `artworkData` → system ignored embedded data