### PR TITLE
style: enhance Now Playing background gradient

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -396,9 +396,9 @@ fun NowPlayingOverlay(
         val background = remember(dominant, accent, colorScheme) {
             Brush.verticalGradient(
                 listOf(
-                    dominant.copy(alpha = 0.20f).compositeOver(colorScheme.background),
-                    accent.copy(alpha = 0.18f).compositeOver(colorScheme.surface),
-                    colorScheme.background,
+                    dominant.copy(alpha = 0.50f).compositeOver(colorScheme.background),
+                    accent.copy(alpha = 0.35f).compositeOver(colorScheme.surface),
+                    dominant.copy(alpha = 0.12f).compositeOver(colorScheme.background),
                 ),
             )
         }


### PR DESCRIPTION
## Changes
Increase Now Playing background gradient intensity so cover art colors are more visible:
- Dominant color alpha: 0.20 → 0.50
- Accent color alpha: 0.18 → 0.35
- Bottom: pure `background` → `dominant.copy(alpha = 0.12)` composited on `background`