### PR TITLE
fix: add navigationBarsPadding to all screens

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.background
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -249,7 +250,7 @@ private fun RootShell(
             .background(shellBackgroundBrush),
     ) {
         CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
-            Column(modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
                 Box(modifier = Modifier.weight(1f)) {
                     if (showSettings) {
                         SettingsScreen(

--- a/app/src/main/java/org/hdhmc/saki/presentation/serverconfig/ServerConfigScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/serverconfig/ServerConfigScreen.kt
@@ -157,7 +157,7 @@ fun ServerConfigScreen(
     }
 
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize().navigationBarsPadding(),
         containerColor = Color.Transparent,
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },

--- a/app/src/main/java/org/hdhmc/saki/presentation/serverconfig/ServerConfigScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/serverconfig/ServerConfigScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -157,9 +158,9 @@ fun ServerConfigScreen(
     }
 
     Scaffold(
-        modifier = modifier.fillMaxSize().navigationBarsPadding(),
+        modifier = modifier.fillMaxSize(),
         containerColor = Color.Transparent,
-        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        contentWindowInsets = WindowInsets.navigationBars,
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         floatingActionButton = {
             if (uiState.servers.isNotEmpty()) {


### PR DESCRIPTION
Closes #145

## Problem
On classic 3-button navigation, bottom content on all non-player screens overlaps with the system navigation bar.

## Fix
Added `navigationBarsPadding()` at two locations:

1. **`SakiApp.kt` — RootShell Column** — covers all screens hosted inside: BrowseScreen (Artists/Albums/Playlists/Songs tabs), detail screens, SearchResultsPage, SettingsScreen, NowPlayingCapsule
2. **`ServerConfigScreen.kt` — Scaffold** — separate overlay with its own layout, not covered by RootShell

## Already handled (no changes needed)
- NowPlayingOverlay (`PlayerChrome.kt`) — fixed in #144
- ServerEditorSheet — already has `safeDrawingPadding()`