### PR TITLE
fix: album feed swipe behavior

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -326,6 +326,7 @@ class SakiAppViewModel @Inject constructor(
                 selectedServerId = serverId,
                 selectedArtist = null,
                 selectedArtistTopSongs = emptyList(),
+                albumFeeds = emptyAlbumFeedStates(),
                 selectedAlbum = null,
                 selectedPlaylist = null,
             )
@@ -341,32 +342,40 @@ class SakiAppViewModel @Inject constructor(
         mutableUiState.update { state ->
             state.copy(
                 selectedAlbumFeed = type,
-                albums = emptyList(),
-                albumsOffset = 0,
-                hasMoreAlbums = type.supportsPagination(),
-                isLoadingMoreAlbums = false,
-                albumsError = null,
+                albumFeeds = state.albumFeeds.updateFeed(type) { feedState ->
+                    feedState.copy(
+                        isLoadingMore = false,
+                        error = null,
+                    )
+                },
             )
         }
-        loadAlbums(serverId, type, forceRefresh = true)
+        loadAlbums(serverId, type)
     }
 
     fun loadMoreAlbums() {
         val state = uiState.value
         val serverId = state.selectedServerId ?: return
         val type = state.selectedAlbumFeed
+        val feedState = state.albumFeedState(type)
         if (
             !type.supportsPagination() ||
-            !state.hasMoreAlbums ||
-            state.isAlbumsLoading ||
-            state.isLoadingMoreAlbums
+            !feedState.hasMore ||
+            feedState.isLoading ||
+            feedState.isLoadingMore
         ) {
             return
         }
-        val offset = state.albumsOffset
+        val offset = feedState.offset
 
         viewModelScope.launch {
-            mutableUiState.update { it.copy(isLoadingMoreAlbums = true, albumsError = null) }
+            mutableUiState.update { current ->
+                current.copy(
+                    albumFeeds = current.albumFeeds.updateFeed(type) {
+                        it.copy(isLoadingMore = true, error = null)
+                    },
+                )
+            }
 
             runCatching {
                 subsonicRepository.getAlbumList(
@@ -376,28 +385,37 @@ class SakiAppViewModel @Inject constructor(
                     offset = offset,
                 ).data
             }.onSuccess { page ->
-                if (uiState.value.selectedServerId == serverId && uiState.value.selectedAlbumFeed == type) {
+                if (uiState.value.selectedServerId == serverId) {
                     var mergedAlbums = emptyList<AlbumSummary>()
                     mutableUiState.update { current ->
-                        mergedAlbums = (current.albums + page).distinctBy(AlbumSummary::id)
-                        val addedAny = mergedAlbums.size > current.albums.size
+                        val currentFeed = current.albumFeedState(type)
+                        mergedAlbums = (currentFeed.albums + page).distinctBy(AlbumSummary::id)
+                        val addedAny = mergedAlbums.size > currentFeed.albums.size
                         current.copy(
-                            albums = mergedAlbums,
-                            albumsOffset = mergedAlbums.size,
-                            hasMoreAlbums = page.size >= ALBUMS_PAGE_SIZE && addedAny,
-                            isLoadingMoreAlbums = false,
-                            albumsError = null,
+                            albumFeeds = current.albumFeeds.updateFeed(type) {
+                                it.copy(
+                                    albums = mergedAlbums,
+                                    offset = mergedAlbums.size,
+                                    hasMore = page.size >= ALBUMS_PAGE_SIZE && addedAny,
+                                    isLoadingMore = false,
+                                    error = null,
+                                )
+                            },
                         )
                     }
                     runCatching { libraryCacheRepository.saveAlbums(serverId, type, mergedAlbums) }
                         .onFailure { Log.w("SakiApp", "Failed to cache albums", it) }
                 }
             }.onFailure { throwable ->
-                if (uiState.value.selectedServerId == serverId && uiState.value.selectedAlbumFeed == type) {
-                    mutableUiState.update {
-                        it.copy(
-                            isLoadingMoreAlbums = false,
-                            albumsError = throwable.localizedOr(R.string.error_load_albums),
+                if (uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { current ->
+                        current.copy(
+                            albumFeeds = current.albumFeeds.updateFeed(type) {
+                                it.copy(
+                                    isLoadingMore = false,
+                                    error = throwable.localizedOr(R.string.error_load_albums),
+                                )
+                            },
                         )
                     }
                 }
@@ -941,6 +959,7 @@ class SakiAppViewModel @Inject constructor(
                 selectedServerId = selectedServerId,
                 selectedArtist = if (serverChanged) null else state.selectedArtist,
                 selectedArtistTopSongs = if (serverChanged) emptyList() else state.selectedArtistTopSongs,
+                albumFeeds = if (serverChanged) emptyAlbumFeedStates() else state.albumFeeds,
                 selectedAlbum = if (serverChanged) null else state.selectedAlbum,
                 selectedPlaylist = if (serverChanged) null else state.selectedPlaylist,
             )
@@ -1043,16 +1062,20 @@ class SakiAppViewModel @Inject constructor(
             if (artists != null && uiState.value.selectedServerId == serverId) {
                 mutableUiState.update { it.copy(libraryIndexes = artists.regroupByLocale()) }
             }
-            val selectedAlbumFeed = uiState.value.selectedAlbumFeed
-            val albums = loadCachedOrNull { libraryCacheRepository.getAlbums(serverId, selectedAlbumFeed) }
-            if (!albums.isNullOrEmpty() && uiState.value.selectedServerId == serverId &&
-                uiState.value.selectedAlbumFeed == selectedAlbumFeed) {
-                mutableUiState.update {
-                    it.copy(
-                        albums = albums,
-                        albumsOffset = albums.size,
-                        hasMoreAlbums = selectedAlbumFeed.supportsPagination(),
-                    )
+            AlbumListType.entries.forEach { albumFeed ->
+                val albums = loadCachedOrNull { libraryCacheRepository.getAlbums(serverId, albumFeed) }
+                if (!albums.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { state ->
+                        state.copy(
+                            albumFeeds = state.albumFeeds.updateFeed(albumFeed) {
+                                it.copy(
+                                    albums = albums,
+                                    offset = albums.size,
+                                    hasMore = albumFeed.supportsPagination(),
+                                )
+                            },
+                        )
+                    }
                 }
             }
             val playlists = loadCachedOrNull { libraryCacheRepository.getPlaylists(serverId) }
@@ -1118,7 +1141,8 @@ class SakiAppViewModel @Inject constructor(
         type: AlbumListType,
         forceRefresh: Boolean = false,
     ) {
-        if (!forceRefresh && uiState.value.albums.isNotEmpty() && uiState.value.selectedAlbumFeed == type) {
+        val currentFeed = uiState.value.albumFeedState(type)
+        if (!forceRefresh && (currentFeed.isLoading || currentFeed.hasLoadedFromNetwork)) {
             return
         }
 
@@ -1126,23 +1150,31 @@ class SakiAppViewModel @Inject constructor(
             if (!forceRefresh) {
                 val cached = runCatching { libraryCacheRepository.getAlbums(serverId, type) }.getOrNull()
                 if (!cached.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
-                    mutableUiState.update {
-                        it.copy(
-                            albums = cached,
-                            albumsOffset = cached.size,
-                            hasMoreAlbums = type.supportsPagination(),
+                    mutableUiState.update { state ->
+                        state.copy(
+                            albumFeeds = state.albumFeeds.updateFeed(type) {
+                                it.copy(
+                                    albums = cached,
+                                    offset = cached.size,
+                                    hasMore = type.supportsPagination(),
+                                    error = null,
+                                )
+                            },
                         )
                     }
                 }
             }
 
-            mutableUiState.update {
-                it.copy(
-                    isAlbumsLoading = true,
-                    isLoadingMoreAlbums = false,
-                    albumsOffset = 0,
-                    hasMoreAlbums = type.supportsPagination(),
-                    albumsError = null,
+            mutableUiState.update { state ->
+                state.copy(
+                    albumFeeds = state.albumFeeds.updateFeed(type) {
+                        it.copy(
+                            isLoading = true,
+                            isLoadingMore = false,
+                            hasMore = type.supportsPagination(),
+                            error = null,
+                        )
+                    },
                 )
             }
 
@@ -1155,27 +1187,36 @@ class SakiAppViewModel @Inject constructor(
                 ).data
             }.onSuccess { albums ->
                 val uniqueAlbums = albums.distinctBy(AlbumSummary::id)
-                if (uiState.value.selectedServerId == serverId && uiState.value.selectedAlbumFeed == type) {
-                    mutableUiState.update {
-                        it.copy(
-                            albums = uniqueAlbums,
-                            albumsOffset = uniqueAlbums.size,
-                            hasMoreAlbums = type.supportsPagination() && albums.size >= ALBUMS_PAGE_SIZE,
-                            isAlbumsLoading = false,
-                            isLoadingMoreAlbums = false,
-                            albumsError = null,
+                if (uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { state ->
+                        state.copy(
+                            albumFeeds = state.albumFeeds.updateFeed(type) {
+                                it.copy(
+                                    albums = uniqueAlbums,
+                                    offset = uniqueAlbums.size,
+                                    hasMore = type.supportsPagination() && albums.size >= ALBUMS_PAGE_SIZE,
+                                    isLoading = false,
+                                    isLoadingMore = false,
+                                    error = null,
+                                    hasLoadedFromNetwork = true,
+                                )
+                            },
                         )
                     }
                 }
                 runCatching { libraryCacheRepository.saveAlbums(serverId, type, uniqueAlbums) }
                     .onFailure { Log.w("SakiApp", "Failed to cache albums", it) }
             }.onFailure { throwable ->
-                if (uiState.value.selectedServerId == serverId && uiState.value.selectedAlbumFeed == type) {
-                    mutableUiState.update {
-                        it.copy(
-                            isAlbumsLoading = false,
-                            isLoadingMoreAlbums = false,
-                            albumsError = throwable.localizedOr(R.string.error_load_albums),
+                if (uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { state ->
+                        state.copy(
+                            albumFeeds = state.albumFeeds.updateFeed(type) {
+                                it.copy(
+                                    isLoading = false,
+                                    isLoadingMore = false,
+                                    error = throwable.localizedOr(R.string.error_load_albums),
+                                )
+                            },
                         )
                     }
                 }
@@ -1494,6 +1535,16 @@ enum class BrowseSection {
     SONGS,
 }
 
+data class AlbumFeedState(
+    val albums: List<AlbumSummary> = emptyList(),
+    val isLoading: Boolean = false,
+    val offset: Int = 0,
+    val hasMore: Boolean = true,
+    val isLoadingMore: Boolean = false,
+    val error: UiText? = null,
+    val hasLoadedFromNetwork: Boolean = false,
+)
+
 data class SakiAppUiState(
     val isAppReady: Boolean = false,
     val textScale: TextScale = TextScale.DEFAULT,
@@ -1509,12 +1560,7 @@ data class SakiAppUiState(
     val selectedArtistTopSongs: List<Song> = emptyList(),
     val isArtistLoading: Boolean = false,
     val artistError: UiText? = null,
-    val albums: List<AlbumSummary> = emptyList(),
-    val isAlbumsLoading: Boolean = false,
-    val albumsOffset: Int = 0,
-    val hasMoreAlbums: Boolean = true,
-    val isLoadingMoreAlbums: Boolean = false,
-    val albumsError: UiText? = null,
+    val albumFeeds: Map<AlbumListType, AlbumFeedState> = emptyAlbumFeedStates(),
     val selectedAlbum: Album? = null,
     val isAlbumLoading: Boolean = false,
     val albumError: UiText? = null,
@@ -1538,7 +1584,36 @@ data class SakiAppUiState(
     val downloadingSongIds: Set<String> = emptySet(),
     val playbackState: PlaybackSessionState = PlaybackSessionState(),
     val currentLyrics: SongLyrics? = null,
-)
+) {
+    fun albumFeedState(type: AlbumListType): AlbumFeedState {
+        return albumFeeds[type] ?: AlbumFeedState(hasMore = type.supportsPagination())
+    }
+
+    val selectedAlbumFeedState: AlbumFeedState
+        get() = albumFeedState(selectedAlbumFeed)
+    val albums: List<AlbumSummary>
+        get() = selectedAlbumFeedState.albums
+    val isAlbumsLoading: Boolean
+        get() = selectedAlbumFeedState.isLoading
+    val hasMoreAlbums: Boolean
+        get() = selectedAlbumFeedState.hasMore
+    val isLoadingMoreAlbums: Boolean
+        get() = selectedAlbumFeedState.isLoadingMore
+    val albumsError: UiText?
+        get() = selectedAlbumFeedState.error
+}
+
+private fun emptyAlbumFeedStates(): Map<AlbumListType, AlbumFeedState> {
+    return AlbumListType.entries.associateWith { AlbumFeedState(hasMore = it.supportsPagination()) }
+}
+
+private fun Map<AlbumListType, AlbumFeedState>.updateFeed(
+    type: AlbumListType,
+    transform: (AlbumFeedState) -> AlbumFeedState,
+): Map<AlbumListType, AlbumFeedState> {
+    val current = this[type] ?: AlbumFeedState(hasMore = type.supportsPagination())
+    return this + (type to transform(current))
+}
 
 private fun Song.withFallbackAlbumMetadata(album: Album): Song {
     return copy(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -395,7 +395,6 @@ private fun BrowsePager(
                         state = pagerState,
                         modifier = Modifier.weight(1f),
                         flingBehavior = pagerFlingBehavior,
-                        userScrollEnabled = uiState.selectedBrowseSection != BrowseSection.ALBUMS,
                     ) { page ->
                         when (sections[page]) {
                             BrowseSection.ARTISTS -> ArtistsPage(
@@ -921,11 +920,18 @@ private fun AlbumFeedControls(
         AlbumViewMode.LIST -> stringResource(R.string.browse_show_album_list)
     }
 
+    val selectedIndex = feeds.indexOf(selectedFeed).coerceAtLeast(0)
+    val lazyRowState = rememberLazyListState()
+    LaunchedEffect(selectedIndex) {
+        lazyRowState.animateScrollToItem(selectedIndex)
+    }
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         LazyRow(
+            state = lazyRowState,
             modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(vertical = 10.dp),
         ) {

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -739,6 +739,8 @@ private fun AlbumsPage(
         state = feedPagerState,
         pagerSnapDistance = PagerSnapDistance.atMost(1),
     )
+    val coroutineScope = rememberCoroutineScope()
+    val highlightedFeed = feeds[feedPagerState.targetPage.coerceIn(0, feeds.lastIndex)]
 
     LaunchedEffect(selectedFeed) {
         val targetPage = feeds.indexOf(selectedFeed).coerceAtLeast(0)
@@ -758,9 +760,14 @@ private fun AlbumsPage(
     Column(modifier = Modifier.fillMaxSize()) {
         AlbumFeedControls(
             feeds = feeds,
-            selectedFeed = selectedFeed,
+            selectedFeed = highlightedFeed,
             viewMode = viewMode,
-            onSelectFeed = onSelectFeed,
+            onSelectFeed = { feed ->
+                val targetPage = feeds.indexOf(feed)
+                if (targetPage >= 0 && feedPagerState.targetPage != targetPage) {
+                    coroutineScope.launch { feedPagerState.animateScrollToPage(targetPage) }
+                }
+            },
             onUpdateViewMode = onUpdateViewMode,
         )
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -34,8 +34,6 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PagerDefaults
-import androidx.compose.foundation.pager.PagerSnapDistance
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
@@ -307,11 +305,6 @@ private fun BrowsePager(
         initialPage = sections.indexOf(uiState.selectedBrowseSection).coerceAtLeast(0),
         pageCount = { sections.size },
     )
-    val pagerFlingBehavior = PagerDefaults.flingBehavior(
-        state = pagerState,
-        pagerSnapDistance = PagerSnapDistance.atMost(1),
-    )
-
     LaunchedEffect(uiState.selectedBrowseSection) {
         val targetPage = sections.indexOf(uiState.selectedBrowseSection).coerceAtLeast(0)
         if (pagerState.settledPage != targetPage && pagerState.targetPage != targetPage) {
@@ -393,7 +386,7 @@ private fun BrowsePager(
                     HorizontalPager(
                         state = pagerState,
                         modifier = Modifier.weight(1f),
-                        flingBehavior = pagerFlingBehavior,
+                        userScrollEnabled = false,
                     ) { page ->
                         when (sections[page]) {
                             BrowseSection.ARTISTS -> ArtistsPage(
@@ -728,121 +721,113 @@ private fun AlbumsPage(
         AlbumListType.HIGHEST,
         AlbumListType.ALPHABETICAL_BY_NAME,
     )
-    when (viewMode) {
-        AlbumViewMode.GRID -> {
-            val gridState = rememberLazyGridState()
-            LaunchedEffect(gridState, hasMore, isLoading, isLoadingMore, albums.size) {
-                snapshotFlow {
-                    if (!hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
-                        false
-                    } else {
-                        val layoutInfo = gridState.layoutInfo
-                        val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                        lastVisibleIndex >= layoutInfo.totalItemsCount - 5
+    Column(modifier = Modifier.fillMaxSize()) {
+        AlbumFeedControls(
+            feeds = feeds,
+            selectedFeed = selectedFeed,
+            viewMode = viewMode,
+            onSelectFeed = onSelectFeed,
+            onUpdateViewMode = onUpdateViewMode,
+        )
+
+        when (viewMode) {
+            AlbumViewMode.GRID -> {
+                val gridState = rememberLazyGridState()
+                LaunchedEffect(gridState, hasMore, isLoading, isLoadingMore, albums.size) {
+                    snapshotFlow {
+                        if (!hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
+                            false
+                        } else {
+                            val layoutInfo = gridState.layoutInfo
+                            val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                            lastVisibleIndex >= layoutInfo.totalItemsCount - 5
+                        }
+                    }
+                        .distinctUntilChanged()
+                        .filter { shouldLoad -> shouldLoad }
+                        .collect { onLoadMore() }
+                }
+
+                LazyVerticalGrid(
+                    state = gridState,
+                    modifier = Modifier.weight(1f),
+                    columns = GridCells.Fixed(2),
+                    contentPadding = PaddingValues(bottom = 24.dp),
+                ) {
+                    when {
+                        isLoading && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
+                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
+                        }
+
+                        error != null && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
+                            ErrorStateCard(error)
+                        }
+
+                        albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
+                            EmptyStateCard(
+                                stringResource(R.string.browse_no_albums),
+                                stringResource(R.string.browse_no_albums_body),
+                            )
+                        }
+
+                        else -> items(albums, key = { it.id }) { album ->
+                            AlbumCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
+                        }
+                    }
+                    if (isLoadingMore) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
+                        }
                     }
                 }
-                    .distinctUntilChanged()
-                    .filter { shouldLoad -> shouldLoad }
-                    .collect { onLoadMore() }
             }
 
-            LazyVerticalGrid(
-                state = gridState,
-                modifier = Modifier.fillMaxSize(),
-                columns = GridCells.Fixed(2),
-                contentPadding = PaddingValues(bottom = 24.dp),
-            ) {
-                item(span = { GridItemSpan(maxLineSpan) }) {
-                    AlbumFeedControls(
-                        feeds = feeds,
-                        selectedFeed = selectedFeed,
-                        viewMode = viewMode,
-                        onSelectFeed = onSelectFeed,
-                        onUpdateViewMode = onUpdateViewMode,
-                    )
+            AlbumViewMode.LIST -> {
+                val listState = rememberLazyListState()
+                LaunchedEffect(listState, hasMore, isLoading, isLoadingMore, albums.size) {
+                    snapshotFlow {
+                        if (!hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
+                            false
+                        } else {
+                            val layoutInfo = listState.layoutInfo
+                            val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                            lastVisibleIndex >= layoutInfo.totalItemsCount - 5
+                        }
+                    }
+                        .distinctUntilChanged()
+                        .filter { shouldLoad -> shouldLoad }
+                        .collect { onLoadMore() }
                 }
-                when {
-                    isLoading && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
-                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                    }
 
-                    error != null && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
-                        ErrorStateCard(error)
-                    }
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(bottom = 24.dp),
+                ) {
+                    when {
+                        isLoading && albums.isEmpty() -> item {
+                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
+                        }
 
-                    albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
-                        EmptyStateCard(
-                            stringResource(R.string.browse_no_albums),
-                            stringResource(R.string.browse_no_albums_body),
-                        )
-                    }
+                        error != null && albums.isEmpty() -> item {
+                            ErrorStateCard(error)
+                        }
 
-                    else -> items(albums, key = { it.id }) { album ->
-                        AlbumCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
-                    }
-                }
-                if (isLoadingMore) {
-                    item(span = { GridItemSpan(maxLineSpan) }) {
-                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                    }
-                }
-            }
-        }
+                        albums.isEmpty() -> item {
+                            EmptyStateCard(
+                                stringResource(R.string.browse_no_albums),
+                                stringResource(R.string.browse_no_albums_body),
+                            )
+                        }
 
-        AlbumViewMode.LIST -> {
-            val listState = rememberLazyListState()
-            LaunchedEffect(listState, hasMore, isLoading, isLoadingMore, albums.size) {
-                snapshotFlow {
-                    if (!hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
-                        false
-                    } else {
-                        val layoutInfo = listState.layoutInfo
-                        val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                        lastVisibleIndex >= layoutInfo.totalItemsCount - 5
+                        else -> items(albums, key = { it.id }) { album ->
+                            AlbumRow(album = album, server = server, onOpenAlbum = onOpenAlbum)
+                        }
                     }
-                }
-                    .distinctUntilChanged()
-                    .filter { shouldLoad -> shouldLoad }
-                    .collect { onLoadMore() }
-            }
-
-            LazyColumn(
-                state = listState,
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(bottom = 24.dp),
-            ) {
-                item {
-                    AlbumFeedControls(
-                        feeds = feeds,
-                        selectedFeed = selectedFeed,
-                        viewMode = viewMode,
-                        onSelectFeed = onSelectFeed,
-                        onUpdateViewMode = onUpdateViewMode,
-                    )
-                }
-                when {
-                    isLoading && albums.isEmpty() -> item {
-                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                    }
-
-                    error != null && albums.isEmpty() -> item {
-                        ErrorStateCard(error)
-                    }
-
-                    albums.isEmpty() -> item {
-                        EmptyStateCard(
-                            stringResource(R.string.browse_no_albums),
-                            stringResource(R.string.browse_no_albums_body),
-                        )
-                    }
-
-                    else -> items(albums, key = { it.id }) { album ->
-                        AlbumRow(album = album, server = server, onOpenAlbum = onOpenAlbum)
-                    }
-                }
-                if (isLoadingMore) {
-                    item {
-                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
+                    if (isLoadingMore) {
+                        item {
+                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
+                        }
                     }
                 }
             }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerDefaults
+import androidx.compose.foundation.pager.PagerSnapDistance
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
@@ -74,6 +76,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.hdhmc.saki.R
 import org.hdhmc.saki.domain.model.AlbumListType
+import org.hdhmc.saki.domain.model.AlbumSummary
 import org.hdhmc.saki.domain.model.AlbumViewMode
 import org.hdhmc.saki.domain.model.CachedSong
 import org.hdhmc.saki.domain.model.SearchResults
@@ -305,6 +308,10 @@ private fun BrowsePager(
         initialPage = sections.indexOf(uiState.selectedBrowseSection).coerceAtLeast(0),
         pageCount = { sections.size },
     )
+    val pagerFlingBehavior = PagerDefaults.flingBehavior(
+        state = pagerState,
+        pagerSnapDistance = PagerSnapDistance.atMost(1),
+    )
     LaunchedEffect(uiState.selectedBrowseSection) {
         val targetPage = sections.indexOf(uiState.selectedBrowseSection).coerceAtLeast(0)
         if (pagerState.settledPage != targetPage && pagerState.targetPage != targetPage) {
@@ -386,7 +393,8 @@ private fun BrowsePager(
                     HorizontalPager(
                         state = pagerState,
                         modifier = Modifier.weight(1f),
-                        userScrollEnabled = false,
+                        flingBehavior = pagerFlingBehavior,
+                        userScrollEnabled = uiState.selectedBrowseSection != BrowseSection.ALBUMS,
                     ) { page ->
                         when (sections[page]) {
                             BrowseSection.ARTISTS -> ArtistsPage(
@@ -699,9 +707,10 @@ private fun ArtistsPage(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AlbumsPage(
-    albums: List<org.hdhmc.saki.domain.model.AlbumSummary>,
+    albums: List<AlbumSummary>,
     server: ServerConfig,
     selectedFeed: AlbumListType,
     viewMode: AlbumViewMode,
@@ -721,6 +730,31 @@ private fun AlbumsPage(
         AlbumListType.HIGHEST,
         AlbumListType.ALPHABETICAL_BY_NAME,
     )
+    val selectedFeedState = rememberUpdatedState(selectedFeed)
+    val feedPagerState = rememberPagerState(
+        initialPage = feeds.indexOf(selectedFeed).coerceAtLeast(0),
+        pageCount = { feeds.size },
+    )
+    val feedPagerFlingBehavior = PagerDefaults.flingBehavior(
+        state = feedPagerState,
+        pagerSnapDistance = PagerSnapDistance.atMost(1),
+    )
+
+    LaunchedEffect(selectedFeed) {
+        val targetPage = feeds.indexOf(selectedFeed).coerceAtLeast(0)
+        if (feedPagerState.settledPage != targetPage && feedPagerState.targetPage != targetPage) {
+            feedPagerState.animateScrollToPage(targetPage)
+        }
+    }
+
+    LaunchedEffect(feedPagerState) {
+        snapshotFlow { feedPagerState.settledPage }
+            .distinctUntilChanged()
+            .map { feeds[it] }
+            .filter { it != selectedFeedState.value }
+            .collect { onSelectFeed(it) }
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         AlbumFeedControls(
             feeds = feeds,
@@ -730,104 +764,136 @@ private fun AlbumsPage(
             onUpdateViewMode = onUpdateViewMode,
         )
 
-        when (viewMode) {
-            AlbumViewMode.GRID -> {
-                val gridState = rememberLazyGridState()
-                LaunchedEffect(gridState, hasMore, isLoading, isLoadingMore, albums.size) {
-                    snapshotFlow {
-                        if (!hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
-                            false
-                        } else {
-                            val layoutInfo = gridState.layoutInfo
-                            val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                            lastVisibleIndex >= layoutInfo.totalItemsCount - 5
-                        }
+        HorizontalPager(
+            state = feedPagerState,
+            modifier = Modifier.weight(1f),
+            flingBehavior = feedPagerFlingBehavior,
+        ) { page ->
+            val isSelectedPage = feeds[page] == selectedFeed
+            AlbumFeedPageContent(
+                albums = if (isSelectedPage) albums else emptyList(),
+                server = server,
+                viewMode = viewMode,
+                isLoading = !isSelectedPage || isLoading,
+                hasMore = isSelectedPage && hasMore,
+                isLoadingMore = isSelectedPage && isLoadingMore,
+                error = if (isSelectedPage) error else null,
+                onLoadMore = onLoadMore,
+                onOpenAlbum = onOpenAlbum,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AlbumFeedPageContent(
+    albums: List<AlbumSummary>,
+    server: ServerConfig,
+    viewMode: AlbumViewMode,
+    isLoading: Boolean,
+    hasMore: Boolean,
+    isLoadingMore: Boolean,
+    error: String?,
+    onLoadMore: () -> Unit,
+    onOpenAlbum: (String) -> Unit,
+) {
+    when (viewMode) {
+        AlbumViewMode.GRID -> {
+            val gridState = rememberLazyGridState()
+            LaunchedEffect(gridState, hasMore, isLoading, isLoadingMore, albums.size) {
+                snapshotFlow {
+                    if (!hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
+                        false
+                    } else {
+                        val layoutInfo = gridState.layoutInfo
+                        val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                        lastVisibleIndex >= layoutInfo.totalItemsCount - 5
                     }
-                        .distinctUntilChanged()
-                        .filter { shouldLoad -> shouldLoad }
-                        .collect { onLoadMore() }
                 }
+                    .distinctUntilChanged()
+                    .filter { shouldLoad -> shouldLoad }
+                    .collect { onLoadMore() }
+            }
 
-                LazyVerticalGrid(
-                    state = gridState,
-                    modifier = Modifier.weight(1f),
-                    columns = GridCells.Fixed(2),
-                    contentPadding = PaddingValues(bottom = 24.dp),
-                ) {
-                    when {
-                        isLoading && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
-                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                        }
-
-                        error != null && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
-                            ErrorStateCard(error)
-                        }
-
-                        albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
-                            EmptyStateCard(
-                                stringResource(R.string.browse_no_albums),
-                                stringResource(R.string.browse_no_albums_body),
-                            )
-                        }
-
-                        else -> items(albums, key = { it.id }) { album ->
-                            AlbumCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
-                        }
+            LazyVerticalGrid(
+                state = gridState,
+                modifier = Modifier.fillMaxSize(),
+                columns = GridCells.Fixed(2),
+                contentPadding = PaddingValues(bottom = 24.dp),
+            ) {
+                when {
+                    isLoading && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
+                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
                     }
-                    if (isLoadingMore) {
-                        item(span = { GridItemSpan(maxLineSpan) }) {
-                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                        }
+
+                    error != null && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
+                        ErrorStateCard(error)
+                    }
+
+                    albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
+                        EmptyStateCard(
+                            stringResource(R.string.browse_no_albums),
+                            stringResource(R.string.browse_no_albums_body),
+                        )
+                    }
+
+                    else -> items(albums, key = { it.id }) { album ->
+                        AlbumCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
+                    }
+                }
+                if (isLoadingMore) {
+                    item(span = { GridItemSpan(maxLineSpan) }) {
+                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
                     }
                 }
             }
+        }
 
-            AlbumViewMode.LIST -> {
-                val listState = rememberLazyListState()
-                LaunchedEffect(listState, hasMore, isLoading, isLoadingMore, albums.size) {
-                    snapshotFlow {
-                        if (!hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
-                            false
-                        } else {
-                            val layoutInfo = listState.layoutInfo
-                            val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                            lastVisibleIndex >= layoutInfo.totalItemsCount - 5
-                        }
+        AlbumViewMode.LIST -> {
+            val listState = rememberLazyListState()
+            LaunchedEffect(listState, hasMore, isLoading, isLoadingMore, albums.size) {
+                snapshotFlow {
+                    if (!hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
+                        false
+                    } else {
+                        val layoutInfo = listState.layoutInfo
+                        val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                        lastVisibleIndex >= layoutInfo.totalItemsCount - 5
                     }
-                        .distinctUntilChanged()
-                        .filter { shouldLoad -> shouldLoad }
-                        .collect { onLoadMore() }
                 }
+                    .distinctUntilChanged()
+                    .filter { shouldLoad -> shouldLoad }
+                    .collect { onLoadMore() }
+            }
 
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier.weight(1f),
-                    contentPadding = PaddingValues(bottom = 24.dp),
-                ) {
-                    when {
-                        isLoading && albums.isEmpty() -> item {
-                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                        }
-
-                        error != null && albums.isEmpty() -> item {
-                            ErrorStateCard(error)
-                        }
-
-                        albums.isEmpty() -> item {
-                            EmptyStateCard(
-                                stringResource(R.string.browse_no_albums),
-                                stringResource(R.string.browse_no_albums_body),
-                            )
-                        }
-
-                        else -> items(albums, key = { it.id }) { album ->
-                            AlbumRow(album = album, server = server, onOpenAlbum = onOpenAlbum)
-                        }
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = 24.dp),
+            ) {
+                when {
+                    isLoading && albums.isEmpty() -> item {
+                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
                     }
-                    if (isLoadingMore) {
-                        item {
-                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                        }
+
+                    error != null && albums.isEmpty() -> item {
+                        ErrorStateCard(error)
+                    }
+
+                    albums.isEmpty() -> item {
+                        EmptyStateCard(
+                            stringResource(R.string.browse_no_albums),
+                            stringResource(R.string.browse_no_albums_body),
+                        )
+                    }
+
+                    else -> items(albums, key = { it.id }) { album ->
+                        AlbumRow(album = album, server = server, onOpenAlbum = onOpenAlbum)
+                    }
+                }
+                if (isLoadingMore) {
+                    item {
+                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
                     }
                 }
             }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -83,6 +83,7 @@ import org.hdhmc.saki.domain.model.SearchResults
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.presentation.BrowseSection
+import org.hdhmc.saki.presentation.AlbumFeedState
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.presentation.SakiAppUiState
 import org.hdhmc.saki.presentation.asString
@@ -406,14 +407,10 @@ private fun BrowsePager(
                             )
 
                             BrowseSection.ALBUMS -> AlbumsPage(
-                                albums = uiState.albums,
+                                albumFeeds = uiState.albumFeeds,
                                 server = currentServer,
                                 selectedFeed = uiState.selectedAlbumFeed,
                                 viewMode = uiState.appPreferences.albumViewMode,
-                                isLoading = uiState.isAlbumsLoading,
-                                hasMore = uiState.hasMoreAlbums,
-                                isLoadingMore = uiState.isLoadingMoreAlbums,
-                                error = uiState.albumsError?.asString(),
                                 onSelectFeed = onSelectAlbumFeed,
                                 onLoadMore = onLoadMoreAlbums,
                                 onUpdateViewMode = onUpdateAlbumViewMode,
@@ -710,14 +707,10 @@ private fun ArtistsPage(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AlbumsPage(
-    albums: List<AlbumSummary>,
+    albumFeeds: Map<AlbumListType, AlbumFeedState>,
     server: ServerConfig,
     selectedFeed: AlbumListType,
     viewMode: AlbumViewMode,
-    isLoading: Boolean,
-    hasMore: Boolean,
-    isLoadingMore: Boolean,
-    error: String?,
     onSelectFeed: (AlbumListType) -> Unit,
     onLoadMore: () -> Unit,
     onUpdateViewMode: (AlbumViewMode) -> Unit,
@@ -750,7 +743,7 @@ private fun AlbumsPage(
     }
 
     LaunchedEffect(feedPagerState) {
-        snapshotFlow { feedPagerState.settledPage }
+        snapshotFlow { feedPagerState.targetPage }
             .distinctUntilChanged()
             .map { feeds[it] }
             .filter { it != selectedFeedState.value }
@@ -776,15 +769,17 @@ private fun AlbumsPage(
             modifier = Modifier.weight(1f),
             flingBehavior = feedPagerFlingBehavior,
         ) { page ->
-            val isSelectedPage = feeds[page] == selectedFeed
+            val feed = feeds[page]
+            val feedState = albumFeeds[feed] ?: AlbumFeedState()
             AlbumFeedPageContent(
-                albums = if (isSelectedPage) albums else emptyList(),
+                albums = feedState.albums,
                 server = server,
                 viewMode = viewMode,
-                isLoading = !isSelectedPage || isLoading,
-                hasMore = isSelectedPage && hasMore,
-                isLoadingMore = isSelectedPage && isLoadingMore,
-                error = if (isSelectedPage) error else null,
+                isLoading = feedState.isLoading,
+                hasMore = feedState.hasMore,
+                isLoadingMore = feedState.isLoadingMore,
+                error = feedState.error?.asString(),
+                canLoadMore = feed == selectedFeed,
                 onLoadMore = onLoadMore,
                 onOpenAlbum = onOpenAlbum,
             )
@@ -801,15 +796,16 @@ private fun AlbumFeedPageContent(
     hasMore: Boolean,
     isLoadingMore: Boolean,
     error: String?,
+    canLoadMore: Boolean,
     onLoadMore: () -> Unit,
     onOpenAlbum: (String) -> Unit,
 ) {
     when (viewMode) {
         AlbumViewMode.GRID -> {
             val gridState = rememberLazyGridState()
-            LaunchedEffect(gridState, hasMore, isLoading, isLoadingMore, albums.size) {
+            LaunchedEffect(gridState, canLoadMore, hasMore, isLoading, isLoadingMore, albums.size) {
                 snapshotFlow {
-                    if (!hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
+                    if (!canLoadMore || !hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
                         false
                     } else {
                         val layoutInfo = gridState.layoutInfo
@@ -858,9 +854,9 @@ private fun AlbumFeedPageContent(
 
         AlbumViewMode.LIST -> {
             val listState = rememberLazyListState()
-            LaunchedEffect(listState, hasMore, isLoading, isLoadingMore, albums.size) {
+            LaunchedEffect(listState, canLoadMore, hasMore, isLoading, isLoadingMore, albums.size) {
                 snapshotFlow {
-                    if (!hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
+                    if (!canLoadMore || !hasMore || isLoading || isLoadingMore || albums.isEmpty()) {
                         false
                     } else {
                         val layoutInfo = listState.layoutInfo

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -742,7 +742,7 @@ private fun AlbumsPage(
     }
 
     LaunchedEffect(feedPagerState) {
-        snapshotFlow { feedPagerState.targetPage }
+        snapshotFlow { feedPagerState.settledPage }
             .distinctUntilChanged()
             .map { feeds[it] }
             .filter { it != selectedFeedState.value }


### PR DESCRIPTION
Closes #132

## Problem
Horizontal swipe in the Albums content area switches the top-level tab (Artists/Albums/Playlists/Songs) instead of switching album sub-feeds (Newest/Recent/Random...).

## Fix

### Nested album feed pager
- Album sub-feeds are now a nested `HorizontalPager` — swiping in the album content area switches between feeds
- Feed FilterChips stay synced with pager swipes (bidirectional: chip tap → animate pager, pager swipe → update chip)
- Feed chips auto-scroll to keep the selected chip visible when swiping to off-screen feeds
- Outer top-level pager remains swipeable — at inner pager boundaries (first/last feed), gestures naturally propagate to the outer pager

### Per-feed state management
- Each album feed (Newest, Recent, Random, etc.) maintains independent state (`AlbumFeedState`: albums, loading, offset, pagination)
- Swiping to a previously loaded feed shows cached data instantly instead of flashing a loading state
- `hasLoadedFromNetwork` flag prevents redundant network requests when revisiting feeds
- All feed caches are loaded on startup and cleared on server switch

### Album feed controls pinned
- Feed chips + view mode toggle are pinned above the scrolling album content (not inside the lazy list)

### Files changed
- `SakiAppViewModel.kt` — `AlbumFeedState` data class, `albumFeeds: Map<AlbumListType, AlbumFeedState>`, per-feed loading/pagination logic
- `BrowseScreen.kt` — Nested `HorizontalPager` for feeds, `AlbumFeedPageContent` composable, chip auto-scroll, pinned controls