### PR TITLE
Replace pill/asymmetric shapes with symmetric rounded rects

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/BrowseComponents.kt
@@ -544,7 +544,7 @@ fun SongDetailsDialog(song: Song, onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
         confirmButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(onClick = onDismiss, shape = MaterialTheme.shapes.small) {
                 Text(stringResource(R.string.common_close))
             }
         },
@@ -578,8 +578,8 @@ fun NoServerBrowseState(modifier: Modifier, onManageServers: () -> Unit, onImpor
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    Button(onClick = onManageServers) { Text(stringResource(R.string.browse_add_server)) }
-                    OutlinedButton(onClick = onImportBackup) { Text(stringResource(R.string.browse_import_backup)) }
+                    Button(onClick = onManageServers, shape = MaterialTheme.shapes.small) { Text(stringResource(R.string.browse_add_server)) }
+                    OutlinedButton(onClick = onImportBackup, shape = MaterialTheme.shapes.small) { Text(stringResource(R.string.browse_import_backup)) }
                 }
             }
         }
@@ -601,7 +601,7 @@ fun SectionTitle(
         ) {
             Text(text = title, style = MaterialTheme.typography.headlineSmall)
             if (actionLabel != null && onAction != null) {
-                Button(onClick = onAction) {
+                Button(onClick = onAction, shape = MaterialTheme.shapes.small) {
                     Icon(Icons.Rounded.PlayArrow, contentDescription = null)
                     Text(actionLabel, modifier = Modifier.padding(start = 8.dp))
                 }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -640,7 +640,7 @@ fun NowPlayingOverlay(
                                 width = if (compactControls) 132.dp else 148.dp,
                                 height = if (compactControls) 64.dp else 72.dp,
                             ),
-                            shape = RoundedCornerShape(30.dp),
+                            shape = MaterialTheme.shapes.medium,
                             color = MaterialTheme.colorScheme.primaryContainer,
                         ) {
                             Row(
@@ -785,7 +785,7 @@ fun NowPlayingOverlay(
         AlertDialog(
             onDismissRequest = { showDetails = false },
             confirmButton = {
-                TextButton(onClick = { showDetails = false }) {
+                TextButton(onClick = { showDetails = false }, shape = MaterialTheme.shapes.small) {
                     Text(stringResource(R.string.common_close))
                 }
             },
@@ -828,7 +828,7 @@ fun NowPlayingOverlay(
         AlertDialog(
             onDismissRequest = { showEndpointStatus = false },
             confirmButton = {
-                TextButton(onClick = { showEndpointStatus = false }) {
+                TextButton(onClick = { showEndpointStatus = false }, shape = MaterialTheme.shapes.small) {
                     Text(stringResource(R.string.common_close))
                 }
             },
@@ -902,6 +902,7 @@ fun NowPlayingOverlay(
                         onClick = onReprobeEndpoints,
                         enabled = !isProbing,
                         modifier = Modifier.fillMaxWidth(),
+                        shape = MaterialTheme.shapes.small,
                     ) {
                         Text(
                             if (isProbing) {
@@ -1075,7 +1076,7 @@ private fun QueueRow(
                 )
             }
             if (!isCurrent) {
-                TextButton(onClick = onRemove) {
+                TextButton(onClick = onRemove, shape = MaterialTheme.shapes.small) {
                     Text(stringResource(R.string.common_remove))
                 }
             }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/serverconfig/ServerConfigScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/serverconfig/ServerConfigScreen.kt
@@ -357,7 +357,7 @@ private fun EmptyStateCard(
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            Button(onClick = onAddServer) {
+            Button(onClick = onAddServer, shape = MaterialTheme.shapes.small) {
                 Text(stringResource(R.string.server_config_create_server))
             }
         }
@@ -436,10 +436,10 @@ private fun ServerCard(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Button(onClick = onEditServer) {
+                Button(onClick = onEditServer, shape = MaterialTheme.shapes.small) {
                     Text(stringResource(R.string.server_config_manage))
                 }
-                TextButton(onClick = onDeleteServer) {
+                TextButton(onClick = onDeleteServer, shape = MaterialTheme.shapes.small) {
                     Text(stringResource(R.string.server_config_delete))
                 }
             }
@@ -520,7 +520,7 @@ private fun ServerEditorSheet(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                TextButton(onClick = onDismissEditor) {
+                TextButton(onClick = onDismissEditor, shape = MaterialTheme.shapes.small) {
                     Text(stringResource(R.string.server_config_close))
                 }
             }
@@ -613,7 +613,7 @@ private fun ServerEditorSheet(
                 )
             }
 
-            TextButton(onClick = onAddEndpoint) {
+            TextButton(onClick = onAddEndpoint, shape = MaterialTheme.shapes.small) {
                 Text(stringResource(R.string.server_config_add_endpoint))
             }
 
@@ -627,6 +627,7 @@ private fun ServerEditorSheet(
                 Button(
                     onClick = onSaveServer,
                     enabled = !isSaving,
+                    shape = MaterialTheme.shapes.small,
                 ) {
                     if (isSaving) {
                         CircularProgressIndicator(
@@ -647,6 +648,7 @@ private fun ServerEditorSheet(
                 TextButton(
                     onClick = onDismissEditor,
                     enabled = !isSaving,
+                    shape = MaterialTheme.shapes.small,
                 ) {
                     Text(stringResource(R.string.server_config_cancel))
                 }
@@ -718,6 +720,7 @@ private fun EndpointEditorCard(
                 Button(
                     onClick = onTest,
                     enabled = endpoint.testState !is EndpointConnectionState.Testing,
+                    shape = MaterialTheme.shapes.small,
                 ) {
                     if (endpoint.testState is EndpointConnectionState.Testing) {
                         CircularProgressIndicator(
@@ -733,7 +736,7 @@ private fun EndpointEditorCard(
                 }
 
                 if (canRemove) {
-                    TextButton(onClick = onRemove) {
+                    TextButton(onClick = onRemove, shape = MaterialTheme.shapes.small) {
                         Text(stringResource(R.string.server_config_remove))
                     }
                 }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/settings/SettingsScreen.kt
@@ -175,7 +175,7 @@ fun SettingsScreen(
                         )
                     }
                 }
-                FilledTonalButton(onClick = onManageServers) {
+                FilledTonalButton(onClick = onManageServers, shape = MaterialTheme.shapes.small) {
                     Icon(Icons.Rounded.WifiTethering, contentDescription = null)
                     Text(stringResource(R.string.settings_open_server_manager), modifier = Modifier.padding(start = 8.dp))
                 }
@@ -472,6 +472,7 @@ fun SettingsScreen(
                 OutlinedButton(
                     onClick = onClearStreamCache,
                     enabled = storageSummary.streamCacheBytes > 0L,
+                    shape = MaterialTheme.shapes.small,
                 ) {
                     Icon(Icons.Rounded.DeleteOutline, contentDescription = null)
                     Text(stringResource(R.string.settings_clear_stream_cache), modifier = Modifier.padding(start = 8.dp))
@@ -541,6 +542,7 @@ fun SettingsScreen(
                 OutlinedButton(
                     onClick = onClearImageCache,
                     enabled = storageSummary.imageCacheBytes > 0L,
+                    shape = MaterialTheme.shapes.small,
                 ) {
                     Icon(Icons.Rounded.DeleteOutline, contentDescription = null)
                     Text(stringResource(R.string.settings_clear_cover_art_cache), modifier = Modifier.padding(start = 8.dp))
@@ -571,7 +573,7 @@ fun SettingsScreen(
             ) {
                 Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                     if (visibleCachedSongs.isNotEmpty()) {
-                        OutlinedButton(onClick = { onPlayCachedQueue(visibleCachedSongs, 0) }) {
+                        OutlinedButton(onClick = { onPlayCachedQueue(visibleCachedSongs, 0) }, shape = MaterialTheme.shapes.small) {
                             Icon(Icons.Rounded.PlayArrow, contentDescription = null)
                             Text(stringResource(R.string.settings_play_all), modifier = Modifier.padding(start = 8.dp))
                         }
@@ -579,6 +581,7 @@ fun SettingsScreen(
                     OutlinedButton(
                         onClick = onClearCachedSongs,
                         enabled = visibleCachedSongs.isNotEmpty(),
+                        shape = MaterialTheme.shapes.small,
                     ) {
                         Icon(Icons.Rounded.DeleteOutline, contentDescription = null)
                         Text(stringResource(R.string.settings_clear_all), modifier = Modifier.padding(start = 8.dp))
@@ -655,11 +658,11 @@ fun SettingsScreen(
                 action = null,
             ) {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Button(onClick = { exportLauncher.launch("saki-backup.json") }) {
+                    Button(onClick = { exportLauncher.launch("saki-backup.json") }, shape = MaterialTheme.shapes.small) {
                         Icon(Icons.Rounded.Upload, contentDescription = null)
                         Text(stringResource(R.string.settings_export), modifier = Modifier.padding(start = 8.dp))
                     }
-                    OutlinedButton(onClick = { importLauncher.launch(arrayOf("application/json", "*/*")) }) {
+                    OutlinedButton(onClick = { importLauncher.launch(arrayOf("application/json", "*/*")) }, shape = MaterialTheme.shapes.small) {
                         Icon(Icons.Rounded.Download, contentDescription = null)
                         Text(stringResource(R.string.settings_import), modifier = Modifier.padding(start = 8.dp))
                     }

--- a/app/src/main/java/com/anzupop/saki/android/ui/theme/Shape.kt
+++ b/app/src/main/java/com/anzupop/saki/android/ui/theme/Shape.kt
@@ -7,22 +7,7 @@ import androidx.compose.ui.unit.dp
 val SakiShapes = Shapes(
     extraSmall = RoundedCornerShape(10.dp),
     small = RoundedCornerShape(18.dp),
-    medium = RoundedCornerShape(
-        topStart = 26.dp,
-        topEnd = 12.dp,
-        bottomEnd = 26.dp,
-        bottomStart = 12.dp,
-    ),
-    large = RoundedCornerShape(
-        topStart = 34.dp,
-        topEnd = 16.dp,
-        bottomEnd = 34.dp,
-        bottomStart = 16.dp,
-    ),
-    extraLarge = RoundedCornerShape(
-        topStart = 40.dp,
-        topEnd = 20.dp,
-        bottomEnd = 40.dp,
-        bottomStart = 20.dp,
-    ),
+    medium = RoundedCornerShape(22.dp),
+    large = RoundedCornerShape(28.dp),
+    extraLarge = RoundedCornerShape(34.dp),
 )

--- a/app/src/main/java/com/anzupop/saki/android/ui/theme/Shape.kt
+++ b/app/src/main/java/com/anzupop/saki/android/ui/theme/Shape.kt
@@ -8,6 +8,6 @@ val SakiShapes = Shapes(
     extraSmall = RoundedCornerShape(10.dp),
     small = RoundedCornerShape(18.dp),
     medium = RoundedCornerShape(22.dp),
-    large = RoundedCornerShape(28.dp),
-    extraLarge = RoundedCornerShape(34.dp),
+    large = RoundedCornerShape(26.dp),
+    extraLarge = RoundedCornerShape(28.dp),
 )


### PR DESCRIPTION
Closes #126

## Changes

### Symmetric theme shapes (`Shape.kt`)
- `medium`: asymmetric (26/12dp) → symmetric **22dp**
- `large`: asymmetric (34/16dp) → symmetric **28dp**
- `extraLarge`: asymmetric (40/20dp) → symmetric **34dp**
- `extraSmall` (10dp) and `small` (18dp) were already symmetric

### Button pill → rounded rect
- Play button `Surface`: `RoundedCornerShape(30.dp)` → `MaterialTheme.shapes.medium`
- Add `shape = MaterialTheme.shapes.small` to all `Button`/`OutlinedButton`/`FilledTonalButton`/`TextButton` calls (4 files)
- Material3 buttons default to `CornerFull` (pill), not configurable at theme level

### Preserved
- 5dp dot separator (`RoundedCornerShape(percent = 50)`) — intentional circle
- Artwork clips (`RoundedCornerShape(34.dp)`) — parameterized corner radius
- `FilterChip` — already uses `shapes.small` via theme