### PR TITLE
feat: manual dark/light theme selection

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.TextScale
+import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.domain.repository.AppPreferencesRepository
 import java.io.IOException
 import javax.inject.Inject
@@ -41,13 +42,19 @@ class DataStoreAppPreferencesRepository @Inject constructor(
         dataStore.edit { it[KEY_LANGUAGE] = language.tag }
     }
 
+    override suspend fun updateThemeMode(themeMode: ThemeMode) {
+        dataStore.edit { it[KEY_THEME_MODE] = themeMode.key }
+    }
+
     companion object {
         val KEY_TEXT_SCALE = stringPreferencesKey("text_scale")
         val KEY_LANGUAGE = stringPreferencesKey("app_language")
+        val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
     }
 }
 
 private fun Preferences.toAppPreferences() = AppPreferences(
     textScale = TextScale.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_TEXT_SCALE]),
     language = AppLanguage.fromTag(this[DataStoreAppPreferencesRepository.KEY_LANGUAGE]),
+    themeMode = ThemeMode.fromKey(this[DataStoreAppPreferencesRepository.KEY_THEME_MODE]),
 )

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
@@ -43,7 +43,7 @@ class DataStoreAppPreferencesRepository @Inject constructor(
     }
 
     override suspend fun updateThemeMode(themeMode: ThemeMode) {
-        dataStore.edit { it[KEY_THEME_MODE] = themeMode.key }
+        dataStore.edit { it[KEY_THEME_MODE] = themeMode.storageKey }
     }
 
     companion object {
@@ -56,5 +56,5 @@ class DataStoreAppPreferencesRepository @Inject constructor(
 private fun Preferences.toAppPreferences() = AppPreferences(
     textScale = TextScale.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_TEXT_SCALE]),
     language = AppLanguage.fromTag(this[DataStoreAppPreferencesRepository.KEY_LANGUAGE]),
-    themeMode = ThemeMode.fromKey(this[DataStoreAppPreferencesRepository.KEY_THEME_MODE]),
+    themeMode = ThemeMode.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_THEME_MODE]),
 )

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
@@ -6,6 +6,7 @@ import org.hdhmc.saki.di.IoDispatcher
 import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.TextScale
+import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.domain.repository.AppPreferencesRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -37,6 +38,10 @@ class DefaultAppPreferencesRepository @Inject constructor(
 
     override suspend fun updateLanguage(language: AppLanguage) {
         // Language preference is only supported via DataStore; no-op here
+    }
+
+    override suspend fun updateThemeMode(themeMode: ThemeMode) {
+        // Theme preference is only supported via DataStore; no-op here
     }
 }
 

--- a/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
@@ -41,6 +41,7 @@ enum class TextScale(
 data class AppPreferences(
     val textScale: TextScale = TextScale.DEFAULT,
     val language: AppLanguage = AppLanguage.SYSTEM,
+    val themeMode: ThemeMode = ThemeMode.SYSTEM,
 )
 
 enum class AppLanguage(val tag: String) {
@@ -51,5 +52,16 @@ enum class AppLanguage(val tag: String) {
     companion object {
         fun fromTag(tag: String?): AppLanguage =
             entries.firstOrNull { it.tag == tag } ?: SYSTEM
+    }
+}
+
+enum class ThemeMode(val key: String) {
+    SYSTEM("system"),
+    LIGHT("light"),
+    DARK("dark");
+
+    companion object {
+        fun fromKey(key: String?): ThemeMode =
+            entries.firstOrNull { it.key == key } ?: SYSTEM
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
@@ -55,13 +55,13 @@ enum class AppLanguage(val tag: String) {
     }
 }
 
-enum class ThemeMode(val key: String) {
+enum class ThemeMode(val storageKey: String) {
     SYSTEM("system"),
     LIGHT("light"),
     DARK("dark");
 
     companion object {
-        fun fromKey(key: String?): ThemeMode =
-            entries.firstOrNull { it.key == key } ?: SYSTEM
+        fun fromStorageKey(storageKey: String?): ThemeMode =
+            entries.firstOrNull { it.storageKey == storageKey } ?: SYSTEM
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
@@ -3,6 +3,7 @@ package org.hdhmc.saki.domain.repository
 import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.TextScale
+import org.hdhmc.saki.domain.model.ThemeMode
 import kotlinx.coroutines.flow.Flow
 
 interface AppPreferencesRepository {
@@ -13,4 +14,6 @@ interface AppPreferencesRepository {
     suspend fun updateTextScale(textScale: TextScale)
 
     suspend fun updateLanguage(language: AppLanguage)
+
+    suspend fun updateThemeMode(themeMode: ThemeMode)
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Density
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.presentation.library.BrowseScreen
 import org.hdhmc.saki.presentation.library.NowPlayingOverlay

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.Density
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.hdhmc.saki.domain.model.AppLanguage
+import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.presentation.library.BrowseScreen
 import org.hdhmc.saki.presentation.library.NowPlayingOverlay
 import org.hdhmc.saki.presentation.library.NowPlayingCapsule
@@ -130,6 +131,7 @@ fun SakiApp(
                         onClearImageCache = viewModel::clearImageCache,
                         onUpdateTextScale = viewModel::updateTextScale,
                         onUpdateLanguage = viewModel::updateLanguage,
+                        onUpdateThemeMode = viewModel::updateThemeMode,
                         onUpdateBluetoothLyrics = viewModel::updateBluetoothLyrics,
                         onUpdateBufferStrategy = viewModel::updateBufferStrategy,
                         onUpdateCustomBufferSeconds = viewModel::updateCustomBufferSeconds,
@@ -204,6 +206,7 @@ private fun RootShell(
     onClearImageCache: () -> Unit,
     onUpdateTextScale: (org.hdhmc.saki.domain.model.TextScale) -> Unit,
     onUpdateLanguage: (org.hdhmc.saki.domain.model.AppLanguage) -> Unit,
+    onUpdateThemeMode: (ThemeMode) -> Unit,
     onUpdateBluetoothLyrics: (Boolean) -> Unit,
     onUpdateBufferStrategy: (org.hdhmc.saki.domain.model.BufferStrategy) -> Unit,
     onUpdateCustomBufferSeconds: (Int) -> Unit,
@@ -271,6 +274,7 @@ private fun RootShell(
                             onClearImageCache = onClearImageCache,
                             onUpdateTextScale = onUpdateTextScale,
                             onUpdateLanguage = onUpdateLanguage,
+                            onUpdateThemeMode = onUpdateThemeMode,
                             onUpdateBluetoothLyrics = onUpdateBluetoothLyrics,
                             onUpdateBufferStrategy = onUpdateBufferStrategy,
                             onUpdateCustomBufferSeconds = onUpdateCustomBufferSeconds,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -108,11 +108,7 @@ class SakiAppViewModel @Inject constructor(
                     }
                 }
                 // Apply saved theme mode
-                val nightMode = when (preferences.themeMode) {
-                    ThemeMode.SYSTEM -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                    ThemeMode.LIGHT -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
-                    ThemeMode.DARK -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
-                }
+                val nightMode = preferences.themeMode.toNightMode()
                 if (androidx.appcompat.app.AppCompatDelegate.getDefaultNightMode() != nightMode) {
                     androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode(nightMode)
                 }
@@ -268,17 +264,21 @@ class SakiAppViewModel @Inject constructor(
         }
     }
 
+    private fun ThemeMode.toNightMode(): Int = when (this) {
+        ThemeMode.SYSTEM -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        ThemeMode.LIGHT -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
+        ThemeMode.DARK -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
+    }
+
     fun updateThemeMode(themeMode: ThemeMode) {
         viewModelScope.launch {
             runCatching {
                 appPreferencesRepository.updateThemeMode(themeMode)
             }.onSuccess {
-                val nightMode = when (themeMode) {
-                    ThemeMode.SYSTEM -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                    ThemeMode.LIGHT -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
-                    ThemeMode.DARK -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
+                val nightMode = themeMode.toNightMode()
+                if (androidx.appcompat.app.AppCompatDelegate.getDefaultNightMode() != nightMode) {
+                    androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode(nightMode)
                 }
-                androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode(nightMode)
             }
         }
     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -11,6 +11,7 @@ import org.hdhmc.saki.domain.model.Album
 import org.hdhmc.saki.domain.model.AlbumListType
 import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.AppPreferences
+import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.domain.model.AlbumSummary
 import org.hdhmc.saki.domain.model.Artist
 import org.hdhmc.saki.domain.model.CacheStorageSummary
@@ -105,6 +106,15 @@ class SakiAppViewModel @Inject constructor(
                     if (current != locales) {
                         androidx.appcompat.app.AppCompatDelegate.setApplicationLocales(locales)
                     }
+                }
+                // Apply saved theme mode
+                val nightMode = when (preferences.themeMode) {
+                    ThemeMode.SYSTEM -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                    ThemeMode.LIGHT -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
+                    ThemeMode.DARK -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
+                }
+                if (androidx.appcompat.app.AppCompatDelegate.getDefaultNightMode() != nightMode) {
+                    androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode(nightMode)
                 }
             }
         }
@@ -254,6 +264,21 @@ class SakiAppViewModel @Inject constructor(
                     else -> androidx.core.os.LocaleListCompat.forLanguageTags(language.tag)
                 }
                 androidx.appcompat.app.AppCompatDelegate.setApplicationLocales(locales)
+            }
+        }
+    }
+
+    fun updateThemeMode(themeMode: ThemeMode) {
+        viewModelScope.launch {
+            runCatching {
+                appPreferencesRepository.updateThemeMode(themeMode)
+            }.onSuccess {
+                val nightMode = when (themeMode) {
+                    ThemeMode.SYSTEM -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                    ThemeMode.LIGHT -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
+                    ThemeMode.DARK -> androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
+                }
+                androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode(nightMode)
             }
         }
     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import org.hdhmc.saki.R
 import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.CachedSong
+import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.domain.model.MAX_STREAM_CACHE_SIZE_MB
 import org.hdhmc.saki.domain.model.MIN_STREAM_CACHE_SIZE_MB
 import org.hdhmc.saki.domain.model.BufferStrategy
@@ -94,6 +95,7 @@ fun SettingsScreen(
     onClearImageCache: () -> Unit,
     onUpdateTextScale: (TextScale) -> Unit,
     onUpdateLanguage: (AppLanguage) -> Unit,
+    onUpdateThemeMode: (ThemeMode) -> Unit,
     onUpdateBluetoothLyrics: (Boolean) -> Unit,
     onUpdateBufferStrategy: (BufferStrategy) -> Unit,
     onUpdateCustomBufferSeconds: (Int) -> Unit,
@@ -395,6 +397,36 @@ fun SettingsScreen(
                         selected = currentLanguage == AppLanguage.CHINESE,
                         coverage = translationCoverage("zh"),
                         onClick = { onUpdateLanguage(AppLanguage.CHINESE) },
+                    )
+                }
+            }
+        }
+
+        item {
+            SettingsSectionCard(
+                title = stringResource(R.string.settings_theme_title),
+                body = stringResource(R.string.settings_theme_body),
+                action = null,
+            ) {
+                val currentTheme = uiState.appPreferences.themeMode
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    FilterChip(
+                        selected = currentTheme == ThemeMode.SYSTEM,
+                        onClick = { onUpdateThemeMode(ThemeMode.SYSTEM) },
+                        label = { Text(stringResource(R.string.settings_theme_system)) },
+                    )
+                    FilterChip(
+                        selected = currentTheme == ThemeMode.LIGHT,
+                        onClick = { onUpdateThemeMode(ThemeMode.LIGHT) },
+                        label = { Text(stringResource(R.string.settings_theme_light)) },
+                    )
+                    FilterChip(
+                        selected = currentTheme == ThemeMode.DARK,
+                        onClick = { onUpdateThemeMode(ThemeMode.DARK) },
+                        label = { Text(stringResource(R.string.settings_theme_dark)) },
                     )
                 }
             }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -48,6 +48,11 @@
     <string name="settings_language_english">English</string>
     <string name="settings_language_chinese">中文</string>
     <string name="settings_language_coverage">%1$d%%</string>
+    <string name="settings_theme_title">主题</string>
+    <string name="settings_theme_body">选择应用的外观。</string>
+    <string name="settings_theme_system">跟随系统</string>
+    <string name="settings_theme_light">浅色</string>
+    <string name="settings_theme_dark">深色</string>
     <string name="settings_play_from_here">从此处播放</string>
     <string name="settings_remove_download">移除下载</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,11 @@
     <string name="settings_language_english">English</string>
     <string name="settings_language_chinese">中文</string>
     <string name="settings_language_coverage">%1$d%%</string>
+    <string name="settings_theme_title">Theme</string>
+    <string name="settings_theme_body">Choose the app appearance.</string>
+    <string name="settings_theme_system">System default</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_play_from_here">Play from here</string>
     <string name="settings_remove_download">Remove download</string>
 


### PR DESCRIPTION
Closes #136

## Feature
Manual dark/light theme selection in Settings, following the same pattern as the existing language selector.

## Changes

### New: ThemeMode enum
- `SYSTEM` (default) / `LIGHT` / `DARK`
- Stored in DataStore with key `theme_mode`
- Applied via `AppCompatDelegate.setDefaultNightMode()`

### Settings UI
- New "Theme" section with 3 FilterChips (System default / Light / Dark)
- Placed after the Language section

### Data flow
- `AppPreferences.themeMode` → DataStore persistence
- `SakiAppViewModel.updateThemeMode()` → saves + applies AppCompat night mode
- Startup restore in ViewModel init block (same pattern as language)

### No changes needed
- `Theme.kt` — `isSystemInDarkTheme()` automatically respects `AppCompatDelegate.setDefaultNightMode()`
- `MainActivity.kt` — no changes

## Files changed (9)
- `domain/model/AppPreferences.kt` — ThemeMode enum + field
- `domain/repository/AppPreferencesRepository.kt` — interface method
- `data/repository/DataStoreAppPreferencesRepository.kt` — key + read/write
- `data/repository/DefaultAppPreferencesRepository.kt` — no-op
- `presentation/SakiAppViewModel.kt` — update method + startup restore
- `presentation/settings/SettingsScreen.kt` — theme section UI
- `presentation/SakiApp.kt` — callback threading
- `values/strings.xml` — EN strings
- `values-zh/strings.xml` — ZH strings