### PR TITLE
Optimize cover art loading

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
@@ -26,6 +26,10 @@ import java.security.MessageDigest
 import java.util.Locale
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
+const val THUMBNAIL_COVER_ART_SIZE_PX = 256
+const val PALETTE_COVER_ART_SIZE_PX = 300
+const val FULL_COVER_ART_SIZE_PX = 768
+
 @Composable
 fun ArtworkCard(
     model: Any?,
@@ -75,12 +79,13 @@ fun resolveArtworkModel(
     server: ServerConfig?,
     coverArtId: String?,
     cachedSong: CachedSong?,
+    sizePx: Int = FULL_COVER_ART_SIZE_PX,
 ): Any? {
     val localCoverPath = cachedSong?.coverArtPath
     if (!localCoverPath.isNullOrBlank() && File(localCoverPath).exists()) {
         return File(localCoverPath)
     }
-    return server?.buildCoverArtUrl(coverArtId)
+    return server?.buildCoverArtUrl(coverArtId, sizePx)
 }
 
 /**
@@ -89,7 +94,7 @@ fun resolveArtworkModel(
  * Coil's disk cache to reuse entries. At request time, [CoverArtEndpointInterceptor] rewrites
  * the base URL to the current best endpoint.
  */
-private fun ServerConfig.buildCoverArtUrl(coverArtId: String?): String? {
+private fun ServerConfig.buildCoverArtUrl(coverArtId: String?, sizePx: Int): String? {
     if (coverArtId.isNullOrBlank()) return null
     val endpoint = endpoints.sortedBy(ServerEndpoint::order).firstOrNull() ?: return null
     val baseUrl = endpoint.baseUrl.toHttpUrlOrNull() ?: return null
@@ -99,7 +104,7 @@ private fun ServerConfig.buildCoverArtUrl(coverArtId: String?): String? {
     return baseUrl.newBuilder()
         .addPathSegments("rest/getCoverArt.view")
         .addQueryParameter("id", coverArtId)
-        .addQueryParameter("size", "768")
+        .addQueryParameter("size", sizePx.coerceAtLeast(1).toString())
         .addQueryParameter("u", username)
         .addQueryParameter("t", hash)
         .addQueryParameter("s", salt)

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
@@ -90,9 +90,10 @@ fun resolveArtworkModel(
 
 /**
  * Builds a deterministic cover art URL using the first endpoint by order and a salt derived
- * from the cover art ID. Stable for a fixed server configuration and coverArtId, enabling
- * Coil's disk cache to reuse entries. At request time, [CoverArtEndpointInterceptor] rewrites
- * the base URL to the current best endpoint.
+ * from the cover art ID. Stable for a fixed (server configuration, coverArtId, sizePx) tuple,
+ * enabling Coil's disk cache to reuse entries. Different [sizePx] values produce different
+ * URLs and therefore separate cache entries. At request time, [CoverArtEndpointInterceptor]
+ * rewrites the base URL to the current best endpoint.
  */
 private fun ServerConfig.buildCoverArtUrl(coverArtId: String?, sizePx: Int): String? {
     if (coverArtId.isNullOrBlank()) return null

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -298,7 +298,7 @@ fun PlaylistCard(playlist: PlaylistSummary, server: ServerConfig, onOpenPlaylist
     RowCard(
         title = playlist.name,
         subtitle = subtitle,
-        artwork = resolveArtworkModel(server, playlist.coverArtId, null),
+        artwork = resolveArtworkModel(server, playlist.coverArtId, null, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
         onClick = { onOpenPlaylist(playlist.id) },
     )
 }
@@ -314,7 +314,7 @@ fun AlbumRow(album: AlbumSummary, server: ServerConfig, onOpenAlbum: (String) ->
     RowCard(
         title = album.name,
         subtitle = subtitle,
-        artwork = resolveArtworkModel(server, album.coverArtId, null),
+        artwork = resolveArtworkModel(server, album.coverArtId, null, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
         onClick = { onOpenAlbum(album.id) },
     )
 }
@@ -357,7 +357,7 @@ fun AlbumCard(album: AlbumSummary, server: ServerConfig, onOpenAlbum: (String) -
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             ArtworkCard(
-                model = resolveArtworkModel(server, album.coverArtId, null),
+                model = resolveArtworkModel(server, album.coverArtId, null, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
                 contentDescription = album.name,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -388,7 +388,7 @@ private fun AlbumMiniCard(album: AlbumSummary, server: ServerConfig, onOpenAlbum
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             ArtworkCard(
-                model = resolveArtworkModel(server, album.coverArtId, null),
+                model = resolveArtworkModel(server, album.coverArtId, null, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
                 contentDescription = album.name,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -426,7 +426,7 @@ fun SongRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ArtworkCard(
-            model = resolveArtworkModel(server, song.coverArtId, cachedSong),
+            model = resolveArtworkModel(server, song.coverArtId, cachedSong, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
             contentDescription = song.title,
             modifier = Modifier.size(60.dp),
             cornerRadiusDp = 18,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -110,8 +110,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.graphicsLayer
@@ -248,7 +246,10 @@ fun NowPlayingCapsule(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 AnimatedContent(
-                    targetState = Pair(track?.queueArtworkModel(currentServer), track?.title),
+                    targetState = Pair(
+                        track?.queueArtworkModel(currentServer, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
+                        track?.title,
+                    ),
                     transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(300)) },
                     label = "capsule-artwork",
                 ) { (model, title) ->
@@ -325,9 +326,6 @@ fun NowPlayingOverlay(
     lyrics: SongLyrics? = null,
 ) {
     val serversById = remember(servers) { servers.associateBy { it.id } }
-    val artwork = rememberArtworkPresentation(
-        fallbackModel = track.queueArtworkModel(currentServer),
-    )
     var showDetails by remember(track.songId) { mutableStateOf(false) }
     var showMenu by remember(track.songId) { mutableStateOf(false) }
     var showLyrics by remember { mutableStateOf(false) }
@@ -339,7 +337,8 @@ fun NowPlayingOverlay(
     val currentIdx = playbackState.currentIndex
     val prevSongId = queue.getOrNull(currentIdx - 1)?.songId
     val nextSongId = queue.getOrNull(currentIdx + 1)?.songId
-    LaunchedEffect(track.songId, prevSongId, nextSongId, currentServer) {
+    LaunchedEffect(visible, track.songId, prevSongId, nextSongId, currentServer) {
+        if (!visible) return@LaunchedEffect
         val adjacentIndices = listOfNotNull(
             if (currentIdx > 0) currentIdx - 1 else null,
             if (currentIdx < queue.lastIndex) currentIdx + 1 else null,
@@ -347,10 +346,10 @@ fun NowPlayingOverlay(
         for (i in adjacentIndices) {
             val item = queue[i]
             val server = item.serverId?.let { serversById[it] }
-            val model = item.queueArtworkModel(server) ?: continue
+            val model = item.queueArtworkModel(server, sizePx = FULL_COVER_ART_SIZE_PX) ?: continue
             val request = ImageRequest.Builder(context)
                 .data(model)
-                .size(coil3.size.Size.ORIGINAL)
+                .size(FULL_COVER_ART_SIZE_PX)
                 .build()
             context.imageLoader.enqueue(request)
         }
@@ -392,6 +391,9 @@ fun NowPlayingOverlay(
             targetOffsetY = { fullHeight -> fullHeight / 3 },
         ),
     ) {
+        val artwork = rememberArtworkPresentation(
+            fallbackModel = track.queueArtworkModel(currentServer, sizePx = PALETTE_COVER_ART_SIZE_PX),
+        )
         val colorScheme = MaterialTheme.colorScheme
         val dominant = artwork.dominantColor ?: colorScheme.primary
         val accent = artwork.accentColor ?: colorScheme.tertiary
@@ -1311,7 +1313,7 @@ private fun QueueRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             ArtworkCard(
-                model = item.queueArtworkModel(currentServer),
+                model = item.queueArtworkModel(currentServer, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
                 contentDescription = item.title,
                 modifier = Modifier.size(48.dp),
                 cornerRadiusDp = 16,
@@ -1373,17 +1375,19 @@ private fun DetailLine(label: String, value: String?) {
     )
 }
 
-private fun PlaybackQueueItem.queueArtworkModel(server: ServerConfig?): Any? {
+private fun PlaybackQueueItem.queueArtworkModel(
+    server: ServerConfig?,
+    sizePx: Int = FULL_COVER_ART_SIZE_PX,
+): Any? {
     return when {
         !coverArtPath.isNullOrBlank() -> File(coverArtPath)
-        server != null -> resolveArtworkModel(server, coverArtId, null)
+        server != null -> resolveArtworkModel(server, coverArtId, null, sizePx = sizePx)
         !artworkUri.isNullOrBlank() -> artworkUri
         else -> null
     }
 }
 
 private data class ArtworkPresentation(
-    val image: ImageBitmap? = null,
     val dominantColor: Color? = null,
     val accentColor: Color? = null,
 )
@@ -1408,15 +1412,15 @@ private suspend fun loadArtworkPresentation(
     if (model == null) return@withContext ArtworkPresentation()
     val request = coil3.request.ImageRequest.Builder(context)
         .data(model)
-        .size(300)
+        .size(PALETTE_COVER_ART_SIZE_PX)
+        .allowHardware(false)
         .build()
     val image = context.imageLoader.execute(request).image
         ?: return@withContext ArtworkPresentation()
-    val bitmap = image.toBitmap().copy(android.graphics.Bitmap.Config.ARGB_8888, false)
+    val bitmap = image.toBitmap()
 
     val palette = Palette.from(bitmap).clearFilters().generate()
     ArtworkPresentation(
-        image = bitmap.asImageBitmap(),
         dominantColor = palette.getDominantColor(0).takeIf { it != 0 }?.let(::Color),
         accentColor = palette.getVibrantColor(0).takeIf { it != 0 }?.let(::Color),
     )

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -132,6 +132,7 @@ import org.hdhmc.saki.domain.model.SongLyrics
 import java.io.File
 import coil3.imageLoader
 import coil3.request.ImageRequest
+import coil3.request.allowHardware
 import coil3.toBitmap
 import kotlin.math.roundToLong
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -76,6 +76,7 @@ import org.hdhmc.saki.domain.model.TextScale
 import org.hdhmc.saki.presentation.SakiAppUiState
 import org.hdhmc.saki.presentation.labelRes
 import org.hdhmc.saki.presentation.library.ArtworkCard
+import org.hdhmc.saki.presentation.library.THUMBNAIL_COVER_ART_SIZE_PX
 import org.hdhmc.saki.presentation.library.resolveArtworkModel
 import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
@@ -880,7 +881,7 @@ private fun CachedSongRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ArtworkCard(
-            model = resolveArtworkModel(server, song.coverArtId, song),
+            model = resolveArtworkModel(server, song.coverArtId, song, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
             contentDescription = song.title,
             modifier = Modifier.size(60.dp),
             cornerRadiusDp = 18,


### PR DESCRIPTION
- Skip Now Playing palette/preload work while the overlay is hidden
- Request smaller remote cover art for list, capsule, queue, and cached-song thumbnails
- Bound adjacent Now Playing cover preloads instead of using original size
- Remove unused retained ImageBitmap from artwork color extraction