### PR TITLE
fix: remove redundant titles and subtitles from browse tabs

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -257,7 +257,7 @@ private fun LibraryDetailScaffold(
                         )
                     }
                     Text(text = title, style = MaterialTheme.typography.displaySmall, modifier = Modifier.padding(top = 14.dp))
-                    if (subtitle != null) {
+                    if (!subtitle.isNullOrBlank()) {
                         Text(
                             text = subtitle,
                             style = MaterialTheme.typography.bodyLarge,
@@ -658,7 +658,7 @@ private fun RowCard(title: String, subtitle: String?, artwork: Any?, onClick: ()
                     .padding(start = if (artwork != null) 12.dp else 0.dp),
             ) {
                 Text(text = title, style = MaterialTheme.typography.titleLarge, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                if (subtitle != null) {
+                if (!subtitle.isNullOrBlank()) {
                     Text(text = subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -77,14 +77,9 @@ fun ArtistDetailScreen(
     onShowActions: (Song) -> Unit,
 ) {
     val albumCount = artist.albumCount
-    val subtitle = if (albumCount != null) {
-        albumCountText(albumCount)
-    } else {
-        stringResource(R.string.library_artist_fallback)
-    }
     LibraryDetailScaffold(
         title = artist.name,
-        subtitle = subtitle,
+        subtitle = if (albumCount != null) albumCountText(albumCount) else null,
         artwork = null,
     ) {
         when {
@@ -234,7 +229,7 @@ fun PlaylistDetailScreen(
 @Composable
 private fun LibraryDetailScaffold(
     title: String,
-    subtitle: String,
+    subtitle: String?,
     artwork: Any?,
     content: androidx.compose.foundation.lazy.LazyListScope.() -> Unit,
 ) {
@@ -262,12 +257,14 @@ private fun LibraryDetailScaffold(
                         )
                     }
                     Text(text = title, style = MaterialTheme.typography.displaySmall, modifier = Modifier.padding(top = 14.dp))
-                    Text(
-                        text = subtitle,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 6.dp),
-                    )
+                    if (subtitle != null) {
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 6.dp),
+                        )
+                    }
                 }
             }
         }
@@ -278,14 +275,9 @@ private fun LibraryDetailScaffold(
 @Composable
 fun ArtistRow(artist: ArtistSummary, onOpenArtist: (String) -> Unit) {
     val albumCount = artist.albumCount
-    val subtitle = if (albumCount != null) {
-        albumCountText(albumCount)
-    } else {
-        stringResource(R.string.library_artist_fallback)
-    }
     RowCard(
         title = artist.name,
-        subtitle = subtitle,
+        subtitle = if (albumCount != null) albumCountText(albumCount) else null,
         artwork = null,
         onClick = { onOpenArtist(artist.id) },
     )
@@ -325,11 +317,6 @@ fun AlbumRow(album: AlbumSummary, server: ServerConfig, onOpenAlbum: (String) ->
 @Composable
 fun ArtistShortcutCard(artist: ArtistSummary, onOpenArtist: (String) -> Unit) {
     val albumCount = artist.albumCount
-    val subtitle = if (albumCount != null) {
-        releaseCountText(albumCount)
-    } else {
-        stringResource(R.string.library_open_artist)
-    }
     Card(
         modifier = Modifier
             .width(190.dp)
@@ -343,11 +330,13 @@ fun ArtistShortcutCard(artist: ArtistSummary, onOpenArtist: (String) -> Unit) {
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Text(text = artist.name, style = MaterialTheme.typography.titleLarge)
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            if (albumCount != null) {
+                Text(
+                    text = releaseCountText(albumCount),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }
@@ -650,7 +639,7 @@ fun EmptyStateCard(title: String, body: String, icon: androidx.compose.ui.graphi
 }
 
 @Composable
-private fun RowCard(title: String, subtitle: String, artwork: Any?, onClick: () -> Unit) {
+private fun RowCard(title: String, subtitle: String?, artwork: Any?, onClick: () -> Unit) {
     Card(
         onClick = onClick,
         modifier = Modifier
@@ -669,7 +658,9 @@ private fun RowCard(title: String, subtitle: String, artwork: Any?, onClick: () 
                     .padding(start = if (artwork != null) 12.dp else 0.dp),
             ) {
                 Text(text = title, style = MaterialTheme.typography.titleLarge, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                Text(text = subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                if (subtitle != null) {
+                    Text(text = subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
             }
             Icon(Icons.AutoMirrored.Rounded.ArrowForward, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
         }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -655,12 +655,6 @@ private fun ArtistsPage(
         ) {
             if (indexes.shortcuts.isNotEmpty()) {
                 item {
-                    SectionTitle(
-                        stringResource(R.string.browse_shortcuts),
-                        stringResource(R.string.browse_shortcuts_subtitle),
-                    )
-                }
-                item {
                     LazyRow {
                         items(indexes.shortcuts, key = { it.id }) { artist ->
                             ArtistShortcutCard(artist = artist, onOpenArtist = onOpenArtist)
@@ -746,12 +740,6 @@ private fun AlbumsPage(
         contentPadding = PaddingValues(bottom = 24.dp),
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {
-            SectionTitle(
-                stringResource(R.string.library_albums),
-                stringResource(R.string.browse_albums_subtitle),
-            )
-        }
-        item(span = { GridItemSpan(maxLineSpan) }) {
             LazyRow(contentPadding = PaddingValues(vertical = 10.dp)) {
                 items(feeds) { feed ->
                     FilterChip(
@@ -819,12 +807,6 @@ private fun PlaylistsPage(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(bottom = 24.dp),
     ) {
-        item {
-            SectionTitle(
-                stringResource(R.string.browse_playlists),
-                stringResource(R.string.browse_playlists_subtitle),
-            )
-        }
         items(playlists, key = { it.id }) { playlist ->
             PlaylistCard(playlist = playlist, server = server, onOpenPlaylist = onOpenPlaylist)
         }
@@ -862,12 +844,6 @@ private fun SongsPage(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(bottom = 24.dp),
     ) {
-        item {
-            SectionTitle(
-                stringResource(R.string.browse_songs),
-                stringResource(R.string.browse_songs_subtitle),
-            )
-        }
         itemsIndexed(songs, key = { _, s -> s.id }) { index, song ->
             SongRow(
                 song = song,

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -111,7 +111,6 @@
     <string name="server_config_latency_ms">%1$d 毫秒</string>
     <string name="server_config_latency_ms_sentence">%1$d 毫秒。</string>
 
-    <string name="library_artist_fallback">艺术家</string>
     <string name="library_loading_artist">正在加载艺术家</string>
     <string name="library_popular_songs">热门歌曲</string>
     <string name="library_popular_songs_subtitle">%1$s 的精选</string>
@@ -125,7 +124,6 @@
     <string name="library_tracks">曲目</string>
     <string name="library_playlist_sequence">播放列表顺序</string>
     <string name="library_play_playlist">播放列表</string>
-    <string name="library_open_artist">查看艺术家</string>
     <string name="library_available_offline">可离线播放</string>
     <string name="library_unknown_artist_album">未知艺术家 · 未知专辑</string>
     <string name="library_more_actions">更多操作</string>
@@ -181,8 +179,6 @@
     <string name="browse_no_artists">无艺术家</string>
     <string name="browse_no_artists_body">服务器未返回艺术家索引。</string>
     <string name="browse_shortcuts">快捷方式</string>
-    <string name="browse_shortcuts_subtitle">置顶艺术家</string>
-    <string name="browse_albums_subtitle">滑动切换标签或切换排序</string>
     <string name="browse_loading_albums">正在加载专辑</string>
     <string name="browse_no_albums">无专辑</string>
     <string name="browse_no_albums_body">试试其他专辑排序。</string>
@@ -190,11 +186,9 @@
     <string name="browse_no_playlists">无播放列表</string>
     <string name="browse_no_playlists_body">在服务器上创建播放列表后即可在此查看。</string>
     <string name="browse_playlists">播放列表</string>
-    <string name="browse_playlists_subtitle">打开完整播放列表页面</string>
     <string name="browse_loading_songs">正在加载歌曲</string>
     <string name="browse_no_songs">无歌曲</string>
     <string name="browse_no_songs_body">当前歌曲列表为空。</string>
-    <string name="browse_songs_subtitle">封面、元数据、下载状态及更多操作</string>
     <string name="browse_section_artists_headline">浏览曲库</string>
     <string name="browse_section_albums_headline">翻阅专辑</string>
     <string name="browse_section_playlists_headline">播放精选合集</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,7 +119,6 @@
     <string name="server_config_latency_ms">%1$d ms</string>
     <string name="server_config_latency_ms_sentence">%1$d ms.</string>
 
-    <string name="library_artist_fallback">Artist</string>
     <string name="library_loading_artist">Loading artist</string>
     <string name="library_popular_songs">Popular songs</string>
     <string name="library_popular_songs_subtitle">Quick picks for %1$s</string>
@@ -133,7 +132,6 @@
     <string name="library_tracks">Tracks</string>
     <string name="library_playlist_sequence">Playlist sequence</string>
     <string name="library_play_playlist">Play playlist</string>
-    <string name="library_open_artist">Open artist</string>
     <string name="library_available_offline">Available offline</string>
     <string name="library_unknown_artist_album">Unknown artist • Unknown album</string>
     <string name="library_more_actions">More actions</string>
@@ -189,8 +187,6 @@
     <string name="browse_no_artists">No artists</string>
     <string name="browse_no_artists_body">The server did not return artist indexes.</string>
     <string name="browse_shortcuts">Shortcuts</string>
-    <string name="browse_shortcuts_subtitle">Pinned artists</string>
-    <string name="browse_albums_subtitle">Swipe to another tab or switch feed</string>
     <string name="browse_loading_albums">Loading albums</string>
     <string name="browse_no_albums">No albums</string>
     <string name="browse_no_albums_body">Try another album feed.</string>
@@ -198,11 +194,9 @@
     <string name="browse_no_playlists">No playlists</string>
     <string name="browse_no_playlists_body">Create a playlist on your server to see it here.</string>
     <string name="browse_playlists">Playlists</string>
-    <string name="browse_playlists_subtitle">Open a full playlist page</string>
     <string name="browse_loading_songs">Loading songs</string>
     <string name="browse_no_songs">No songs</string>
     <string name="browse_no_songs_body">The current song feed is empty.</string>
-    <string name="browse_songs_subtitle">Artwork, metadata, download state, and more actions</string>
     <string name="browse_section_artists_headline">Browse the library</string>
     <string name="browse_section_albums_headline">Flip through releases</string>
     <string name="browse_section_playlists_headline">Queue curated mixes</string>


### PR DESCRIPTION
Closes #154

## Problem
Browse tabs display redundant `SectionTitle` headers and subtitles that waste vertical space — the tab bar already provides navigation context. Artist cards all show a useless "Artist" / "艺术家" fallback subtitle.

## Fix
- Remove `SectionTitle` from Albums, Songs, Playlists, Shortcuts tab pages
- Remove "Artist" fallback subtitle from `ArtistRow` and artist detail page
- Remove "Open artist" fallback subtitle from `ArtistShortcutCard`
- Keep album count subtitle ("X releases" / "X albums") when available
- Make `RowCard` and `LibraryDetailScaffold` subtitle nullable
- Remove 7 unused string resources (EN + ZH)

Search results page section titles are preserved — they serve a real purpose there.