### PR TITLE
fix: album nested pager

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -738,10 +738,6 @@ private fun AlbumsPage(
         initialPage = feeds.indexOf(selectedFeed).coerceAtLeast(0),
         pageCount = { feeds.size },
     )
-    val feedPagerFlingBehavior = PagerDefaults.flingBehavior(
-        state = feedPagerState,
-        pagerSnapDistance = PagerSnapDistance.atMost(1),
-    )
     val coroutineScope = rememberCoroutineScope()
     val highlightedFeed = feeds[feedPagerState.targetPage.coerceIn(0, feeds.lastIndex)]
 
@@ -777,7 +773,8 @@ private fun AlbumsPage(
         HorizontalPager(
             state = feedPagerState,
             modifier = Modifier.weight(1f),
-            flingBehavior = feedPagerFlingBehavior,
+            // Feed chips still switch this pager, while horizontal drags stay with the outer tab pager.
+            userScrollEnabled = false,
         ) { page ->
             val feed = feeds[page]
             val feedState = albumFeeds[feed] ?: AlbumFeedState()

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.PagerSnapDistance
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
@@ -68,13 +69,19 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlin.math.abs
 import org.hdhmc.saki.R
 import org.hdhmc.saki.domain.model.AlbumListType
 import org.hdhmc.saki.domain.model.AlbumSummary
@@ -418,6 +425,7 @@ private fun BrowsePager(
 
                             BrowseSection.ALBUMS -> AlbumsPage(
                                 albumFeeds = uiState.albumFeeds,
+                                browsePagerState = pagerState,
                                 server = currentServer,
                                 selectedFeed = uiState.selectedAlbumFeed,
                                 viewMode = uiState.appPreferences.albumViewMode,
@@ -723,6 +731,7 @@ private fun ArtistsPage(
 @Composable
 private fun AlbumsPage(
     albumFeeds: Map<AlbumListType, AlbumFeedState>,
+    browsePagerState: PagerState,
     server: ServerConfig,
     selectedFeed: AlbumListType,
     viewMode: AlbumViewMode,
@@ -741,6 +750,10 @@ private fun AlbumsPage(
     val feedPagerFlingBehavior = PagerDefaults.flingBehavior(
         state = feedPagerState,
         pagerSnapDistance = PagerSnapDistance.atMost(1),
+    )
+    val feedBoundaryHandoffConnection = rememberAlbumFeedBoundaryHandoffConnection(
+        feedPagerState = feedPagerState,
+        browsePagerState = browsePagerState,
     )
     val coroutineScope = rememberCoroutineScope()
     val highlightedFeed = feeds[feedPagerState.targetPage.coerceIn(0, feeds.lastIndex)]
@@ -776,9 +789,10 @@ private fun AlbumsPage(
 
         HorizontalPager(
             state = feedPagerState,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .nestedScroll(feedBoundaryHandoffConnection),
             flingBehavior = feedPagerFlingBehavior,
-            overscrollEffect = null,
         ) { page ->
             val feed = feeds[page]
             val feedState = albumFeeds[feed] ?: AlbumFeedState()
@@ -798,6 +812,67 @@ private fun AlbumsPage(
         }
     }
 }
+
+@Composable
+private fun rememberAlbumFeedBoundaryHandoffConnection(
+    feedPagerState: PagerState,
+    browsePagerState: PagerState,
+): NestedScrollConnection {
+    return remember(feedPagerState, browsePagerState) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (source != NestedScrollSource.UserInput || available.x == 0f) {
+                    return Offset.Zero
+                }
+
+                val scrollDelta = -available.x
+                if (!feedPagerState.shouldHandOffAlbumFeedDelta(scrollDelta)) {
+                    return Offset.Zero
+                }
+
+                val consumed = browsePagerState.dispatchRawDelta(scrollDelta)
+                return Offset(x = -consumed, y = 0f)
+            }
+
+            override suspend fun onPreFling(available: Velocity): Velocity {
+                val scrollVelocity = -available.x
+                val browsePagerNeedsSettling = abs(browsePagerState.currentPageOffsetFraction) >
+                    PagerOffsetSettlingEpsilon
+                if (scrollVelocity != 0f && !feedPagerState.shouldHandOffAlbumFeedDelta(scrollVelocity)) {
+                    return Velocity.Zero
+                }
+                if (scrollVelocity == 0f && !browsePagerNeedsSettling) {
+                    return Velocity.Zero
+                }
+
+                val direction = if (scrollVelocity > 0f) 1 else -1
+                val targetPage = if (abs(scrollVelocity) > AlbumBoundaryFlingVelocityThreshold) {
+                    browsePagerState.settledPage + direction
+                } else {
+                    browsePagerState.currentPage
+                }.coerceIn(0, browsePagerState.pageCount - 1)
+
+                val isAlreadySettled = targetPage == browsePagerState.currentPage &&
+                    browsePagerState.currentPageOffsetFraction == 0f
+                if (!isAlreadySettled) {
+                    browsePagerState.animateScrollToPage(targetPage)
+                }
+                return Velocity(x = available.x, y = 0f)
+            }
+        }
+    }
+}
+
+private fun PagerState.shouldHandOffAlbumFeedDelta(scrollDelta: Float): Boolean {
+    return when {
+        scrollDelta > 0f -> !canScrollForward
+        scrollDelta < 0f -> !canScrollBackward
+        else -> false
+    }
+}
+
+private const val AlbumBoundaryFlingVelocityThreshold = 350f
+private const val PagerOffsetSettlingEpsilon = 0.001f
 
 @Composable
 private fun AlbumFeedPageContent(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -738,6 +738,10 @@ private fun AlbumsPage(
         initialPage = feeds.indexOf(selectedFeed).coerceAtLeast(0),
         pageCount = { feeds.size },
     )
+    val feedPagerFlingBehavior = PagerDefaults.flingBehavior(
+        state = feedPagerState,
+        pagerSnapDistance = PagerSnapDistance.atMost(1),
+    )
     val coroutineScope = rememberCoroutineScope()
     val highlightedFeed = feeds[feedPagerState.targetPage.coerceIn(0, feeds.lastIndex)]
 
@@ -773,8 +777,8 @@ private fun AlbumsPage(
         HorizontalPager(
             state = feedPagerState,
             modifier = Modifier.weight(1f),
-            // Feed chips still switch this pager, while horizontal drags stay with the outer tab pager.
-            userScrollEnabled = false,
+            flingBehavior = feedPagerFlingBehavior,
+            overscrollEffect = null,
         ) { page ->
             val feed = feeds[page]
             val feedState = albumFeeds[feed] ?: AlbumFeedState()

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -1,5 +1,6 @@
 package org.hdhmc.saki.presentation.library
 
+import android.view.ViewConfiguration
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -74,6 +75,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -751,9 +753,14 @@ private fun AlbumsPage(
         state = feedPagerState,
         pagerSnapDistance = PagerSnapDistance.atMost(1),
     )
+    val context = LocalContext.current
+    val boundaryFlingVelocityThreshold = remember(context) {
+        ViewConfiguration.get(context).scaledMinimumFlingVelocity.toFloat()
+    }
     val feedBoundaryHandoffConnection = rememberAlbumFeedBoundaryHandoffConnection(
         feedPagerState = feedPagerState,
         browsePagerState = browsePagerState,
+        boundaryFlingVelocityThreshold = boundaryFlingVelocityThreshold,
     )
     val coroutineScope = rememberCoroutineScope()
     val highlightedFeed = feeds[feedPagerState.targetPage.coerceIn(0, feeds.lastIndex)]
@@ -817,8 +824,9 @@ private fun AlbumsPage(
 private fun rememberAlbumFeedBoundaryHandoffConnection(
     feedPagerState: PagerState,
     browsePagerState: PagerState,
+    boundaryFlingVelocityThreshold: Float,
 ): NestedScrollConnection {
-    return remember(feedPagerState, browsePagerState) {
+    return remember(feedPagerState, browsePagerState, boundaryFlingVelocityThreshold) {
         object : NestedScrollConnection {
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                 if (source != NestedScrollSource.UserInput || available.x == 0f) {
@@ -846,14 +854,14 @@ private fun rememberAlbumFeedBoundaryHandoffConnection(
                 }
 
                 val direction = if (scrollVelocity > 0f) 1 else -1
-                val targetPage = if (abs(scrollVelocity) > AlbumBoundaryFlingVelocityThreshold) {
+                val targetPage = if (abs(scrollVelocity) > boundaryFlingVelocityThreshold) {
                     browsePagerState.settledPage + direction
                 } else {
                     browsePagerState.currentPage
                 }.coerceIn(0, browsePagerState.pageCount - 1)
 
                 val isAlreadySettled = targetPage == browsePagerState.currentPage &&
-                    browsePagerState.currentPageOffsetFraction == 0f
+                    abs(browsePagerState.currentPageOffsetFraction) <= PagerOffsetSettlingEpsilon
                 if (!isAlreadySettled) {
                     browsePagerState.animateScrollToPage(targetPage)
                 }
@@ -871,7 +879,6 @@ private fun PagerState.shouldHandOffAlbumFeedDelta(scrollDelta: Float): Boolean 
     }
 }
 
-private const val AlbumBoundaryFlingVelocityThreshold = 350f
 private const val PagerOffsetSettlingEpsilon = 0.001f
 
 @Composable


### PR DESCRIPTION
Closes #171

## Problem
Swiping from Albums to adjacent tabs (Artists, Playlists) gets stuck halfway or feels heavier than other tab transitions. The nested `HorizontalPager` (album feeds) consumes horizontal drag gestures even at its boundary, preventing the outer browse pager from receiving them.

## Fix
Add a `NestedScrollConnection` that intercepts scroll events from the inner feed pager and forwards them to the outer browse pager when the feed pager is at its boundary:

- **`onPreScroll`**: When the inner pager can't scroll further in the drag direction (`!canScrollForward` / `!canScrollBackward`), forward the delta to the outer pager via `dispatchRawDelta`
- **`onPreFling`**: When a fling occurs at the boundary, drive the outer pager to the next/previous page via `animateScrollToPage`, using `scaledMinimumFlingVelocity` as the threshold
- **`shouldHandOffAlbumFeedDelta`**: Simple boundary check using pager's `canScrollForward/Backward`

Tab switching from Albums now feels identical to other tabs.