### PR TITLE
fix: prefer cached local files for library playback

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultCachedSongRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultCachedSongRepository.kt
@@ -50,6 +50,27 @@ class DefaultCachedSongRepository @Inject constructor(
         cachedSongDao.getCachedSong(serverId, songId)?.toDomain()
     }
 
+    override suspend fun getPlayableCachedSong(
+        serverId: Long,
+        songId: String,
+        preferredQuality: StreamQuality,
+    ): CachedSong? = withContext(ioDispatcher) {
+        cachedSongDao.getCachedSong(serverId, songId)
+            ?.toDomain()
+            ?.takeIf { song -> song.canPlayAt(preferredQuality) }
+    }
+
+    override suspend fun getPlayableCachedSongs(
+        serverId: Long,
+        preferredQuality: StreamQuality,
+    ): Map<String, CachedSong> = withContext(ioDispatcher) {
+        cachedSongDao.getCachedSongsForServer(serverId)
+            .asSequence()
+            .map(CachedSongEntity::toDomain)
+            .filter { song -> song.canPlayAt(preferredQuality) }
+            .associateBy(CachedSong::songId)
+    }
+
     override suspend fun cacheSong(
         serverId: Long,
         song: Song,
@@ -316,6 +337,14 @@ private fun CachedSongEntity.toDomain(): CachedSong {
         fileSizeBytes = fileSizeBytes,
         downloadedAt = downloadedAt,
     )
+}
+
+private fun CachedSong.canPlayAt(preferredQuality: StreamQuality): Boolean {
+    return File(localPath).isFile && quality.isAtLeast(preferredQuality)
+}
+
+private fun StreamQuality.isAtLeast(preferredQuality: StreamQuality): Boolean {
+    return ordinal <= preferredQuality.ordinal
 }
 
 private fun buildCacheFileStem(

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/CachedSongRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/CachedSongRepository.kt
@@ -3,6 +3,7 @@ package org.hdhmc.saki.domain.repository
 import org.hdhmc.saki.domain.model.CacheStorageSummary
 import org.hdhmc.saki.domain.model.CachedSong
 import org.hdhmc.saki.domain.model.Song
+import org.hdhmc.saki.domain.model.StreamQuality
 import kotlinx.coroutines.flow.Flow
 
 interface CachedSongRepository {
@@ -12,6 +13,17 @@ interface CachedSongRepository {
         serverId: Long,
         songId: String,
     ): CachedSong?
+
+    suspend fun getPlayableCachedSong(
+        serverId: Long,
+        songId: String,
+        preferredQuality: StreamQuality,
+    ): CachedSong?
+
+    suspend fun getPlayableCachedSongs(
+        serverId: Long,
+        preferredQuality: StreamQuality,
+    ): Map<String, CachedSong>
 
     suspend fun cacheSong(
         serverId: Long,

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -22,10 +22,12 @@ import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.RepeatModeSetting
 import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.domain.model.StreamQuality
+import org.hdhmc.saki.domain.repository.CachedSongRepository
 import org.hdhmc.saki.domain.repository.PlaybackManager
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
 import org.hdhmc.saki.domain.repository.StreamCacheRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
 import javax.inject.Inject
@@ -53,6 +55,7 @@ class DefaultPlaybackManager @Inject constructor(
     @param:ApplicationContext private val appContext: Context,
     @param:MainDispatcher private val mainDispatcher: CoroutineDispatcher,
     private val playbackPreferencesRepository: PlaybackPreferencesRepository,
+    private val cachedSongRepository: CachedSongRepository,
     private val streamCacheRepository: StreamCacheRepository,
     private val networkTypeProvider: NetworkTypeProvider,
 ) : PlaybackManager {
@@ -85,10 +88,51 @@ class DefaultPlaybackManager @Inject constructor(
         }
     }
 
-    private fun resolveQualityForSong(serverId: Long, songId: String): StreamQuality {
-        val preferred = effectiveQuality()
+    private fun resolveQualityForSong(
+        serverId: Long,
+        songId: String,
+        preferred: StreamQuality = effectiveQuality(),
+    ): StreamQuality {
         val cachedKey = streamCacheRepository.findCachedQualityKey(serverId, songId, preferred)
         return if (cachedKey != null) StreamQuality.fromStorageKey(cachedKey) else preferred
+    }
+
+    private suspend fun Song.toPreferredMediaItem(serverId: Long): MediaItem {
+        val preferredQuality = effectiveQuality()
+        val cachedSong = cachedSongRepository.getCachedSong(serverId, id)
+        if (cachedSong != null && cachedSong.canPlayAt(preferredQuality)) {
+            return cachedSong.toCachedMediaItem()
+        }
+
+        val quality = resolveQualityForSong(serverId, id, preferredQuality)
+        return toPlaybackRequestMediaItem(
+            serverId = serverId,
+            qualityLabel = quality.label,
+            streamCacheKey = streamCacheRepository.buildCacheKey(serverId, id, quality),
+            artworkUri = null,
+            maxBitRate = quality.maxBitRate,
+            format = quality.format,
+        )
+    }
+
+    private suspend fun PlaybackRequest.toPreferredMediaItemOrNull(): MediaItem? {
+        val preferredQuality = effectiveQuality()
+        val cachedSong = cachedSongRepository.getCachedSong(serverId, songId)
+        if (cachedSong != null && cachedSong.canPlayAt(preferredQuality)) {
+            return cachedSong.toCachedMediaItem()
+        }
+
+        val quality = resolveQualityForSong(serverId, songId, preferredQuality)
+        if (quality.maxBitRate == maxBitRate && quality.format == format) {
+            return null
+        }
+
+        return copy(
+            qualityLabel = quality.label,
+            streamCacheKey = streamCacheRepository.buildCacheKey(serverId, songId, quality),
+            maxBitRate = quality.maxBitRate,
+            format = quality.format,
+        ).toLogicalMediaItem()
     }
 
     init {
@@ -137,17 +181,7 @@ class DefaultPlaybackManager @Inject constructor(
         require(songs.isNotEmpty()) { "Playback queue cannot be empty." }
         shuffleDisplayOrder = null
         persistShuffleState()
-        val mediaItems = songs.map { song ->
-            val quality = resolveQualityForSong(serverId, song.id)
-            song.toPlaybackRequestMediaItem(
-                serverId = serverId,
-                qualityLabel = quality.label,
-                streamCacheKey = streamCacheRepository.buildCacheKey(serverId, song.id, quality),
-                artworkUri = null,
-                maxBitRate = quality.maxBitRate,
-                format = quality.format,
-            )
-        }
+        val mediaItems = songs.map { song -> song.toPreferredMediaItem(serverId) }
 
         withController { activeController ->
             val safeStartIndex = startIndex.coerceIn(mediaItems.indices)
@@ -167,17 +201,7 @@ class DefaultPlaybackManager @Inject constructor(
     ) {
         if (songs.isEmpty()) return
         shuffleDisplayOrder = null
-        val mediaItems = songs.map { song ->
-            val quality = resolveQualityForSong(serverId, song.id)
-            song.toPlaybackRequestMediaItem(
-                serverId = serverId,
-                qualityLabel = quality.label,
-                streamCacheKey = streamCacheRepository.buildCacheKey(serverId, song.id, quality),
-                artworkUri = null,
-                maxBitRate = quality.maxBitRate,
-                format = quality.format,
-            )
-        }
+        val mediaItems = songs.map { song -> song.toPreferredMediaItem(serverId) }
 
         withController { activeController ->
             val safeStartIndex = startIndex.coerceIn(mediaItems.indices)
@@ -225,17 +249,7 @@ class DefaultPlaybackManager @Inject constructor(
     ) {
         if (songs.isEmpty()) return
         clearShuffleIfActive()
-        val mediaItems = songs.map { song ->
-            val quality = resolveQualityForSong(serverId, song.id)
-            song.toPlaybackRequestMediaItem(
-                serverId = serverId,
-                qualityLabel = quality.label,
-                streamCacheKey = streamCacheRepository.buildCacheKey(serverId, song.id, quality),
-                artworkUri = null,
-                maxBitRate = quality.maxBitRate,
-                format = quality.format,
-            )
-        }
+        val mediaItems = songs.map { song -> song.toPreferredMediaItem(serverId) }
 
         withController { activeController ->
             activeController.addMediaItems(mediaItems)
@@ -248,15 +262,7 @@ class DefaultPlaybackManager @Inject constructor(
         song: Song,
     ) {
         clearShuffleIfActive()
-        val quality = resolveQualityForSong(serverId, song.id)
-        val mediaItem = song.toPlaybackRequestMediaItem(
-            serverId = serverId,
-            qualityLabel = quality.label,
-            streamCacheKey = streamCacheRepository.buildCacheKey(serverId, song.id, quality),
-            artworkUri = null,
-            maxBitRate = quality.maxBitRate,
-            format = quality.format,
-        )
+        val mediaItem = song.toPreferredMediaItem(serverId)
 
         withController { activeController ->
             val insertIndex = if (activeController.currentMediaItemIndex == C.INDEX_UNSET) {
@@ -291,24 +297,7 @@ class DefaultPlaybackManager @Inject constructor(
                 val nextItem = activeController.getMediaItemAt(nextIndex)
                 val request = nextItem.toPlaybackRequestOrNull()
                 if (request != null && !request.isCached) {
-                    val quality = resolveQualityForSong(request.serverId, request.songId)
-                    if (quality.maxBitRate != request.maxBitRate) {
-                        val rebuilt = request.copy(
-                            qualityLabel = quality.label,
-                            streamCacheKey = streamCacheRepository.buildCacheKey(request.serverId, request.songId, quality),
-                            maxBitRate = quality.maxBitRate,
-                            format = quality.format,
-                        ).let { updated ->
-                            MediaItem.Builder()
-                                .setMediaId(updated.songId)
-                                .setMediaMetadata(updated.toMediaMetadata())
-                                .setRequestMetadata(
-                                    MediaItem.RequestMetadata.Builder()
-                                        .setExtras(updated.toBundle())
-                                        .build(),
-                                )
-                                .build()
-                        }
+                    request.toPreferredMediaItemOrNull()?.let { rebuilt ->
                         activeController.replaceMediaItem(nextIndex, rebuilt)
                     }
                 }
@@ -562,6 +551,26 @@ private fun Int.toRepeatModeSetting(): RepeatModeSetting {
         Player.REPEAT_MODE_ALL -> RepeatModeSetting.ALL
         else -> RepeatModeSetting.OFF
     }
+}
+
+private fun CachedSong.canPlayAt(preferredQuality: StreamQuality): Boolean {
+    return File(localPath).isFile && quality.isAtLeast(preferredQuality)
+}
+
+private fun StreamQuality.isAtLeast(preferredQuality: StreamQuality): Boolean {
+    return StreamQuality.entries.indexOf(this) <= StreamQuality.entries.indexOf(preferredQuality)
+}
+
+private fun PlaybackRequest.toLogicalMediaItem(): MediaItem {
+    return MediaItem.Builder()
+        .setMediaId(songId)
+        .setMediaMetadata(toMediaMetadata())
+        .setRequestMetadata(
+            MediaItem.RequestMetadata.Builder()
+                .setExtras(toBundle())
+                .build(),
+        )
+        .build()
 }
 
 @UnstableApi

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -27,7 +27,6 @@ import org.hdhmc.saki.domain.repository.PlaybackManager
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
 import org.hdhmc.saki.domain.repository.StreamCacheRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.io.File
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
 import javax.inject.Inject
@@ -97,10 +96,12 @@ class DefaultPlaybackManager @Inject constructor(
         return if (cachedKey != null) StreamQuality.fromStorageKey(cachedKey) else preferred
     }
 
-    private suspend fun Song.toPreferredMediaItem(serverId: Long): MediaItem {
-        val preferredQuality = effectiveQuality()
-        val cachedSong = cachedSongRepository.getCachedSong(serverId, id)
-        if (cachedSong != null && cachedSong.canPlayAt(preferredQuality)) {
+    private fun Song.toPreferredMediaItem(
+        serverId: Long,
+        preferredQuality: StreamQuality,
+        cachedSong: CachedSong?,
+    ): MediaItem {
+        if (cachedSong != null) {
             return cachedSong.toCachedMediaItem()
         }
 
@@ -117,8 +118,8 @@ class DefaultPlaybackManager @Inject constructor(
 
     private suspend fun PlaybackRequest.toPreferredMediaItemOrNull(): MediaItem? {
         val preferredQuality = effectiveQuality()
-        val cachedSong = cachedSongRepository.getCachedSong(serverId, songId)
-        if (cachedSong != null && cachedSong.canPlayAt(preferredQuality)) {
+        val cachedSong = cachedSongRepository.getPlayableCachedSong(serverId, songId, preferredQuality)
+        if (cachedSong != null) {
             return cachedSong.toCachedMediaItem()
         }
 
@@ -181,7 +182,15 @@ class DefaultPlaybackManager @Inject constructor(
         require(songs.isNotEmpty()) { "Playback queue cannot be empty." }
         shuffleDisplayOrder = null
         persistShuffleState()
-        val mediaItems = songs.map { song -> song.toPreferredMediaItem(serverId) }
+        val preferredQuality = effectiveQuality()
+        val cachedSongsById = cachedSongRepository.getPlayableCachedSongs(serverId, preferredQuality)
+        val mediaItems = songs.map { song ->
+            song.toPreferredMediaItem(
+                serverId = serverId,
+                preferredQuality = preferredQuality,
+                cachedSong = cachedSongsById[song.id],
+            )
+        }
 
         withController { activeController ->
             val safeStartIndex = startIndex.coerceIn(mediaItems.indices)
@@ -201,7 +210,15 @@ class DefaultPlaybackManager @Inject constructor(
     ) {
         if (songs.isEmpty()) return
         shuffleDisplayOrder = null
-        val mediaItems = songs.map { song -> song.toPreferredMediaItem(serverId) }
+        val preferredQuality = effectiveQuality()
+        val cachedSongsById = cachedSongRepository.getPlayableCachedSongs(serverId, preferredQuality)
+        val mediaItems = songs.map { song ->
+            song.toPreferredMediaItem(
+                serverId = serverId,
+                preferredQuality = preferredQuality,
+                cachedSong = cachedSongsById[song.id],
+            )
+        }
 
         withController { activeController ->
             val safeStartIndex = startIndex.coerceIn(mediaItems.indices)
@@ -249,7 +266,15 @@ class DefaultPlaybackManager @Inject constructor(
     ) {
         if (songs.isEmpty()) return
         clearShuffleIfActive()
-        val mediaItems = songs.map { song -> song.toPreferredMediaItem(serverId) }
+        val preferredQuality = effectiveQuality()
+        val cachedSongsById = cachedSongRepository.getPlayableCachedSongs(serverId, preferredQuality)
+        val mediaItems = songs.map { song ->
+            song.toPreferredMediaItem(
+                serverId = serverId,
+                preferredQuality = preferredQuality,
+                cachedSong = cachedSongsById[song.id],
+            )
+        }
 
         withController { activeController ->
             activeController.addMediaItems(mediaItems)
@@ -262,7 +287,13 @@ class DefaultPlaybackManager @Inject constructor(
         song: Song,
     ) {
         clearShuffleIfActive()
-        val mediaItem = song.toPreferredMediaItem(serverId)
+        val preferredQuality = effectiveQuality()
+        val cachedSong = cachedSongRepository.getPlayableCachedSong(serverId, song.id, preferredQuality)
+        val mediaItem = song.toPreferredMediaItem(
+            serverId = serverId,
+            preferredQuality = preferredQuality,
+            cachedSong = cachedSong,
+        )
 
         withController { activeController ->
             val insertIndex = if (activeController.currentMediaItemIndex == C.INDEX_UNSET) {
@@ -551,14 +582,6 @@ private fun Int.toRepeatModeSetting(): RepeatModeSetting {
         Player.REPEAT_MODE_ALL -> RepeatModeSetting.ALL
         else -> RepeatModeSetting.OFF
     }
-}
-
-private fun CachedSong.canPlayAt(preferredQuality: StreamQuality): Boolean {
-    return File(localPath).isFile && quality.isAtLeast(preferredQuality)
-}
-
-private fun StreamQuality.isAtLeast(preferredQuality: StreamQuality): Boolean {
-    return StreamQuality.entries.indexOf(this) <= StreamQuality.entries.indexOf(preferredQuality)
 }
 
 private fun PlaybackRequest.toLogicalMediaItem(): MediaItem {


### PR DESCRIPTION
Closes #150

## Problem
Songs that have been downloaded (shown with a checkmark in the Songs list) still play via streaming instead of using the local cached file, even when the cached quality meets or exceeds the current stream quality setting.

## Fix
`DefaultPlaybackManager` now checks for cached songs before building stream URLs. If a cached file exists and its quality is at least as good as the current stream quality, the local file is used for playback.

### Changes

**`CachedSongRepository` / `DefaultCachedSongRepository`**
- `getPlayableCachedSong(serverId, songId, preferredQuality)` — single song lookup with quality + file existence check
- `getPlayableCachedSongs(serverId, preferredQuality)` — batch lookup returning `Map<songId, CachedSong>` for queue building
- `CachedSong.canPlayAt()` — checks `File(localPath).isFile` and `quality.isAtLeast(preferredQuality)`
- `StreamQuality.isAtLeast()` — ordinal comparison (ORIGINAL=0 is highest)

**`DefaultPlaybackManager`**
- Inject `CachedSongRepository`
- `Song.toPreferredMediaItem()` — prefers cached file, falls back to stream
- `PlaybackRequest.toPreferredMediaItemOrNull()` — for prefetch/quality upgrade of next track
- All playback entry points (`play`, `playNext`, `addToQueue`, `addSongToQueue`) now check cache first
- Prefetch logic also checks for cached versions
- Extract `PlaybackRequest.toLogicalMediaItem()` to eliminate duplicated MediaItem builder code

### Quality comparison logic
`StreamQuality` enum ordinal: ORIGINAL(0) > 320kbps(1) > ... > 96kbps(6). A cached song is playable if its ordinal ≤ the preferred quality's ordinal (i.e., same or better quality).