### PR TITLE
fix: dark mode text color in ServerConfigScreen

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -154,10 +154,12 @@ fun SakiApp(
             }
 
             if (showServerManager) {
-                ServerConfigRoute(
-                    modifier = Modifier.fillMaxSize(),
-                    onCloseManager = { showServerManager = false },
-                )
+                CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
+                    ServerConfigRoute(
+                        modifier = Modifier.fillMaxSize(),
+                        onCloseManager = { showServerManager = false },
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #123

## Problem
In dark mode, text in ServerConfigScreen (server names, titles, labels) remains dark/black and is unreadable against the dark background.

## Root Cause
`ServerConfigScreen` is rendered as a sibling of `RootShell` in `SakiApp.kt`, not inside it. `RootShell` provides `LocalContentColor` via `CompositionLocalProvider`, but `ServerConfigScreen` doesn't inherit it. Without a provider, `LocalContentColor` defaults to `Color.Black` (Compose default).

The `Surface` components in ServerConfigScreen use alpha-modified container colors (e.g., `surface.copy(alpha = 0.88f)`), which Material 3's `contentColorFor()` can't match, so they fall back to `LocalContentColor.current` — which is black.

## Fix
Wrap `ServerConfigRoute` in `CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground)`, matching what `RootShell` does for all other screens.

## Audit Results
Scanned all screens in the app — **ServerConfigScreen is the only affected screen**:
- BrowseScreen, SettingsScreen → inside RootShell (has provider) ✅
- NowPlayingOverlay → has its own provider ✅
- Lyrics overlay → intentionally hardcoded Color.White (scrim over artwork) ✅
- No hardcoded `Color(0x...)` found in any presentation file ✅