### PR TITLE
fix: stabilize artwork pager during deferred queue expansion

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -442,15 +442,34 @@ fun NowPlayingOverlay(
         var lastTrackId by remember { mutableStateOf(track.songId) }
         // Guard: suppress pager-driven skips during programmatic scroll
         var suppressPagerSkip by remember { mutableStateOf(false) }
+        var currentArtworkKeyPage by remember { mutableStateOf(playbackState.currentIndex.coerceAtLeast(0)) }
+        var pinnedCurrentArtworkPage by remember { mutableStateOf<Int?>(null) }
         // Buffer queue to avoid pager flash during shuffle toggle:
-        // update queue snapshot only after pager has scrolled to correct page
+        // keep the current artwork keyed to the visible page until the pager can
+        // move after any page-count change caused by deferred queue expansion.
         val targetPage = playbackState.currentIndex.coerceAtLeast(0)
         LaunchedEffect(targetPage, track.songId, playbackState.queue) {
             if (track.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
                 suppressPagerSkip = true
-                try { artworkPagerState.scrollToPage(targetPage) } finally { suppressPagerSkip = false }
+                pinnedCurrentArtworkPage = artworkPagerState.currentPage
+                currentArtworkKeyPage = artworkPagerState.currentPage
+                try {
+                    stableQueue = playbackState.queue
+                    withFrameNanos { }
+                    if (artworkPagerState.currentPage != targetPage) {
+                        artworkPagerState.scrollToPage(targetPage)
+                    }
+                    currentArtworkKeyPage = targetPage
+                    pinnedCurrentArtworkPage = null
+                    withFrameNanos { }
+                } finally {
+                    pinnedCurrentArtworkPage = null
+                    suppressPagerSkip = false
+                }
+            } else {
+                stableQueue = playbackState.queue
+                currentArtworkKeyPage = targetPage
             }
-            stableQueue = playbackState.queue
             if (track.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
                 suppressPagerSkip = true
                 try { artworkPagerState.animateScrollToPage(targetPage) } finally { suppressPagerSkip = false }
@@ -575,15 +594,28 @@ fun NowPlayingOverlay(
                                 .clip(RoundedCornerShape(34.dp)),
                             pageSpacing = 16.dp,
                             beyondViewportPageCount = 1,
+                            key = { page ->
+                                if (page == currentArtworkKeyPage) {
+                                    "current-${track.mediaId}"
+                                } else {
+                                    stableQueue.getOrNull(page)?.let { "queue-${it.mediaId}-$page" }
+                                        ?: "empty-$page"
+                                }
+                            },
                         ) { page ->
                             Box(
                                 modifier = Modifier.fillMaxSize(),
                                 contentAlignment = Alignment.Center,
                             ) {
                                 val queueItem = stableQueue.getOrNull(page)
+                                val artworkItem = if (page == pinnedCurrentArtworkPage) {
+                                    track
+                                } else {
+                                    queueItem
+                                }
                                 ArtworkCard(
-                                    model = queueItem?.queueArtworkModel(queueItem.serverId?.let { serversById[it] }),
-                                    contentDescription = queueItem?.title,
+                                    model = artworkItem?.queueArtworkModel(artworkItem.serverId?.let { serversById[it] }),
+                                    contentDescription = artworkItem?.title,
                                     modifier = Modifier
                                         .aspectRatio(1f)
                                         .fillMaxHeight()

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -444,9 +444,9 @@ fun NowPlayingOverlay(
         var suppressPagerSkip by remember { mutableStateOf(false) }
         var currentArtworkKeyPage by remember { mutableStateOf(playbackState.currentIndex.coerceAtLeast(0)) }
         var pinnedCurrentArtworkPage by remember { mutableStateOf<Int?>(null) }
-        // Buffer queue to avoid pager flash during shuffle toggle:
+        // Stabilize artwork during deferred queue expansion:
         // keep the current artwork keyed to the visible page until the pager can
-        // move after any page-count change caused by deferred queue expansion.
+        // move after any page-count change caused by queue item insertion.
         val targetPage = playbackState.currentIndex.coerceAtLeast(0)
         LaunchedEffect(targetPage, track.songId, playbackState.queue) {
             if (track.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {


### PR DESCRIPTION
Closes #197

## Problem
After deferred queue expansion (PR #196), `addMediaItems(0, before)` shifts `currentMediaItemIndex` from 0 to N. The artwork pager jumps from page 0 to page N, causing ArtworkCard to recompose and Coil to re-initiate the image load, resulting in a visible flash (cached cover → placeholder → cover).

## Fix
- **Stable pager key**: current playing page uses `"current-${track.mediaId}"` as key, so Compose reuses the composable when the index shifts
- **Pinned artwork**: during the pager transition, pin the current page's artwork to `track` to prevent briefly showing a wrong queue item
- **Frame-synced update**: use `withFrameNanos` to let the pager complete layout before updating keys, avoiding intermediate flicker
- **Queue update ordering**: update `stableQueue` before `scrollToPage`, then unpin after scroll completes