### PR TITLE
fix: increase capsule bottom padding for screen corner radius

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -162,7 +162,7 @@ fun NowPlayingCapsule(
         enabled = track != null,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 14.dp, vertical = 4.dp)
+            .padding(start = 14.dp, end = 14.dp, top = 4.dp, bottom = 8.dp)
             .pointerInput(track != null) {
                 if (track == null) return@pointerInput
                 val distanceThresholdPx = 72.dp.toPx()


### PR DESCRIPTION
Closes #180

Increase capsule bottom padding from 4dp to 8dp to prevent clipping by screen corner radius on devices with fullscreen gesture navigation and hidden hint bar.