### PR TITLE
fix: Now Playing capsule background

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/AppBackgrounds.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/AppBackgrounds.kt
@@ -1,9 +1,12 @@
 package org.hdhmc.saki.presentation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.compose.material3.MaterialTheme
 
 @Composable
@@ -19,3 +22,5 @@ fun rememberBrowseBackgroundBrush(): Brush {
         )
     }
 }
+
+fun bottomContentPadding(overlayPadding: Dp) = PaddingValues(bottom = 24.dp + overlayPadding)

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -344,7 +344,10 @@ private fun RootShell(
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .onGloballyPositioned { coordinates ->
-                            capsuleHeightPx = coordinates.size.height
+                            val measuredHeight = coordinates.size.height
+                            if (capsuleHeightPx != measuredHeight) {
+                                capsuleHeightPx = measuredHeight
+                            }
                         },
                 ) {
                     NowPlayingCapsule(

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -26,6 +27,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -241,8 +243,10 @@ private fun RootShell(
     val currentOrQueuedTrack = uiState.playbackState.currentItem ?: uiState.playbackState.queue.firstOrNull()
     val shellBackgroundBrush = rememberBrowseBackgroundBrush()
     var showSettings by rememberSaveable { mutableStateOf(false) }
-    var capsuleHeightPx by remember { mutableStateOf(0) }
-    val capsuleOverlayPadding = with(LocalDensity.current) { capsuleHeightPx.toDp() }
+    val density = LocalDensity.current
+    val defaultCapsuleHeightPx = with(density) { 72.dp.roundToPx() }
+    var capsuleHeightPx by remember { mutableIntStateOf(defaultCapsuleHeightPx) }
+    val capsuleOverlayPadding = with(density) { capsuleHeightPx.toDp() }
     val availableArtistIds = remember(uiState.libraryIndexes) {
         uiState.libraryIndexes
             ?.let { indexes ->

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -3,10 +3,10 @@ package org.hdhmc.saki.presentation
 import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.background
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -26,6 +26,8 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.hdhmc.saki.domain.model.ThemeMode
@@ -239,6 +241,8 @@ private fun RootShell(
     val currentOrQueuedTrack = uiState.playbackState.currentItem ?: uiState.playbackState.queue.firstOrNull()
     val shellBackgroundBrush = rememberBrowseBackgroundBrush()
     var showSettings by rememberSaveable { mutableStateOf(false) }
+    var capsuleHeightPx by remember { mutableStateOf(0) }
+    val capsuleOverlayPadding = with(LocalDensity.current) { capsuleHeightPx.toDp() }
     val availableArtistIds = remember(uiState.libraryIndexes) {
         uiState.libraryIndexes
             ?.let { indexes ->
@@ -264,85 +268,95 @@ private fun RootShell(
             .background(shellBackgroundBrush),
     ) {
         CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
-            Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-                Box(modifier = Modifier.weight(1f)) {
-                    if (showSettings) {
-                        SettingsScreen(
-                            uiState = uiState,
-                            contentPadding = PaddingValues(),
-                            onManageServers = onManageServers,
-                            onSelectServer = onSelectServer,
-                            onUpdateStreamQuality = onUpdateStreamQuality,
-                            onUpdateDownloadQuality = onUpdateDownloadQuality,
-                            onUpdateAdaptiveQuality = onUpdateAdaptiveQuality,
-                            onUpdateWifiStreamQuality = onUpdateWifiStreamQuality,
-                            onUpdateMobileStreamQuality = onUpdateMobileStreamQuality,
-                            onUpdateSoundBalancing = onUpdateSoundBalancing,
-                            onUpdateStreamCacheSizeMb = onUpdateStreamCacheSizeMb,
-                            onClearStreamCache = onClearStreamCache,
-                            onUpdateImageCacheSizeMb = onUpdateImageCacheSizeMb,
-                            onClearImageCache = onClearImageCache,
-                            onUpdateTextScale = onUpdateTextScale,
-                            onUpdateLanguage = onUpdateLanguage,
-                            onUpdateThemeMode = onUpdateThemeMode,
-                            onUpdateDefaultBrowseTab = onUpdateDefaultBrowseTab,
-                            onUpdateDefaultAlbumFeed = onUpdateDefaultAlbumFeed,
-                            onUpdateBluetoothLyrics = onUpdateBluetoothLyrics,
-                            onUpdateBufferStrategy = onUpdateBufferStrategy,
-                            onUpdateCustomBufferSeconds = onUpdateCustomBufferSeconds,
-                            onExportConfig = onExportConfig,
-                            onImportConfig = onImportConfig,
-                            onPlayCachedSong = onPlayCachedSong,
-                            onPlayCachedQueue = onPlayCachedQueue,
-                            onDeleteCachedSong = onDeleteCachedSong,
-                            onClearCachedSongs = onClearCachedSongs,
-                        )
-                    } else {
-                        BrowseScreen(
-                            uiState = uiState,
-                            contentPadding = PaddingValues(),
-                            onManageServers = onManageServers,
-                            onSelectBrowseSection = onSelectBrowseSection,
-                            onSetSearchActive = onSetSearchActive,
-                            onUpdateSearchQuery = onUpdateSearchQuery,
-                            onRefreshCurrentTab = onRefreshCurrentTab,
-                            onSelectAlbumFeed = onSelectAlbumFeed,
-                            onLoadMoreAlbums = onLoadMoreAlbums,
-                            onUpdateAlbumViewMode = onUpdateAlbumViewMode,
-                            onOpenArtist = onOpenArtist,
-                            onCloseArtist = onCloseArtist,
-                            onOpenAlbum = onOpenAlbum,
-                            onCloseAlbum = onCloseAlbum,
-                            onOpenPlaylist = onOpenPlaylist,
-                            onClosePlaylist = onClosePlaylist,
-                            onPlaySongs = onPlaySongs,
-                            onQueueSong = onQueueSong,
-                            onPlaySongNext = onPlaySongNext,
-                            onToggleSongDownload = onToggleSongDownload,
-                            onOpenSettings = { showSettings = true },
-                            onImportConfig = onImportConfig,
-                        )
-                    }
-
-                    SnackbarHost(
-                        hostState = snackbarHostState,
-                        modifier = Modifier.align(androidx.compose.ui.Alignment.BottomCenter),
+            Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
+                if (showSettings) {
+                    SettingsScreen(
+                        uiState = uiState,
+                        contentPadding = PaddingValues(),
+                        bottomOverlayPadding = capsuleOverlayPadding,
+                        onManageServers = onManageServers,
+                        onSelectServer = onSelectServer,
+                        onUpdateStreamQuality = onUpdateStreamQuality,
+                        onUpdateDownloadQuality = onUpdateDownloadQuality,
+                        onUpdateAdaptiveQuality = onUpdateAdaptiveQuality,
+                        onUpdateWifiStreamQuality = onUpdateWifiStreamQuality,
+                        onUpdateMobileStreamQuality = onUpdateMobileStreamQuality,
+                        onUpdateSoundBalancing = onUpdateSoundBalancing,
+                        onUpdateStreamCacheSizeMb = onUpdateStreamCacheSizeMb,
+                        onClearStreamCache = onClearStreamCache,
+                        onUpdateImageCacheSizeMb = onUpdateImageCacheSizeMb,
+                        onClearImageCache = onClearImageCache,
+                        onUpdateTextScale = onUpdateTextScale,
+                        onUpdateLanguage = onUpdateLanguage,
+                        onUpdateThemeMode = onUpdateThemeMode,
+                        onUpdateDefaultBrowseTab = onUpdateDefaultBrowseTab,
+                        onUpdateDefaultAlbumFeed = onUpdateDefaultAlbumFeed,
+                        onUpdateBluetoothLyrics = onUpdateBluetoothLyrics,
+                        onUpdateBufferStrategy = onUpdateBufferStrategy,
+                        onUpdateCustomBufferSeconds = onUpdateCustomBufferSeconds,
+                        onExportConfig = onExportConfig,
+                        onImportConfig = onImportConfig,
+                        onPlayCachedSong = onPlayCachedSong,
+                        onPlayCachedQueue = onPlayCachedQueue,
+                        onDeleteCachedSong = onDeleteCachedSong,
+                        onClearCachedSongs = onClearCachedSongs,
+                    )
+                } else {
+                    BrowseScreen(
+                        uiState = uiState,
+                        contentPadding = PaddingValues(),
+                        bottomOverlayPadding = capsuleOverlayPadding,
+                        onManageServers = onManageServers,
+                        onSelectBrowseSection = onSelectBrowseSection,
+                        onSetSearchActive = onSetSearchActive,
+                        onUpdateSearchQuery = onUpdateSearchQuery,
+                        onRefreshCurrentTab = onRefreshCurrentTab,
+                        onSelectAlbumFeed = onSelectAlbumFeed,
+                        onLoadMoreAlbums = onLoadMoreAlbums,
+                        onUpdateAlbumViewMode = onUpdateAlbumViewMode,
+                        onOpenArtist = onOpenArtist,
+                        onCloseArtist = onCloseArtist,
+                        onOpenAlbum = onOpenAlbum,
+                        onCloseAlbum = onCloseAlbum,
+                        onOpenPlaylist = onOpenPlaylist,
+                        onClosePlaylist = onClosePlaylist,
+                        onPlaySongs = onPlaySongs,
+                        onQueueSong = onQueueSong,
+                        onPlaySongNext = onPlaySongNext,
+                        onToggleSongDownload = onToggleSongDownload,
+                        onOpenSettings = { showSettings = true },
+                        onImportConfig = onImportConfig,
                     )
                 }
 
-                NowPlayingCapsule(
-                    track = currentOrQueuedTrack,
-                    isPlaying = uiState.playbackState.isPlaying,
-                    currentServer = currentOrQueuedTrack?.serverId?.let { sid ->
-                        uiState.servers.firstOrNull { it.id == sid }
-                    },
-                    onExpand = onOpenNowPlaying,
-                    onPlayPause = {
-                        if (uiState.playbackState.isPlaying) onPausePlayback() else onResumePlayback()
-                    },
-                    onSkipToPrevious = onSkipToPrevious,
-                    onSkipToNext = onSkipToNext,
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = capsuleOverlayPadding),
                 )
+
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .onGloballyPositioned { coordinates ->
+                            capsuleHeightPx = coordinates.size.height
+                        },
+                ) {
+                    NowPlayingCapsule(
+                        track = currentOrQueuedTrack,
+                        isPlaying = uiState.playbackState.isPlaying,
+                        currentServer = currentOrQueuedTrack?.serverId?.let { sid ->
+                            uiState.servers.firstOrNull { it.id == sid }
+                        },
+                        onExpand = onOpenNowPlaying,
+                        onPlayPause = {
+                            if (uiState.playbackState.isPlaying) onPausePlayback() else onResumePlayback()
+                        },
+                        onSkipToPrevious = onSkipToPrevious,
+                        onSkipToNext = onSkipToNext,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.hdhmc.saki.R
 import org.hdhmc.saki.domain.model.Album
@@ -72,6 +73,7 @@ fun ArtistDetailScreen(
     downloadingSongIds: Set<String>,
     isLoading: Boolean,
     error: String?,
+    bottomOverlayPadding: Dp = 0.dp,
     onOpenAlbum: (String) -> Unit,
     onPlaySongs: (List<Song>, Int) -> Unit,
     onShowActions: (Song) -> Unit,
@@ -81,6 +83,7 @@ fun ArtistDetailScreen(
         title = artist.name,
         subtitle = if (albumCount != null) albumCountText(albumCount) else null,
         artwork = null,
+        bottomOverlayPadding = bottomOverlayPadding,
     ) {
         when {
             isLoading && topSongs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_artist)) }
@@ -134,6 +137,7 @@ fun AlbumDetailScreen(
     downloadingSongIds: Set<String>,
     isLoading: Boolean,
     error: String?,
+    bottomOverlayPadding: Dp = 0.dp,
     onPlaySongs: (List<Song>, Int) -> Unit,
     onShowActions: (Song) -> Unit,
 ) {
@@ -147,6 +151,7 @@ fun AlbumDetailScreen(
         title = album.name,
         subtitle = subtitle,
         artwork = resolveArtworkModel(server, album.coverArtId, null),
+        bottomOverlayPadding = bottomOverlayPadding,
     ) {
         when {
             isLoading && album.songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_album)) }
@@ -185,6 +190,7 @@ fun PlaylistDetailScreen(
     downloadingSongIds: Set<String>,
     isLoading: Boolean,
     error: String?,
+    bottomOverlayPadding: Dp = 0.dp,
     onPlaySongs: (List<Song>, Int) -> Unit,
     onShowActions: (Song) -> Unit,
 ) {
@@ -197,6 +203,7 @@ fun PlaylistDetailScreen(
         title = playlist.name,
         subtitle = subtitle,
         artwork = resolveArtworkModel(server, playlist.coverArtId, null),
+        bottomOverlayPadding = bottomOverlayPadding,
     ) {
         when {
             isLoading && playlist.songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_playlist)) }
@@ -231,11 +238,12 @@ private fun LibraryDetailScaffold(
     title: String,
     subtitle: String?,
     artwork: Any?,
+    bottomOverlayPadding: Dp,
     content: androidx.compose.foundation.lazy.LazyListScope.() -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 24.dp),
+        contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
     ) {
         item {
             Column(modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp, bottom = 20.dp)) {

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.hdhmc.saki.R
+import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.domain.model.Album
 import org.hdhmc.saki.domain.model.AlbumSummary
 import org.hdhmc.saki.domain.model.Artist
@@ -243,7 +244,7 @@ private fun LibraryDetailScaffold(
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
+        contentPadding = bottomContentPadding(bottomOverlayPadding),
     ) {
         item {
             Column(modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp, bottom = 20.dp)) {

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.hdhmc.saki.R
@@ -98,6 +99,7 @@ import kotlinx.coroutines.flow.map
 fun BrowseScreen(
     uiState: SakiAppUiState,
     contentPadding: PaddingValues,
+    bottomOverlayPadding: Dp = 0.dp,
     onManageServers: () -> Unit,
     onSelectBrowseSection: (BrowseSection) -> Unit,
     onSetSearchActive: (Boolean) -> Unit,
@@ -147,8 +149,8 @@ fun BrowseScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(contentPadding)
             .background(background)
+            .padding(contentPadding)
             .statusBarsPadding()
             .padding(horizontal = 16.dp),
     ) {
@@ -193,6 +195,7 @@ fun BrowseScreen(
                         downloadingSongIds = uiState.downloadingSongIds,
                         isLoading = uiState.isAlbumLoading,
                         error = uiState.albumError?.asString(),
+                        bottomOverlayPadding = bottomOverlayPadding,
                         onPlaySongs = onPlaySongs,
                         onShowActions = { actionSong = it },
                     )
@@ -206,6 +209,7 @@ fun BrowseScreen(
                         downloadingSongIds = uiState.downloadingSongIds,
                         isLoading = uiState.isArtistLoading,
                         error = uiState.artistError?.asString(),
+                        bottomOverlayPadding = bottomOverlayPadding,
                         onOpenAlbum = onOpenAlbum,
                         onPlaySongs = onPlaySongs,
                         onShowActions = { actionSong = it },
@@ -219,6 +223,7 @@ fun BrowseScreen(
                         downloadingSongIds = uiState.downloadingSongIds,
                         isLoading = uiState.isPlaylistLoading,
                         error = uiState.playlistError?.asString(),
+                        bottomOverlayPadding = bottomOverlayPadding,
                         onPlaySongs = onPlaySongs,
                         onShowActions = { actionSong = it },
                     )
@@ -228,6 +233,7 @@ fun BrowseScreen(
                         uiState = uiState,
                         currentServer = currentServer,
                         cachedSongsBySongId = cachedSongsBySongId,
+                        bottomOverlayPadding = bottomOverlayPadding,
                         onSelectBrowseSection = onSelectBrowseSection,
                         onSetSearchActive = onSetSearchActive,
                         onUpdateSearchQuery = onUpdateSearchQuery,
@@ -290,6 +296,7 @@ private fun BrowsePager(
     uiState: SakiAppUiState,
     currentServer: ServerConfig,
     cachedSongsBySongId: Map<String, CachedSong>,
+    bottomOverlayPadding: Dp,
     onSelectBrowseSection: (BrowseSection) -> Unit,
     onSetSearchActive: (Boolean) -> Unit,
     onUpdateSearchQuery: (String) -> Unit,
@@ -349,6 +356,7 @@ private fun BrowsePager(
                 cachedSongsBySongId = cachedSongsBySongId,
                 streamCachedSongIds = uiState.streamCachedSongIds,
                 downloadingSongIds = uiState.downloadingSongIds,
+                bottomOverlayPadding = bottomOverlayPadding,
                 onOpenArtist = onOpenArtist,
                 onOpenAlbum = onOpenAlbum,
                 onPlaySongs = onPlaySongs,
@@ -403,6 +411,7 @@ private fun BrowsePager(
                                 server = currentServer,
                                 isLoading = uiState.isArtistsLoading,
                                 error = uiState.artistsError?.asString(),
+                                bottomOverlayPadding = bottomOverlayPadding,
                                 onOpenArtist = onOpenArtist,
                             )
 
@@ -415,6 +424,7 @@ private fun BrowsePager(
                                 onLoadMore = onLoadMoreAlbums,
                                 onUpdateViewMode = onUpdateAlbumViewMode,
                                 onOpenAlbum = onOpenAlbum,
+                                bottomOverlayPadding = bottomOverlayPadding,
                             )
 
                             BrowseSection.PLAYLISTS -> PlaylistsPage(
@@ -422,6 +432,7 @@ private fun BrowsePager(
                                 server = currentServer,
                                 isLoading = uiState.isPlaylistsLoading,
                                 error = uiState.playlistsError?.asString(),
+                                bottomOverlayPadding = bottomOverlayPadding,
                                 onOpenPlaylist = onOpenPlaylist,
                             )
 
@@ -433,6 +444,7 @@ private fun BrowsePager(
                                 downloadingSongIds = uiState.downloadingSongIds,
                                 isLoading = uiState.isSongsLoading,
                                 error = uiState.songsError?.asString(),
+                                bottomOverlayPadding = bottomOverlayPadding,
                                 onPlaySongs = onPlaySongs,
                                 onShowSongActions = onShowSongActions,
                             )
@@ -513,6 +525,7 @@ private fun SearchResultsPage(
     cachedSongsBySongId: Map<String, CachedSong>,
     streamCachedSongIds: Set<String>,
     downloadingSongIds: Set<String>,
+    bottomOverlayPadding: Dp,
     onOpenArtist: (String) -> Unit,
     onOpenAlbum: (String) -> Unit,
     onPlaySongs: (List<Song>, Int) -> Unit,
@@ -544,7 +557,7 @@ private fun SearchResultsPage(
 
         else -> LazyColumn(
             modifier = modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = 24.dp),
+            contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
         ) {
             if (results.artists.isNotEmpty()) {
                 item {
@@ -599,6 +612,7 @@ private fun ArtistsPage(
     server: ServerConfig,
     isLoading: Boolean,
     error: String?,
+    bottomOverlayPadding: Dp,
     onOpenArtist: (String) -> Unit,
 ) {
     if (isLoading && indexes == null) {
@@ -657,7 +671,7 @@ private fun ArtistsPage(
         LazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = 24.dp, end = 24.dp),
+            contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding, end = 24.dp),
         ) {
             if (indexes.shortcuts.isNotEmpty()) {
                 item {
@@ -715,6 +729,7 @@ private fun AlbumsPage(
     onLoadMore: () -> Unit,
     onUpdateViewMode: (AlbumViewMode) -> Unit,
     onOpenAlbum: (String) -> Unit,
+    bottomOverlayPadding: Dp,
 ) {
     val feeds = AlbumListType.defaultBrowseFeeds
     val selectedFeedState = rememberUpdatedState(selectedFeed)
@@ -776,6 +791,7 @@ private fun AlbumsPage(
                 canLoadMore = feed == selectedFeed,
                 onLoadMore = onLoadMore,
                 onOpenAlbum = onOpenAlbum,
+                bottomOverlayPadding = bottomOverlayPadding,
             )
         }
     }
@@ -793,6 +809,7 @@ private fun AlbumFeedPageContent(
     canLoadMore: Boolean,
     onLoadMore: () -> Unit,
     onOpenAlbum: (String) -> Unit,
+    bottomOverlayPadding: Dp,
 ) {
     when (viewMode) {
         AlbumViewMode.GRID -> {
@@ -816,7 +833,7 @@ private fun AlbumFeedPageContent(
                 state = gridState,
                 modifier = Modifier.fillMaxSize(),
                 columns = GridCells.Fixed(2),
-                contentPadding = PaddingValues(bottom = 24.dp),
+                contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
             ) {
                 when {
                     isLoading && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
@@ -866,7 +883,7 @@ private fun AlbumFeedPageContent(
             LazyColumn(
                 state = listState,
                 modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(bottom = 24.dp),
+                contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
             ) {
                 when {
                     isLoading && albums.isEmpty() -> item {
@@ -958,6 +975,7 @@ private fun PlaylistsPage(
     server: ServerConfig,
     isLoading: Boolean,
     error: String?,
+    bottomOverlayPadding: Dp,
     onOpenPlaylist: (String) -> Unit,
 ) {
     if (isLoading && playlists.isEmpty()) {
@@ -978,7 +996,7 @@ private fun PlaylistsPage(
     }
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 24.dp),
+        contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
     ) {
         items(playlists, key = { it.id }) { playlist ->
             PlaylistCard(playlist = playlist, server = server, onOpenPlaylist = onOpenPlaylist)
@@ -995,6 +1013,7 @@ private fun SongsPage(
     downloadingSongIds: Set<String>,
     isLoading: Boolean,
     error: String?,
+    bottomOverlayPadding: Dp,
     onPlaySongs: (List<Song>, Int) -> Unit,
     onShowSongActions: (Song) -> Unit,
 ) {
@@ -1015,7 +1034,7 @@ private fun SongsPage(
     }
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 24.dp),
+        contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
     ) {
         itemsIndexed(songs, key = { _, s -> s.id }) { index, song ->
             SongRow(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -86,6 +86,7 @@ import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.presentation.BrowseSection
 import org.hdhmc.saki.presentation.AlbumFeedState
 import org.hdhmc.saki.presentation.labelRes
+import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.presentation.SakiAppUiState
 import org.hdhmc.saki.presentation.asString
@@ -557,7 +558,7 @@ private fun SearchResultsPage(
 
         else -> LazyColumn(
             modifier = modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
+            contentPadding = bottomContentPadding(bottomOverlayPadding),
         ) {
             if (results.artists.isNotEmpty()) {
                 item {
@@ -833,7 +834,7 @@ private fun AlbumFeedPageContent(
                 state = gridState,
                 modifier = Modifier.fillMaxSize(),
                 columns = GridCells.Fixed(2),
-                contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
+                contentPadding = bottomContentPadding(bottomOverlayPadding),
             ) {
                 when {
                     isLoading && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
@@ -883,7 +884,7 @@ private fun AlbumFeedPageContent(
             LazyColumn(
                 state = listState,
                 modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
+                contentPadding = bottomContentPadding(bottomOverlayPadding),
             ) {
                 when {
                     isLoading && albums.isEmpty() -> item {
@@ -996,7 +997,7 @@ private fun PlaylistsPage(
     }
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
+        contentPadding = bottomContentPadding(bottomOverlayPadding),
     ) {
         items(playlists, key = { it.id }) { playlist ->
             PlaylistCard(playlist = playlist, server = server, onOpenPlaylist = onOpenPlaylist)
@@ -1034,7 +1035,7 @@ private fun SongsPage(
     }
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
+        contentPadding = bottomContentPadding(bottomOverlayPadding),
     ) {
         itemsIndexed(songs, key = { _, s -> s.id }) { index, song ->
             SongRow(

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.hdhmc.saki.R
 import org.hdhmc.saki.domain.model.AlbumListType
@@ -84,6 +85,7 @@ import kotlin.math.roundToInt
 fun SettingsScreen(
     uiState: SakiAppUiState,
     contentPadding: PaddingValues,
+    bottomOverlayPadding: Dp = 0.dp,
     onManageServers: () -> Unit,
     onSelectServer: (Long) -> Unit,
     onUpdateStreamQuality: (StreamQuality) -> Unit,
@@ -129,11 +131,11 @@ fun SettingsScreen(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(contentPadding)
             .background(background)
+            .padding(contentPadding)
             .statusBarsPadding()
             .padding(horizontal = 16.dp),
-        contentPadding = PaddingValues(bottom = 24.dp),
+        contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
         item {

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -77,6 +77,7 @@ import org.hdhmc.saki.presentation.SakiAppUiState
 import org.hdhmc.saki.presentation.labelRes
 import org.hdhmc.saki.presentation.library.ArtworkCard
 import org.hdhmc.saki.presentation.library.resolveArtworkModel
+import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import java.util.Locale
 import kotlin.math.roundToInt
@@ -135,7 +136,7 @@ fun SettingsScreen(
             .padding(contentPadding)
             .statusBarsPadding()
             .padding(horizontal = 16.dp),
-        contentPadding = PaddingValues(bottom = 24.dp + bottomOverlayPadding),
+        contentPadding = bottomContentPadding(bottomOverlayPadding),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
         item {


### PR DESCRIPTION
Closes #165

## Changes
Change the Now Playing capsule from Column stacking to Box overlay layout, so the shell gradient background shows through behind the capsule instead of a flat opaque color block.

- **Layout**: Replace `Column(content + capsule)` with `Box` — capsule floats at bottom via `Modifier.align(BottomCenter)`, content fills the full area
- **Bottom padding**: Pass `bottomOverlayPadding` (measured capsule height) to all scrollable lists so content doesn't hide behind the capsule
- **Initial height estimate**: `capsuleHeightPx` starts at 72dp (estimated capsule height) to avoid first-frame flicker
- **Helper**: Extract `bottomContentPadding(overlayPadding)` to `AppBackgrounds.kt` to eliminate 7 duplicated `PaddingValues(bottom = 24.dp + overlay)` calls
- **Performance**: Guard `onGloballyPositioned` assignment to skip unnecessary snapshot writes during animations