### PR TITLE
feat: remember last selected server across restarts

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import org.hdhmc.saki.domain.model.AlbumListType
 import org.hdhmc.saki.domain.model.AlbumViewMode
@@ -61,6 +62,10 @@ class DataStoreAppPreferencesRepository @Inject constructor(
         dataStore.edit { it[KEY_DEFAULT_ALBUM_FEED] = feed.apiValue }
     }
 
+    override suspend fun updateLastSelectedServerId(serverId: Long) {
+        dataStore.edit { it[KEY_LAST_SELECTED_SERVER_ID] = serverId }
+    }
+
     companion object {
         val KEY_TEXT_SCALE = stringPreferencesKey("text_scale")
         val KEY_LANGUAGE = stringPreferencesKey("app_language")
@@ -68,6 +73,7 @@ class DataStoreAppPreferencesRepository @Inject constructor(
         val KEY_ALBUM_VIEW_MODE = stringPreferencesKey("album_view_mode")
         val KEY_DEFAULT_BROWSE_TAB = stringPreferencesKey("default_browse_tab")
         val KEY_DEFAULT_ALBUM_FEED = stringPreferencesKey("default_album_feed")
+        val KEY_LAST_SELECTED_SERVER_ID = longPreferencesKey("last_selected_server_id")
     }
 }
 
@@ -80,4 +86,5 @@ private fun Preferences.toAppPreferences() = AppPreferences(
     defaultAlbumFeed = AlbumListType.fromApiValue(
         this[DataStoreAppPreferencesRepository.KEY_DEFAULT_ALBUM_FEED],
     )?.takeIf { it in AlbumListType.defaultBrowseFeeds } ?: AlbumListType.NEWEST,
+    lastSelectedServerId = this[DataStoreAppPreferencesRepository.KEY_LAST_SELECTED_SERVER_ID],
 )

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
@@ -62,8 +62,14 @@ class DataStoreAppPreferencesRepository @Inject constructor(
         dataStore.edit { it[KEY_DEFAULT_ALBUM_FEED] = feed.apiValue }
     }
 
-    override suspend fun updateLastSelectedServerId(serverId: Long) {
-        dataStore.edit { it[KEY_LAST_SELECTED_SERVER_ID] = serverId }
+    override suspend fun updateLastSelectedServerId(serverId: Long?) {
+        dataStore.edit {
+            if (serverId == null) {
+                it.remove(KEY_LAST_SELECTED_SERVER_ID)
+            } else {
+                it[KEY_LAST_SELECTED_SERVER_ID] = serverId
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
@@ -59,7 +59,7 @@ class DefaultAppPreferencesRepository @Inject constructor(
         // Default album feed preference is only supported via DataStore; no-op here
     }
 
-    override suspend fun updateLastSelectedServerId(serverId: Long) {
+    override suspend fun updateLastSelectedServerId(serverId: Long?) {
         // Last selected server is only supported via DataStore; no-op here
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
@@ -58,6 +58,10 @@ class DefaultAppPreferencesRepository @Inject constructor(
     override suspend fun updateDefaultAlbumFeed(feed: AlbumListType) {
         // Default album feed preference is only supported via DataStore; no-op here
     }
+
+    override suspend fun updateLastSelectedServerId(serverId: Long) {
+        // Last selected server is only supported via DataStore; no-op here
+    }
 }
 
 private fun AppPreferencesEntity.toDomain(): AppPreferences {

--- a/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
@@ -45,6 +45,7 @@ data class AppPreferences(
     val albumViewMode: AlbumViewMode = AlbumViewMode.GRID,
     val defaultBrowseTab: DefaultBrowseTab = DefaultBrowseTab.ARTISTS,
     val defaultAlbumFeed: AlbumListType = AlbumListType.NEWEST,
+    val lastSelectedServerId: Long? = null,
 )
 
 enum class DefaultBrowseTab(val storageKey: String) {

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
@@ -25,4 +25,6 @@ interface AppPreferencesRepository {
     suspend fun updateDefaultBrowseTab(tab: DefaultBrowseTab)
 
     suspend fun updateDefaultAlbumFeed(feed: AlbumListType)
+
+    suspend fun updateLastSelectedServerId(serverId: Long)
 }

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
@@ -26,5 +26,5 @@ interface AppPreferencesRepository {
 
     suspend fun updateDefaultAlbumFeed(feed: AlbumListType)
 
-    suspend fun updateLastSelectedServerId(serverId: Long)
+    suspend fun updateLastSelectedServerId(serverId: Long?)
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -369,6 +369,7 @@ class SakiAppViewModel @Inject constructor(
             )
         }
         viewModelScope.launch {
+            appPreferencesRepository.updateLastSelectedServerId(serverId)
             refreshCacheStorageSummary(serverId)
         }
         loadServerContent(serverId, forceRefresh = true)
@@ -980,6 +981,7 @@ class SakiAppViewModel @Inject constructor(
 
     private fun handleServerConfigsChanged(servers: List<ServerConfig>) {
         val previousServerId = uiState.value.selectedServerId
+            ?: uiState.value.appPreferences.lastSelectedServerId
         val selectedServerId = when {
             servers.isEmpty() -> null
             previousServerId != null && servers.any { it.id == previousServerId } -> previousServerId


### PR DESCRIPTION
Closes #173

## Changes
Remember the last selected server across app restarts via DataStore.

- `AppPreferences.lastSelectedServerId: Long?` — new field
- `selectServer()` persists the ID to DataStore
- `handleServerConfigsChanged()` reads the persisted ID when `selectedServerId` is null (first launch), falling back to `servers.first()` if the saved server no longer exists

5 files, +16 lines.