### PR TITLE
fix: Now Playing touch passthrough and artwork click area

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -453,10 +453,10 @@ fun NowPlayingOverlay(
             modifier = Modifier
                 .fillMaxSize()
                 .background(background)
-                .pointerInput(Unit) { detectTapGestures { /* consume all taps */ } }
                 .statusBarsPadding()
                 .navigationBarsPadding()
-                .imePadding(),
+                .imePadding()
+                .pointerInput(Unit) { detectTapGestures { /* consume all taps */ } },
         ) {
             val playerSnackbarHostState = remember { SnackbarHostState() }
             val scope = rememberCoroutineScope()

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -452,6 +453,7 @@ fun NowPlayingOverlay(
             modifier = Modifier
                 .fillMaxSize()
                 .background(background)
+                .pointerInput(Unit) { detectTapGestures { /* consume all taps */ } }
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .imePadding(),
@@ -541,11 +543,7 @@ fun NowPlayingOverlay(
                     Box(
                         modifier = Modifier
                             .weight(1f)
-                            .fillMaxWidth()
-                            .clickable {
-                                if (showLyrics) showLyrics = false
-                                else if (hasLyrics) showLyrics = true
-                            },
+                            .fillMaxWidth(),
                         contentAlignment = Alignment.Center,
                     ) {
                         HorizontalPager(
@@ -566,7 +564,12 @@ fun NowPlayingOverlay(
                                     contentDescription = queueItem?.title,
                                     modifier = Modifier
                                         .aspectRatio(1f)
-                                        .fillMaxHeight(),
+                                        .fillMaxHeight()
+                                        .clip(RoundedCornerShape(34.dp))
+                                        .clickable {
+                                            if (showLyrics) showLyrics = false
+                                            else if (hasLyrics) showLyrics = true
+                                        },
                                     cornerRadiusDp = 34,
                                 )
                             }


### PR DESCRIPTION
Closes #185
Closes #187

## Fixes

**Touch passthrough (regression from PR #167):** Add `pointerInput { detectTapGestures {} }` on `BoxWithConstraints` to consume all taps, preventing them from reaching the underlying BrowseScreen.

**Artwork click area (#185):** Move `clickable` from the outer `Box(weight(1f).fillMaxWidth())` to the `ArtworkCard` modifier with `clip(RoundedCornerShape(34.dp))`, so the touch target matches the visible cover art shape.