### PR TITLE
fix: unify cover art cache keys

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
@@ -11,13 +11,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
 import org.hdhmc.saki.domain.model.CachedSong
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.ServerEndpoint
@@ -36,6 +39,7 @@ fun ArtworkCard(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     cornerRadiusDp: Int = 24,
+    requestSizePx: Int? = null,
 ) {
     val fallbackBrush = Brush.linearGradient(
         listOf(
@@ -43,15 +47,26 @@ fun ArtworkCard(
             MaterialTheme.colorScheme.tertiary.copy(alpha = 0.7f),
         ),
     )
+    val context = LocalContext.current
+    val imageModel = remember(model, requestSizePx, context) {
+        if (model != null && requestSizePx != null) {
+            ImageRequest.Builder(context)
+                .data(model)
+                .size(requestSizePx.coerceAtLeast(1))
+                .build()
+        } else {
+            model
+        }
+    }
 
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(cornerRadiusDp.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f),
     ) {
-        if (model != null) {
+        if (imageModel != null) {
             AsyncImage(
-                model = model,
+                model = imageModel,
                 contentDescription = contentDescription,
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,
@@ -79,23 +94,21 @@ fun resolveArtworkModel(
     server: ServerConfig?,
     coverArtId: String?,
     cachedSong: CachedSong?,
-    sizePx: Int = FULL_COVER_ART_SIZE_PX,
 ): Any? {
     val localCoverPath = cachedSong?.coverArtPath
     if (!localCoverPath.isNullOrBlank() && File(localCoverPath).exists()) {
         return File(localCoverPath)
     }
-    return server?.buildCoverArtUrl(coverArtId, sizePx)
+    return server?.buildCoverArtUrl(coverArtId)
 }
 
 /**
  * Builds a deterministic cover art URL using the first endpoint by order and a salt derived
- * from the cover art ID. Stable for a fixed (server configuration, coverArtId, sizePx) tuple,
- * enabling Coil's disk cache to reuse entries. Different [sizePx] values produce different
- * URLs and therefore separate cache entries. At request time, [CoverArtEndpointInterceptor]
- * rewrites the base URL to the current best endpoint.
+ * from the cover art ID. Stable for a fixed server configuration and coverArtId, enabling
+ * Coil's disk cache to reuse entries across thumbnail and full-size UI requests. At request
+ * time, [CoverArtEndpointInterceptor] rewrites the base URL to the current best endpoint.
  */
-private fun ServerConfig.buildCoverArtUrl(coverArtId: String?, sizePx: Int): String? {
+private fun ServerConfig.buildCoverArtUrl(coverArtId: String?): String? {
     if (coverArtId.isNullOrBlank()) return null
     val endpoint = endpoints.sortedBy(ServerEndpoint::order).firstOrNull() ?: return null
     val baseUrl = endpoint.baseUrl.toHttpUrlOrNull() ?: return null
@@ -105,7 +118,7 @@ private fun ServerConfig.buildCoverArtUrl(coverArtId: String?, sizePx: Int): Str
     return baseUrl.newBuilder()
         .addPathSegments("rest/getCoverArt.view")
         .addQueryParameter("id", coverArtId)
-        .addQueryParameter("size", sizePx.coerceAtLeast(1).toString())
+        .addQueryParameter("size", FULL_COVER_ART_SIZE_PX.toString())
         .addQueryParameter("u", username)
         .addQueryParameter("t", hash)
         .addQueryParameter("s", salt)

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -298,7 +298,8 @@ fun PlaylistCard(playlist: PlaylistSummary, server: ServerConfig, onOpenPlaylist
     RowCard(
         title = playlist.name,
         subtitle = subtitle,
-        artwork = resolveArtworkModel(server, playlist.coverArtId, null, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
+        artwork = resolveArtworkModel(server, playlist.coverArtId, null),
+        artworkRequestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
         onClick = { onOpenPlaylist(playlist.id) },
     )
 }
@@ -314,7 +315,8 @@ fun AlbumRow(album: AlbumSummary, server: ServerConfig, onOpenAlbum: (String) ->
     RowCard(
         title = album.name,
         subtitle = subtitle,
-        artwork = resolveArtworkModel(server, album.coverArtId, null, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
+        artwork = resolveArtworkModel(server, album.coverArtId, null),
+        artworkRequestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
         onClick = { onOpenAlbum(album.id) },
     )
 }
@@ -357,12 +359,13 @@ fun AlbumCard(album: AlbumSummary, server: ServerConfig, onOpenAlbum: (String) -
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             ArtworkCard(
-                model = resolveArtworkModel(server, album.coverArtId, null, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
+                model = resolveArtworkModel(server, album.coverArtId, null),
                 contentDescription = album.name,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(170.dp),
                 cornerRadiusDp = 24,
+                requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
             )
             Text(text = album.name, style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(top = 10.dp), maxLines = 2, overflow = TextOverflow.Ellipsis)
             Text(
@@ -388,12 +391,13 @@ private fun AlbumMiniCard(album: AlbumSummary, server: ServerConfig, onOpenAlbum
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             ArtworkCard(
-                model = resolveArtworkModel(server, album.coverArtId, null, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
+                model = resolveArtworkModel(server, album.coverArtId, null),
                 contentDescription = album.name,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(124.dp),
                 cornerRadiusDp = 18,
+                requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
             )
             Text(text = album.name, style = MaterialTheme.typography.titleSmall, modifier = Modifier.padding(top = 8.dp), maxLines = 2, overflow = TextOverflow.Ellipsis)
             Text(
@@ -426,10 +430,11 @@ fun SongRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ArtworkCard(
-            model = resolveArtworkModel(server, song.coverArtId, cachedSong, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
+            model = resolveArtworkModel(server, song.coverArtId, cachedSong),
             contentDescription = song.title,
             modifier = Modifier.size(60.dp),
             cornerRadiusDp = 18,
+            requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
         )
         Column(
             modifier = Modifier
@@ -644,7 +649,13 @@ fun EmptyStateCard(title: String, body: String, icon: androidx.compose.ui.graphi
 }
 
 @Composable
-private fun RowCard(title: String, subtitle: String?, artwork: Any?, onClick: () -> Unit) {
+private fun RowCard(
+    title: String,
+    subtitle: String?,
+    artwork: Any?,
+    artworkRequestSizePx: Int? = null,
+    onClick: () -> Unit,
+) {
     Card(
         onClick = onClick,
         modifier = Modifier
@@ -655,7 +666,13 @@ private fun RowCard(title: String, subtitle: String?, artwork: Any?, onClick: ()
     ) {
         Row(modifier = Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
             if (artwork != null) {
-                ArtworkCard(model = artwork, contentDescription = title, modifier = Modifier.size(72.dp), cornerRadiusDp = 22)
+                ArtworkCard(
+                    model = artwork,
+                    contentDescription = title,
+                    modifier = Modifier.size(72.dp),
+                    cornerRadiusDp = 22,
+                    requestSizePx = artworkRequestSizePx,
+                )
             }
             Column(
                 modifier = Modifier

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -248,7 +248,7 @@ fun NowPlayingCapsule(
             ) {
                 AnimatedContent(
                     targetState = Pair(
-                        track?.queueArtworkModel(currentServer, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
+                        track?.queueArtworkModel(currentServer),
                         track?.title,
                     ),
                     transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(300)) },
@@ -259,6 +259,7 @@ fun NowPlayingCapsule(
                         contentDescription = title,
                         modifier = Modifier.size(46.dp),
                         cornerRadiusDp = 14,
+                        requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
                     )
                 }
                 Column(
@@ -347,7 +348,7 @@ fun NowPlayingOverlay(
         for (i in adjacentIndices) {
             val item = queue[i]
             val server = item.serverId?.let { serversById[it] }
-            val model = item.queueArtworkModel(server, sizePx = FULL_COVER_ART_SIZE_PX) ?: continue
+            val model = item.queueArtworkModel(server) ?: continue
             val request = ImageRequest.Builder(context)
                 .data(model)
                 .size(FULL_COVER_ART_SIZE_PX)
@@ -393,7 +394,7 @@ fun NowPlayingOverlay(
         ),
     ) {
         val artwork = rememberArtworkPresentation(
-            fallbackModel = track.queueArtworkModel(currentServer, sizePx = PALETTE_COVER_ART_SIZE_PX),
+            fallbackModel = track.queueArtworkModel(currentServer),
         )
         val colorScheme = MaterialTheme.colorScheme
         val dominant = artwork.dominantColor ?: colorScheme.primary
@@ -1314,10 +1315,11 @@ private fun QueueRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             ArtworkCard(
-                model = item.queueArtworkModel(currentServer, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
+                model = item.queueArtworkModel(currentServer),
                 contentDescription = item.title,
                 modifier = Modifier.size(48.dp),
                 cornerRadiusDp = 16,
+                requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
             )
             Column(
                 modifier = Modifier
@@ -1376,13 +1378,10 @@ private fun DetailLine(label: String, value: String?) {
     )
 }
 
-private fun PlaybackQueueItem.queueArtworkModel(
-    server: ServerConfig?,
-    sizePx: Int = FULL_COVER_ART_SIZE_PX,
-): Any? {
+private fun PlaybackQueueItem.queueArtworkModel(server: ServerConfig?): Any? {
     return when {
         !coverArtPath.isNullOrBlank() -> File(coverArtPath)
-        server != null -> resolveArtworkModel(server, coverArtId, null, sizePx = sizePx)
+        server != null -> resolveArtworkModel(server, coverArtId, null)
         !artworkUri.isNullOrBlank() -> artworkUri
         else -> null
     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -881,10 +881,11 @@ private fun CachedSongRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ArtworkCard(
-            model = resolveArtworkModel(server, song.coverArtId, song, sizePx = THUMBNAIL_COVER_ART_SIZE_PX),
+            model = resolveArtworkModel(server, song.coverArtId, song),
             contentDescription = song.title,
             modifier = Modifier.size(60.dp),
             cornerRadiusDp = 18,
+            requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
         )
         Column(
             modifier = Modifier


### PR DESCRIPTION
- Use one server-side cover art URL size for all remote artwork
- Keep thumbnail decode savings by applying Coil request sizes in ArtworkCard
- Preserve bounded Now Playing preload and palette decode sizes