### PR TITLE
fix: remove outdated primary endpoint description

### DIFF
--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -94,7 +94,7 @@
     <string name="server_config_client_name">客户端名称</string>
     <string name="server_config_api_version_label">API 版本</string>
     <string name="server_config_endpoints_title">端点</string>
-    <string name="server_config_endpoints_body">将一个端点标记为主端点。保存前可使用测试功能验证凭据。</string>
+    <string name="server_config_endpoints_body">添加一个或多个端点。保存前可使用测试功能验证凭据。</string>
     <string name="server_config_add_endpoint">添加端点</string>
     <string name="server_config_save_server">保存服务器</string>
     <string name="server_config_save_changes">保存更改</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,7 +102,7 @@
     <string name="server_config_client_name">Client name</string>
     <string name="server_config_api_version_label">API version</string>
     <string name="server_config_endpoints_title">Endpoints</string>
-    <string name="server_config_endpoints_body">Mark one endpoint as primary. Use the test action to confirm the draft credentials work before saving.</string>
+    <string name="server_config_endpoints_body">Add one or more endpoints. Use the test action to confirm the credentials work before saving.</string>
     <string name="server_config_add_endpoint">Add another endpoint</string>
     <string name="server_config_save_server">Save server</string>
     <string name="server_config_save_changes">Save changes</string>


### PR DESCRIPTION
Remove outdated "mark one endpoint as primary" text from the endpoint management description. The primary endpoint concept no longer exists — the app auto-selects the best endpoint via probing.

- EN: "Mark one endpoint as primary. Use the test action…" → "Add one or more endpoints. Use the test action…"
- ZH: "将一个端点标记为主端点。…" → "添加一个或多个端点。…"