### PR TITLE
Fix song details: width jitter and unknown codec/bitrate

### DIFF
--- a/app/src/main/java/com/anzupop/saki/android/domain/model/PlaybackModels.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/model/PlaybackModels.kt
@@ -223,6 +223,9 @@ data class PlaybackQueueItem(
     val localPath: String?,
     val qualityLabel: String,
     val isCached: Boolean,
+    val suffix: String? = null,
+    val bitRate: Int? = null,
+    val contentType: String? = null,
 )
 
 data class PlaybackRuntimeInfo(

--- a/app/src/main/java/com/anzupop/saki/android/domain/model/PlaybackModels.kt
+++ b/app/src/main/java/com/anzupop/saki/android/domain/model/PlaybackModels.kt
@@ -224,7 +224,7 @@ data class PlaybackQueueItem(
     val qualityLabel: String,
     val isCached: Boolean,
     val suffix: String? = null,
-    val bitRate: Int? = null,
+    val bitRateKbps: Int? = null,
     val contentType: String? = null,
 )
 

--- a/app/src/main/java/com/anzupop/saki/android/playback/SubsonicPlaybackItems.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SubsonicPlaybackItems.kt
@@ -33,6 +33,8 @@ private const val EXTRA_MAX_BIT_RATE = "saki.playback.max_bit_rate"
 private const val EXTRA_FORMAT = "saki.playback.format"
 private const val EXTRA_STREAM_URLS = "saki.playback.stream_urls"
 private const val EXTRA_STREAM_INDEX = "saki.playback.stream_index"
+private const val EXTRA_SUFFIX = "saki.playback.suffix"
+private const val EXTRA_BIT_RATE = "saki.playback.bit_rate"
 
 internal data class PlaybackRequest(
     val serverId: Long,
@@ -55,6 +57,8 @@ internal data class PlaybackRequest(
     val isCached: Boolean,
     val maxBitRate: Int?,
     val format: String?,
+    val suffix: String?,
+    val bitRate: Int?,
 )
 
 internal fun Song.toPlaybackRequestMediaItem(
@@ -86,6 +90,8 @@ internal fun Song.toPlaybackRequestMediaItem(
         isCached = false,
         maxBitRate = maxBitRate,
         format = format,
+        suffix = suffix,
+        bitRate = bitRate,
     )
 
     return MediaItem.Builder()
@@ -122,6 +128,8 @@ internal fun CachedSong.toCachedMediaItem(): MediaItem {
         isCached = true,
         maxBitRate = null,
         format = null,
+        suffix = suffix,
+        bitRate = null,
     )
 
     return MediaItem.Builder()
@@ -169,6 +177,8 @@ internal fun MediaItem.toPlaybackRequestOrNull(): PlaybackRequest? {
         isCached = extras.getBoolean(EXTRA_IS_CACHED, false),
         maxBitRate = extras.getInt(EXTRA_MAX_BIT_RATE).takeIf { extras.containsKey(EXTRA_MAX_BIT_RATE) },
         format = extras.getString(EXTRA_FORMAT),
+        suffix = extras.getString(EXTRA_SUFFIX),
+        bitRate = extras.getInt(EXTRA_BIT_RATE).takeIf { extras.containsKey(EXTRA_BIT_RATE) },
     )
 }
 
@@ -196,6 +206,9 @@ internal fun MediaItem.toQueueItemOrNull(): PlaybackQueueItem? {
         localPath = extras.getString(EXTRA_LOCAL_PATH),
         qualityLabel = extras.getString(EXTRA_QUALITY_LABEL).orEmpty().ifBlank { "Original" },
         isCached = extras.getBoolean(EXTRA_IS_CACHED, false),
+        suffix = extras.getString(EXTRA_SUFFIX),
+        bitRate = extras.getInt(EXTRA_BIT_RATE).takeIf { extras.containsKey(EXTRA_BIT_RATE) },
+        contentType = extras.getString(EXTRA_MIME_TYPE),
     )
 }
 
@@ -280,6 +293,8 @@ internal fun PlaybackRequest.toBundle(): Bundle {
         putBoolean(EXTRA_IS_CACHED, isCached)
         maxBitRate?.let { putInt(EXTRA_MAX_BIT_RATE, it) }
         putString(EXTRA_FORMAT, format)
+        putString(EXTRA_SUFFIX, suffix)
+        bitRate?.let { putInt(EXTRA_BIT_RATE, it) }
     }
 }
 

--- a/app/src/main/java/com/anzupop/saki/android/playback/SubsonicPlaybackItems.kt
+++ b/app/src/main/java/com/anzupop/saki/android/playback/SubsonicPlaybackItems.kt
@@ -207,7 +207,7 @@ internal fun MediaItem.toQueueItemOrNull(): PlaybackQueueItem? {
         qualityLabel = extras.getString(EXTRA_QUALITY_LABEL).orEmpty().ifBlank { "Original" },
         isCached = extras.getBoolean(EXTRA_IS_CACHED, false),
         suffix = extras.getString(EXTRA_SUFFIX),
-        bitRate = extras.getInt(EXTRA_BIT_RATE).takeIf { extras.containsKey(EXTRA_BIT_RATE) },
+        bitRateKbps = extras.getInt(EXTRA_BIT_RATE).takeIf { extras.containsKey(EXTRA_BIT_RATE) },
         contentType = extras.getString(EXTRA_MIME_TYPE),
     )
 }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -792,7 +792,7 @@ fun NowPlayingOverlay(
             title = { Text(track.title) },
             text = {
                 LazyColumn(
-                    modifier = Modifier.heightIn(max = 320.dp),
+                    modifier = Modifier.fillMaxWidth().heightIn(max = 320.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     item { DetailLine(stringResource(R.string.detail_artist), track.artist) }
@@ -809,10 +809,10 @@ fun NowPlayingOverlay(
                             },
                         )
                     }
-                    item { DetailLine(stringResource(R.string.detail_mime_type), playbackState.runtimeInfo?.sampleMimeType) }
+                    item { DetailLine(stringResource(R.string.detail_mime_type), playbackState.runtimeInfo?.sampleMimeType ?: track.contentType) }
                     item { DetailLine(stringResource(R.string.detail_container), playbackState.runtimeInfo?.containerMimeType) }
-                    item { DetailLine(stringResource(R.string.detail_codec), playbackState.runtimeInfo?.codecs) }
-                    item { DetailLine(stringResource(R.string.detail_average_bitrate), playbackState.runtimeInfo?.averageBitrate?.let(::formatBitrate)) }
+                    item { DetailLine(stringResource(R.string.detail_codec), playbackState.runtimeInfo?.codecs ?: track.suffix?.uppercase()) }
+                    item { DetailLine(stringResource(R.string.detail_average_bitrate), playbackState.runtimeInfo?.averageBitrate?.let(::formatBitrate) ?: track.bitRate?.let(::formatBitrate)) }
                     item { DetailLine(stringResource(R.string.detail_peak_bitrate), playbackState.runtimeInfo?.peakBitrate?.let(::formatBitrate)) }
                     item { DetailLine(stringResource(R.string.detail_sample_rate), playbackState.runtimeInfo?.sampleRate?.let(::formatSampleRate)) }
                     item { DetailLine(stringResource(R.string.detail_channels), playbackState.runtimeInfo?.channelCount?.toString()) }

--- a/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/com/anzupop/saki/android/presentation/library/PlayerChrome.kt
@@ -811,8 +811,8 @@ fun NowPlayingOverlay(
                     }
                     item { DetailLine(stringResource(R.string.detail_mime_type), playbackState.runtimeInfo?.sampleMimeType ?: track.contentType) }
                     item { DetailLine(stringResource(R.string.detail_container), playbackState.runtimeInfo?.containerMimeType) }
-                    item { DetailLine(stringResource(R.string.detail_codec), playbackState.runtimeInfo?.codecs ?: track.suffix?.uppercase()) }
-                    item { DetailLine(stringResource(R.string.detail_average_bitrate), playbackState.runtimeInfo?.averageBitrate?.let(::formatBitrate) ?: track.bitRate?.let(::formatBitrate)) }
+                    item { DetailLine(stringResource(R.string.detail_codec), playbackState.runtimeInfo?.codecs ?: track.suffix?.uppercase(java.util.Locale.ROOT)) }
+                    item { DetailLine(stringResource(R.string.detail_average_bitrate), playbackState.runtimeInfo?.averageBitrate?.let(::formatBitrate) ?: track.bitRateKbps?.let { formatBitrate(it * 1_000) }) }
                     item { DetailLine(stringResource(R.string.detail_peak_bitrate), playbackState.runtimeInfo?.peakBitrate?.let(::formatBitrate)) }
                     item { DetailLine(stringResource(R.string.detail_sample_rate), playbackState.runtimeInfo?.sampleRate?.let(::formatSampleRate)) }
                     item { DetailLine(stringResource(R.string.detail_channels), playbackState.runtimeInfo?.channelCount?.toString()) }


### PR DESCRIPTION
Closes #127, closes #128

## #127 — Dialog width jitter
Add `fillMaxWidth()` to `LazyColumn` in song details `AlertDialog`, locking width regardless of visible content.

## #128 — Unknown codec/bitrate
- Add `suffix`, `bitRate`, `contentType` fields to `PlaybackQueueItem`
- Wire through `SubsonicPlaybackItems` bundle extras from Subsonic API `Song` metadata
- Song details dialog falls back to API metadata when ExoPlayer `runtimeInfo` is null:
  - Codec → `suffix.uppercase()` (e.g. "FLAC")
  - Average bitrate → `Song.bitRate`
  - MIME type → `Song.contentType`