### PR TITLE
fix: alphabet scroll bar clipped by capsule overlay

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -910,7 +910,7 @@ private fun ArtistsPage(
             exit = androidx.compose.animation.fadeOut(),
             modifier = Modifier
                 .align(Alignment.CenterEnd)
-                .padding(vertical = 8.dp),
+                .padding(top = 8.dp, bottom = 8.dp + bottomOverlayPadding),
         ) {
             AlphabetScrollBar(
                 labels = visibleScrollLabels,


### PR DESCRIPTION
## Bug
The alphabet scroll bar on the Artists page has its bottom letters (Y, Z, etc.) hidden behind the Now Playing capsule. Regression from PR #167 which changed the capsule from Column stacking to Box overlay.

## Fix
Add `bottomOverlayPadding` to the scroll bar's bottom padding so it clears the capsule.