### PR TITLE
fix: remove Card background from detail page headers

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -238,7 +238,7 @@ private fun LibraryDetailScaffold(
         contentPadding = PaddingValues(bottom = 24.dp),
     ) {
         item {
-            Column(modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp)) {
+            Column(modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp, bottom = 20.dp)) {
                 if (artwork != null) {
                     ArtworkCard(
                         model = artwork,
@@ -249,7 +249,11 @@ private fun LibraryDetailScaffold(
                         cornerRadiusDp = 34,
                     )
                 }
-                Text(text = title, style = MaterialTheme.typography.displaySmall, modifier = Modifier.padding(top = 14.dp))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.displaySmall,
+                    modifier = Modifier.padding(top = if (artwork != null) 14.dp else 0.dp),
+                )
                 if (!subtitle.isNullOrBlank()) {
                     Text(
                         text = subtitle,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -238,33 +238,25 @@ private fun LibraryDetailScaffold(
         contentPadding = PaddingValues(bottom = 24.dp),
     ) {
         item {
-            Card(
-                modifier = Modifier.padding(top = 8.dp),
-                shape = MaterialTheme.shapes.extraLarge,
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
-                ),
-            ) {
-                Column(modifier = Modifier.padding(20.dp)) {
-                    if (artwork != null) {
-                        ArtworkCard(
-                            model = artwork,
-                            contentDescription = title,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(320.dp),
-                            cornerRadiusDp = 34,
-                        )
-                    }
-                    Text(text = title, style = MaterialTheme.typography.displaySmall, modifier = Modifier.padding(top = 14.dp))
-                    if (!subtitle.isNullOrBlank()) {
-                        Text(
-                            text = subtitle,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(top = 6.dp),
-                        )
-                    }
+            Column(modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp)) {
+                if (artwork != null) {
+                    ArtworkCard(
+                        model = artwork,
+                        contentDescription = title,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(320.dp),
+                        cornerRadiusDp = 34,
+                    )
+                }
+                Text(text = title, style = MaterialTheme.typography.displaySmall, modifier = Modifier.padding(top = 14.dp))
+                if (!subtitle.isNullOrBlank()) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 6.dp),
+                    )
                 }
             }
         }


### PR DESCRIPTION
Closes #158

## Problem
Artist and album detail pages wrap the header (title, subtitle, artwork) in a `Card` with a dark surface background, adding visual clutter.

## Fix
Replace the `Card` wrapper in `LibraryDetailScaffold` with a plain `Column`, keeping the same padding. Affects both artist detail (title + album count) and album detail (artwork + title + metadata).