### PR TITLE
feat: unify Toast → Snackbar with restart action

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.background
-import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -59,14 +58,16 @@ fun SakiApp(
         viewModel.messages.collectLatest { msg ->
             val result = snackbarHostState.showSnackbar(
                 message = msg.text.asString(context),
-                actionLabel = msg.actionLabel?.asString(context),
+                actionLabel = msg.action?.let { context.getString(it.labelRes) },
                 duration = msg.duration,
             )
-            if (result == SnackbarResult.ActionPerformed && msg.actionLabel != null) {
+            if (result == SnackbarResult.ActionPerformed && msg.action == SnackbarAction.RESTART) {
                 val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
-                intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                context.startActivity(intent)
-                Runtime.getRuntime().exit(0)
+                if (intent != null) {
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    context.startActivity(intent)
+                    Runtime.getRuntime().exit(0)
+                }
             }
         }
     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -1,5 +1,6 @@
 package org.hdhmc.saki.presentation
 
+import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,6 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -54,11 +56,18 @@ fun SakiApp(
     }
 
     LaunchedEffect(viewModel) {
-        viewModel.messages.collectLatest { message ->
-            snackbarHostState.showSnackbar(
-                message = message.asString(context),
-                duration = SnackbarDuration.Short,
+        viewModel.messages.collectLatest { msg ->
+            val result = snackbarHostState.showSnackbar(
+                message = msg.text.asString(context),
+                actionLabel = msg.actionLabel?.asString(context),
+                duration = msg.duration,
             )
+            if (result == SnackbarResult.ActionPerformed && msg.actionLabel != null) {
+                val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+                intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                context.startActivity(intent)
+                Runtime.getRuntime().exit(0)
+            }
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -721,7 +721,7 @@ class SakiAppViewModel @Inject constructor(
                 snackbarMessages.emit(
                     SnackbarMessage(
                         text = UiText.resource(R.string.message_buffer_strategy_set, UiText.resource(strategy.labelRes())),
-                        actionLabel = UiText.resource(R.string.snackbar_restart),
+                        action = SnackbarAction.RESTART,
                     ),
                 )
             }.onFailure { throwable ->
@@ -737,7 +737,7 @@ class SakiAppViewModel @Inject constructor(
             }.onSuccess {
                 snackbarMessages.emit(SnackbarMessage(
                     text = UiText.resource(R.string.message_custom_buffer_set, seconds),
-                    actionLabel = UiText.resource(R.string.snackbar_restart),
+                    action = SnackbarAction.RESTART,
                 ))
             }.onFailure { throwable ->
                 snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_update_custom_buffer)))
@@ -752,7 +752,7 @@ class SakiAppViewModel @Inject constructor(
             }.onSuccess {
                 snackbarMessages.emit(SnackbarMessage(
                     text = UiText.resource(R.string.message_cover_art_cache_limit_updated),
-                    actionLabel = UiText.resource(R.string.snackbar_restart),
+                    action = SnackbarAction.RESTART,
                 ))
             }.onFailure { throwable ->
                 snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_update_cover_art_cache_size)))

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -73,7 +73,7 @@ class SakiAppViewModel @Inject constructor(
     private val configBackupManager: ConfigBackupManager,
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(SakiAppUiState())
-    private val snackbarMessages = MutableSharedFlow<UiText>(extraBufferCapacity = 1)
+    private val snackbarMessages = MutableSharedFlow<SnackbarMessage>(extraBufferCapacity = 1)
     private val openNowPlayingRequestsFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     private val searchQueryFlow = MutableStateFlow("")
     private var lastLoadedServerId: Long? = null
@@ -236,10 +236,10 @@ class SakiAppViewModel @Inject constructor(
                 appPreferencesRepository.updateTextScale(textScale)
             }.onSuccess {
                 snackbarMessages.emit(
-                    UiText.resource(R.string.message_text_size_set, UiText.resource(textScale.labelRes())),
+                    SnackbarMessage(UiText.resource(R.string.message_text_size_set, UiText.resource(textScale.labelRes()))),
                 )
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_update_text_size))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_update_text_size)))
             }
         }
     }
@@ -462,7 +462,7 @@ class SakiAppViewModel @Inject constructor(
             }.onSuccess {
                 openNowPlayingRequestsFlow.emit(Unit)
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_start_playback))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_start_playback)))
             }
         }
     }
@@ -479,7 +479,7 @@ class SakiAppViewModel @Inject constructor(
             }.onSuccess {
                 openNowPlayingRequestsFlow.emit(Unit)
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_start_playback))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_start_playback)))
             }
         }
     }
@@ -490,9 +490,9 @@ class SakiAppViewModel @Inject constructor(
             runCatching {
                 playbackManager.addToQueue(serverId, listOf(song))
             }.onSuccess {
-                snackbarMessages.emit(UiText.resource(R.string.message_added_to_queue, song.title))
+                snackbarMessages.emit(SnackbarMessage(UiText.resource(R.string.message_added_to_queue, song.title)))
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_queue_song))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_queue_song)))
             }
         }
     }
@@ -503,9 +503,9 @@ class SakiAppViewModel @Inject constructor(
             runCatching {
                 playbackManager.playNext(serverId, song)
             }.onSuccess {
-                snackbarMessages.emit(UiText.resource(R.string.message_play_next, song.title))
+                snackbarMessages.emit(SnackbarMessage(UiText.resource(R.string.message_play_next, song.title)))
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_reorder_queue))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_reorder_queue)))
             }
         }
     }
@@ -533,14 +533,14 @@ class SakiAppViewModel @Inject constructor(
                 cachedSongRepository.cacheSong(serverId, song)
             }.onSuccess { cachedSong ->
                 snackbarMessages.emit(
-                    UiText.resource(
+                    SnackbarMessage(UiText.resource(
                         R.string.message_saved_offline,
                         cachedSong.title,
                         UiText.resource(cachedSong.quality.labelRes()),
-                    ),
+                    )),
                 )
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_cache_song))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_cache_song)))
             }
             mutableUiState.update { state ->
                 state.copy(downloadingSongIds = state.downloadingSongIds - song.id)
@@ -555,7 +555,7 @@ class SakiAppViewModel @Inject constructor(
             }.onSuccess {
                 openNowPlayingRequestsFlow.emit(Unit)
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_play_cached_song))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_play_cached_song)))
             }
         }
     }
@@ -571,7 +571,7 @@ class SakiAppViewModel @Inject constructor(
             }.onSuccess {
                 openNowPlayingRequestsFlow.emit(Unit)
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_start_offline_playback))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_start_offline_playback)))
             }
         }
     }
@@ -581,9 +581,9 @@ class SakiAppViewModel @Inject constructor(
             runCatching {
                 cachedSongRepository.deleteCachedSong(cacheId)
             }.onSuccess {
-                snackbarMessages.emit(UiText.resource(R.string.message_removed_cached_file))
+                snackbarMessages.emit(SnackbarMessage(UiText.resource(R.string.message_removed_cached_file)))
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_remove_cached_file))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_remove_cached_file)))
             }
         }
     }
@@ -595,15 +595,15 @@ class SakiAppViewModel @Inject constructor(
                 cachedSongRepository.clearCachedSongs(targetServerId)
             }.onSuccess { removed ->
                 snackbarMessages.emit(
-                    if (removed > 0) {
+                    SnackbarMessage(if (removed > 0) {
                         UiText.plural(R.plurals.message_cleared_download_count, removed, removed)
                     } else {
                         UiText.resource(R.string.message_no_downloads_to_clear)
-                    },
+                    }),
                 )
                 refreshCacheStorageSummary(targetServerId)
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_clear_downloads))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_clear_downloads)))
             }
         }
     }
@@ -615,15 +615,15 @@ class SakiAppViewModel @Inject constructor(
                 streamCacheRepository.clearStreamCache(targetServerId)
             }.onSuccess { removed ->
                 snackbarMessages.emit(
-                    if (removed > 0) {
+                    SnackbarMessage(if (removed > 0) {
                         UiText.plural(R.plurals.message_cleared_stream_cache_entry_count, removed, removed)
                     } else {
                         UiText.resource(R.string.message_no_stream_cache_to_clear)
-                    },
+                    }),
                 )
                 refreshCacheStorageSummary(targetServerId)
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_clear_stream_cache))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_clear_stream_cache)))
             }
         }
     }
@@ -637,10 +637,10 @@ class SakiAppViewModel @Inject constructor(
                     dir.mkdirs()
                 }
             }.onSuccess {
-                snackbarMessages.emit(UiText.resource(R.string.message_cover_art_cache_cleared))
+                snackbarMessages.emit(SnackbarMessage(UiText.resource(R.string.message_cover_art_cache_cleared)))
                 refreshCacheStorageSummary(uiState.value.selectedServerId)
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_clear_cover_art_cache))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_clear_cover_art_cache)))
             }
         }
     }
@@ -651,10 +651,10 @@ class SakiAppViewModel @Inject constructor(
                 playbackPreferencesRepository.updateStreamQuality(quality)
             }.onSuccess {
                 snackbarMessages.emit(
-                    UiText.resource(R.string.message_stream_quality_set, UiText.resource(quality.labelRes())),
+                    SnackbarMessage(UiText.resource(R.string.message_stream_quality_set, UiText.resource(quality.labelRes()))),
                 )
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_update_stream_quality))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_update_stream_quality)))
             }
         }
     }
@@ -683,10 +683,10 @@ class SakiAppViewModel @Inject constructor(
                 playbackPreferencesRepository.updateSoundBalancing(mode)
             }.onSuccess {
                 snackbarMessages.emit(
-                    UiText.resource(R.string.message_sound_balancing_set, UiText.resource(mode.labelRes())),
+                    SnackbarMessage(UiText.resource(R.string.message_sound_balancing_set, UiText.resource(mode.labelRes()))),
                 )
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_update_sound_balancing))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_update_sound_balancing)))
             }
         }
     }
@@ -696,9 +696,9 @@ class SakiAppViewModel @Inject constructor(
             runCatching {
                 playbackPreferencesRepository.updateStreamCacheSizeMb(sizeMb)
             }.onSuccess {
-                snackbarMessages.emit(UiText.resource(R.string.message_stream_cache_limit_updated))
+                snackbarMessages.emit(SnackbarMessage(UiText.resource(R.string.message_stream_cache_limit_updated)))
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_update_stream_cache_size))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_update_stream_cache_size)))
             }
         }
     }
@@ -708,7 +708,7 @@ class SakiAppViewModel @Inject constructor(
             runCatching {
                 playbackPreferencesRepository.updateBluetoothLyrics(enabled)
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_update_bluetooth_lyrics))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_update_bluetooth_lyrics)))
             }
         }
     }
@@ -719,10 +719,13 @@ class SakiAppViewModel @Inject constructor(
                 playbackPreferencesRepository.updateBufferStrategy(strategy)
             }.onSuccess {
                 snackbarMessages.emit(
-                    UiText.resource(R.string.message_buffer_strategy_set, UiText.resource(strategy.labelRes())),
+                    SnackbarMessage(
+                        text = UiText.resource(R.string.message_buffer_strategy_set, UiText.resource(strategy.labelRes())),
+                        actionLabel = UiText.resource(R.string.snackbar_restart),
+                    ),
                 )
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_update_buffer_strategy))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_update_buffer_strategy)))
             }
         }
     }
@@ -732,9 +735,12 @@ class SakiAppViewModel @Inject constructor(
             runCatching {
                 playbackPreferencesRepository.updateCustomBufferSeconds(seconds)
             }.onSuccess {
-                snackbarMessages.emit(UiText.resource(R.string.message_custom_buffer_set, seconds))
+                snackbarMessages.emit(SnackbarMessage(
+                    text = UiText.resource(R.string.message_custom_buffer_set, seconds),
+                    actionLabel = UiText.resource(R.string.snackbar_restart),
+                ))
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_update_custom_buffer))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_update_custom_buffer)))
             }
         }
     }
@@ -744,9 +750,12 @@ class SakiAppViewModel @Inject constructor(
             runCatching {
                 playbackPreferencesRepository.updateImageCacheSizeMb(sizeMb)
             }.onSuccess {
-                snackbarMessages.emit(UiText.resource(R.string.message_cover_art_cache_limit_updated))
+                snackbarMessages.emit(SnackbarMessage(
+                    text = UiText.resource(R.string.message_cover_art_cache_limit_updated),
+                    actionLabel = UiText.resource(R.string.snackbar_restart),
+                ))
             }.onFailure { throwable ->
-                snackbarMessages.emit(throwable.localizedOr(R.string.error_update_cover_art_cache_size))
+                snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_update_cover_art_cache_size)))
             }
         }
     }
@@ -1262,11 +1271,11 @@ class SakiAppViewModel @Inject constructor(
                 appContext.contentResolver.openOutputStream(uri, "wt")?.use { it.write(json.toByteArray()) }
                     ?: error("Cannot open output stream")
             }
-                .onSuccess { snackbarMessages.tryEmit(UiText.resource(R.string.message_backup_exported)) }
+                .onSuccess { snackbarMessages.tryEmit(SnackbarMessage(UiText.resource(R.string.message_backup_exported))) }
                 .onFailure { e ->
                     if (e is CancellationException) throw e
                     snackbarMessages.tryEmit(
-                        UiText.resource(R.string.message_export_failed, e.message.orEmpty()),
+                        SnackbarMessage(UiText.resource(R.string.message_export_failed, e.message.orEmpty())),
                     )
                 }
         }
@@ -1278,7 +1287,7 @@ class SakiAppViewModel @Inject constructor(
                 val json = withContext(kotlinx.coroutines.Dispatchers.IO) {
                     appContext.contentResolver.openInputStream(uri)?.use { it.bufferedReader().readText() }
                 } ?: run {
-                    snackbarMessages.tryEmit(UiText.resource(R.string.message_cannot_read_backup))
+                    snackbarMessages.tryEmit(SnackbarMessage(UiText.resource(R.string.message_cannot_read_backup)))
                     return@launch
                 }
                 when (val result = configBackupManager.importFromJson(json)) {
@@ -1289,24 +1298,24 @@ class SakiAppViewModel @Inject constructor(
                             ""
                         }
                         snackbarMessages.tryEmit(
-                            UiText.plural(
+                            SnackbarMessage(UiText.plural(
                                 R.plurals.message_import_success,
                                 result.serversImported,
                                 result.serversImported,
                                 settingsSuffix,
-                            ),
+                            )),
                         )
                         onSuccess?.invoke()
                     }
-                    is ImportResult.InvalidFormat -> snackbarMessages.tryEmit(UiText.resource(R.string.message_invalid_backup))
+                    is ImportResult.InvalidFormat -> snackbarMessages.tryEmit(SnackbarMessage(UiText.resource(R.string.message_invalid_backup)))
                     is ImportResult.UnsupportedVersion -> snackbarMessages.tryEmit(
-                        UiText.resource(R.string.message_unsupported_backup_version, result.version),
+                        SnackbarMessage(UiText.resource(R.string.message_unsupported_backup_version, result.version)),
                     )
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                snackbarMessages.tryEmit(UiText.resource(R.string.message_import_failed, e.message.orEmpty()))
+                snackbarMessages.tryEmit(SnackbarMessage(UiText.resource(R.string.message_import_failed, e.message.orEmpty())))
             }
         }
     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/UiText.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/UiText.kt
@@ -5,6 +5,7 @@ import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.runtime.Composable
+import org.hdhmc.saki.R
 import androidx.compose.ui.platform.LocalContext
 
 sealed interface UiText {
@@ -61,8 +62,12 @@ fun Throwable.localizedOr(@StringRes fallback: Int): UiText {
     return if (detail != null) UiText.Dynamic(detail) else UiText.Resource(fallback)
 }
 
+enum class SnackbarAction(@StringRes val labelRes: Int) {
+    RESTART(R.string.snackbar_restart),
+}
+
 data class SnackbarMessage(
     val text: UiText,
-    val actionLabel: UiText? = null,
+    val action: SnackbarAction? = null,
     val duration: SnackbarDuration = SnackbarDuration.Short,
 )

--- a/app/src/main/java/org/hdhmc/saki/presentation/UiText.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/UiText.kt
@@ -3,6 +3,7 @@ package org.hdhmc.saki.presentation
 import android.content.Context
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 
@@ -59,3 +60,9 @@ fun Throwable.localizedOr(@StringRes fallback: Int): UiText {
     val detail = message?.takeIf { it.isNotBlank() }
     return if (detail != null) UiText.Dynamic(detail) else UiText.Resource(fallback)
 }
+
+data class SnackbarMessage(
+    val text: UiText,
+    val actionLabel: UiText? = null,
+    val duration: SnackbarDuration = SnackbarDuration.Short,
+)

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -131,6 +131,7 @@ import coil3.request.ImageRequest
 import coil3.toBitmap
 import kotlin.math.roundToLong
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
@@ -390,6 +391,19 @@ fun NowPlayingOverlay(
         ) {
             val playerSnackbarHostState = remember { SnackbarHostState() }
             val scope = rememberCoroutineScope()
+            var snackbarJob by remember { mutableStateOf<Job?>(null) }
+            fun showPlayerSnackbar(message: String) {
+                playerSnackbarHostState.currentSnackbarData?.dismiss()
+                snackbarJob?.cancel()
+                snackbarJob = scope.launch {
+                    playerSnackbarHostState.showSnackbar(message, duration = SnackbarDuration.Indefinite)
+                }
+                scope.launch {
+                    delay(1500)
+                    snackbarJob?.cancel()
+                    playerSnackbarHostState.currentSnackbarData?.dismiss()
+                }
+            }
             val combinedMetadata = listOfNotNull(track.artist, track.album).joinToString(" • ")
             val denseTitle = track.title.length >= 24
             val denseMetadata = combinedMetadata.length >= 42
@@ -555,14 +569,7 @@ fun NowPlayingOverlay(
                                         RepeatModeSetting.ALL -> repeatOneLabel
                                         RepeatModeSetting.ONE -> repeatOffLabel
                                     }
-                                    playerSnackbarHostState.currentSnackbarData?.dismiss()
-                                    scope.launch {
-                                        playerSnackbarHostState.showSnackbar(label, duration = SnackbarDuration.Indefinite)
-                                    }
-                                    scope.launch {
-                                        delay(1500)
-                                        playerSnackbarHostState.currentSnackbarData?.dismiss()
-                                    }
+                                    showPlayerSnackbar(label)
                                 },
                                 compact = true,
                             )
@@ -573,14 +580,7 @@ fun NowPlayingOverlay(
                                 onClick = {
                                     onToggleShuffle()
                                     val label = if (!playbackState.shuffleEnabled) shuffleOnLabel else shuffleOffLabel
-                                    playerSnackbarHostState.currentSnackbarData?.dismiss()
-                                    scope.launch {
-                                        playerSnackbarHostState.showSnackbar(label, duration = SnackbarDuration.Indefinite)
-                                    }
-                                    scope.launch {
-                                        delay(1500)
-                                        playerSnackbarHostState.currentSnackbarData?.dismiss()
-                                    }
+                                    showPlayerSnackbar(label)
                                 },
                                 compact = true,
                             )

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -67,6 +67,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -80,6 +84,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -126,6 +131,7 @@ import coil3.request.ImageRequest
 import coil3.toBitmap
 import kotlin.math.roundToLong
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -382,6 +388,8 @@ fun NowPlayingOverlay(
                 .navigationBarsPadding()
                 .imePadding(),
         ) {
+            val playerSnackbarHostState = remember { SnackbarHostState() }
+            val scope = rememberCoroutineScope()
             val combinedMetadata = listOfNotNull(track.artist, track.album).joinToString(" • ")
             val denseTitle = track.title.length >= 24
             val denseMetadata = combinedMetadata.length >= 42
@@ -528,7 +536,6 @@ fun NowPlayingOverlay(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        val toastContext = LocalContext.current
                         val repeatDescription = stringResource(R.string.player_repeat)
                         val repeatOneLabel = stringResource(R.string.player_repeat_one)
                         val repeatAllLabel = stringResource(R.string.player_repeat_all)
@@ -548,7 +555,14 @@ fun NowPlayingOverlay(
                                         RepeatModeSetting.ALL -> repeatOneLabel
                                         RepeatModeSetting.ONE -> repeatOffLabel
                                     }
-                                    android.widget.Toast.makeText(toastContext, label, android.widget.Toast.LENGTH_SHORT).show()
+                                    playerSnackbarHostState.currentSnackbarData?.dismiss()
+                                    scope.launch {
+                                        playerSnackbarHostState.showSnackbar(label, duration = SnackbarDuration.Indefinite)
+                                    }
+                                    scope.launch {
+                                        delay(1500)
+                                        playerSnackbarHostState.currentSnackbarData?.dismiss()
+                                    }
                                 },
                                 compact = true,
                             )
@@ -559,7 +573,14 @@ fun NowPlayingOverlay(
                                 onClick = {
                                     onToggleShuffle()
                                     val label = if (!playbackState.shuffleEnabled) shuffleOnLabel else shuffleOffLabel
-                                    android.widget.Toast.makeText(toastContext, label, android.widget.Toast.LENGTH_SHORT).show()
+                                    playerSnackbarHostState.currentSnackbarData?.dismiss()
+                                    scope.launch {
+                                        playerSnackbarHostState.showSnackbar(label, duration = SnackbarDuration.Indefinite)
+                                    }
+                                    scope.launch {
+                                        delay(1500)
+                                        playerSnackbarHostState.currentSnackbarData?.dismiss()
+                                    }
                                 },
                                 compact = true,
                             )
@@ -833,6 +854,19 @@ fun NowPlayingOverlay(
                         }
                     }
                 }
+            }
+
+            SnackbarHost(
+                hostState = playerSnackbarHostState,
+                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 8.dp),
+            ) { data ->
+                Snackbar(
+                    snackbarData = data,
+                    shape = MaterialTheme.shapes.small,
+                    containerColor = MaterialTheme.colorScheme.inverseSurface,
+                    contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                    modifier = Modifier.padding(horizontal = 48.dp),
+                )
             }
         }
     }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -235,6 +235,7 @@
     <string name="common_on">开</string>
     <string name="common_off">关</string>
     <string name="message_text_size_set">字体大小已设为 %1$s。</string>
+    <string name="snackbar_restart">重启</string>
     <string name="error_update_text_size">无法更新字体大小。</string>
     <string name="error_load_artist_details">无法加载艺术家详情。</string>
     <string name="error_load_album_details">无法加载专辑详情。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,6 +243,7 @@
     <string name="common_on">On</string>
     <string name="common_off">Off</string>
     <string name="message_text_size_set">Text size set to %1$s.</string>
+    <string name="snackbar_restart">Restart</string>
     <string name="error_update_text_size">Unable to update text size.</string>
     <string name="error_load_artist_details">Unable to load artist details.</string>
     <string name="error_load_album_details">Unable to load album details.</string>


### PR DESCRIPTION
Closes #125

## Changes

### Snackbar infrastructure
- Added `SnackbarMessage` data class in `UiText.kt` with optional `actionLabel` and `duration`
- Changed `SakiAppViewModel.snackbarMessages` flow from `SharedFlow<UiText>` to `SharedFlow<SnackbarMessage>`

### Settings restart action
- Buffer strategy, custom buffer, and image cache settings now show Snackbar with "Restart" action button
- Action triggers app relaunch via `getLaunchIntentForPackage` + `Runtime.exit(0)`

### Player feedback (repeat/shuffle)
- Replaced `android.widget.Toast` with local `SnackbarHost` in `NowPlayingOverlay`
- Compact styling: narrower width, `shapes.small` corners
- 1.5s display duration with instant replacement on fast toggle
- Zero remaining Toast usage in codebase

### Strings
- Added `snackbar_restart`: "Restart" / "重启"

## Known limitation
- Player Snackbar dismiss has no fade-out animation (dismiss is instant). Can be improved later with a custom composable overlay.