### PR TITLE
fix: split playback progress updates

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/domain/model/PlaybackModels.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/PlaybackModels.kt
@@ -240,6 +240,12 @@ data class PlaybackRuntimeInfo(
     val language: String? = null,
 )
 
+data class PlaybackProgressState(
+    val positionMs: Long = 0,
+    val durationMs: Long = 0,
+    val bufferedPositionMs: Long = 0,
+)
+
 data class PlaybackSessionState(
     val isConnected: Boolean = false,
     val isPlaying: Boolean = false,

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/PlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/PlaybackManager.kt
@@ -1,12 +1,14 @@
 package org.hdhmc.saki.domain.repository
 
 import org.hdhmc.saki.domain.model.CachedSong
+import org.hdhmc.saki.domain.model.PlaybackProgressState
 import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.Song
 import kotlinx.coroutines.flow.StateFlow
 
 interface PlaybackManager {
     val playbackState: StateFlow<PlaybackSessionState>
+    val playbackProgress: StateFlow<PlaybackProgressState>
 
     suspend fun playSong(
         serverId: Long,

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -18,6 +18,7 @@ import org.hdhmc.saki.data.remote.NetworkTypeProvider
 import org.hdhmc.saki.di.DefaultDispatcher
 import org.hdhmc.saki.di.MainDispatcher
 import org.hdhmc.saki.domain.model.CachedSong
+import org.hdhmc.saki.domain.model.PlaybackProgressState
 import org.hdhmc.saki.domain.model.PlaybackRuntimeInfo
 import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.RepeatModeSetting
@@ -86,9 +87,11 @@ class DefaultPlaybackManager @Inject constructor(
 
     private var controller: MediaController? = null
     private val mutablePlaybackState = MutableStateFlow(PlaybackSessionState())
+    private val mutablePlaybackProgress = MutableStateFlow(PlaybackProgressState())
     @Volatile private var cacheReady = false
 
     override val playbackState: StateFlow<PlaybackSessionState> = mutablePlaybackState.asStateFlow()
+    override val playbackProgress: StateFlow<PlaybackProgressState> = mutablePlaybackProgress.asStateFlow()
 
     private fun effectiveQuality(): StreamQuality {
         val prefs = playbackState.value.preferences
@@ -150,21 +153,33 @@ class DefaultPlaybackManager @Inject constructor(
 
     init {
         scope.launch {
-            streamCacheRepository.observeCacheVersion().collect { if (it > 0L) cacheReady = true }
+            streamCacheRepository.observeCacheVersion().collect {
+                if (it > 0L) cacheReady = true
+                controller?.let(::syncState)
+            }
         }
         scope.launch {
             playbackPreferencesRepository.observePreferences().collect { preferences ->
                 mutablePlaybackState.update { state ->
                     state.copy(preferences = preferences)
                 }
+                controller?.let(::syncState)
+            }
+        }
+        scope.launch {
+            networkTypeProvider.networkType.collect {
+                controller?.let(::syncState)
             }
         }
         scope.launch {
             runCatching { ensureControllerConnected() }
             while (isActive) {
                 controller?.let { activeController ->
-                    syncExternalShuffleState(activeController)
-                    syncState(activeController)
+                    if (syncExternalShuffleState(activeController)) {
+                        syncState(activeController)
+                    } else {
+                        syncProgress(activeController)
+                    }
                 }
                 delay(if (mutablePlaybackState.value.isPlaying) 500L else 1_000L)
             }
@@ -715,6 +730,8 @@ class DefaultPlaybackManager @Inject constructor(
             )
         } else null
         val streamCached = cachedQualityKey != null
+        val progress = player.toProgressState()
+        mutablePlaybackProgress.value = progress
 
         mutablePlaybackState.update { state ->
             val currentDisplayItem = displayQueue.getOrNull(displayIndex)?.let { item ->
@@ -736,11 +753,9 @@ class DefaultPlaybackManager @Inject constructor(
                 currentItem = currentDisplayItem,
                 currentIndex = displayIndex,
                 queue = displayQueue,
-                positionMs = player.currentPosition.coerceKnownTime(),
-                durationMs = player.duration.coerceKnownTime().takeIf { it > 0 }
-                    ?: player.currentMediaItem?.metadataDurationMs()
-                    ?: 0L,
-                bufferedPositionMs = player.bufferedPosition.coerceKnownTime(),
+                positionMs = progress.positionMs,
+                durationMs = progress.durationMs,
+                bufferedPositionMs = progress.bufferedPositionMs,
                 isStreamCached = streamCached,
                 repeatMode = player.repeatMode.toRepeatModeSetting(),
                 shuffleEnabled = pendingDeferredShuffleEnabled ?: (shuffleDisplayOrder != null || player.shuffleModeEnabled),
@@ -749,16 +764,21 @@ class DefaultPlaybackManager @Inject constructor(
         }
     }
 
-    private fun syncExternalShuffleState(player: Player) {
+    private fun syncProgress(player: Player) {
+        mutablePlaybackProgress.value = player.toProgressState()
+    }
+
+    private fun syncExternalShuffleState(player: Player): Boolean {
         if (!player.shuffleModeEnabled) {
             restoringExternalShuffleState = false
             if (shuffleDisplayOrder != null) {
                 shuffleDisplayOrder = null
                 scope.launch { playbackPreferencesRepository.clearShuffleState() }
+                return true
             }
-            return
+            return false
         }
-        if (shuffleDisplayOrder != null || player.mediaItemCount <= 1 || restoringExternalShuffleState) return
+        if (shuffleDisplayOrder != null || player.mediaItemCount <= 1 || restoringExternalShuffleState) return false
 
         restoringExternalShuffleState = true
         scope.launch {
@@ -775,6 +795,7 @@ class DefaultPlaybackManager @Inject constructor(
                 restoringExternalShuffleState = false
             }
         }
+        return false
     }
 
     private suspend fun readExternalShuffleState(): Pair<Long, Int>? {
@@ -810,6 +831,16 @@ private suspend fun ListenableFuture<MediaController>.await(
 
 private fun Long.coerceKnownTime(): Long {
     return if (this == C.TIME_UNSET || this < 0L) 0L else this
+}
+
+private fun Player.toProgressState(): PlaybackProgressState {
+    return PlaybackProgressState(
+        positionMs = currentPosition.coerceKnownTime(),
+        durationMs = duration.coerceKnownTime().takeIf { it > 0 }
+            ?: currentMediaItem?.metadataDurationMs()
+            ?: 0L,
+        bufferedPositionMs = bufferedPosition.coerceKnownTime(),
+    )
 }
 
 private fun Int.toRepeatModeSetting(): RepeatModeSetting {

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -35,7 +35,10 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import org.hdhmc.saki.domain.model.PlaybackProgressState
+import org.hdhmc.saki.domain.model.PlaybackQueueItem
 import org.hdhmc.saki.domain.model.PlaybackSessionState
+import org.hdhmc.saki.domain.model.ServerConfig
+import org.hdhmc.saki.domain.model.SongLyrics
 import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.presentation.library.BrowseScreen
 import org.hdhmc.saki.presentation.library.NowPlayingCapsule
@@ -97,7 +100,7 @@ fun SakiApp(
                 else -> {
                     RootShell(
                         uiState = uiState,
-                        playbackProgress = viewModel.playbackProgress,
+                        playbackProgressFlow = viewModel.playbackProgress,
                         snackbarHostState = snackbarHostState,
                         showNowPlaying = showNowPlaying,
                         onManageServers = { showServerManager = true },
@@ -184,7 +187,7 @@ fun SakiApp(
 @Composable
 private fun RootShell(
     uiState: SakiAppUiState,
-    playbackProgress: StateFlow<PlaybackProgressState>,
+    playbackProgressFlow: StateFlow<PlaybackProgressState>,
     snackbarHostState: SnackbarHostState,
     showNowPlaying: Boolean,
     onManageServers: () -> Unit,
@@ -386,15 +389,10 @@ private fun RootShell(
                 track.serverId != uiState.selectedServerId ||
                 track.artistId in availableArtistIds
             )
-        val progress = if (showNowPlaying) {
-            playbackProgress.collectAsStateWithLifecycle().value
-        } else {
-            uiState.playbackState.toProgressState()
-        }
-        NowPlayingOverlay(
+        NowPlayingOverlayHost(
             visible = showNowPlaying,
             playbackState = uiState.playbackState,
-            playbackProgress = progress,
+            playbackProgressFlow = playbackProgressFlow,
             track = track,
             onDismiss = onDismissNowPlaying,
             canOpenArtist = canOpenArtistFromNowPlaying,
@@ -430,6 +428,74 @@ private fun RootShell(
             lyrics = uiState.currentLyrics,
         )
     }
+}
+
+/**
+ * Isolates [playbackProgressFlow] collection so progress ticks only recompose
+ * the overlay subtree, not the parent [RootShell].
+ */
+@Composable
+private fun NowPlayingOverlayHost(
+    visible: Boolean,
+    playbackState: PlaybackSessionState,
+    playbackProgressFlow: StateFlow<PlaybackProgressState>,
+    track: PlaybackQueueItem,
+    onDismiss: () -> Unit,
+    canOpenArtist: Boolean,
+    onOpenArtist: () -> Unit,
+    onOpenAlbum: () -> Unit,
+    onPlayPause: () -> Unit,
+    onSkipToNext: () -> Unit,
+    onSkipToPrevious: () -> Unit,
+    onSeekTo: (Long) -> Unit,
+    onCycleRepeatMode: () -> Unit,
+    onToggleShuffle: () -> Unit,
+    onSkipToQueueItem: (Int) -> Unit,
+    onRemoveQueueItem: (Int) -> Unit,
+    currentServer: ServerConfig?,
+    servers: List<ServerConfig>,
+    activeEndpointLabel: String?,
+    activeEndpointId: Long?,
+    isEndpointForced: Boolean,
+    endpointProbeResults: List<EndpointProbeInfo>,
+    isProbing: Boolean,
+    onReprobeEndpoints: () -> Unit,
+    onForceEndpoint: (Long) -> Unit,
+    lyrics: SongLyrics?,
+) {
+    val progress = if (visible) {
+        playbackProgressFlow.collectAsStateWithLifecycle().value
+    } else {
+        playbackState.toProgressState()
+    }
+    NowPlayingOverlay(
+        visible = visible,
+        playbackState = playbackState,
+        playbackProgress = progress,
+        track = track,
+        onDismiss = onDismiss,
+        canOpenArtist = canOpenArtist,
+        onOpenArtist = onOpenArtist,
+        onOpenAlbum = onOpenAlbum,
+        onPlayPause = onPlayPause,
+        onSkipToNext = onSkipToNext,
+        onSkipToPrevious = onSkipToPrevious,
+        onSeekTo = onSeekTo,
+        onCycleRepeatMode = onCycleRepeatMode,
+        onToggleShuffle = onToggleShuffle,
+        onSkipToQueueItem = onSkipToQueueItem,
+        onRemoveQueueItem = onRemoveQueueItem,
+        currentServer = currentServer,
+        servers = servers,
+        activeEndpointLabel = activeEndpointLabel,
+        activeEndpointId = activeEndpointId,
+        isEndpointForced = isEndpointForced,
+        endpointProbeResults = endpointProbeResults,
+        isProbing = isProbing,
+        onReprobeEndpoints = onReprobeEndpoints,
+        onForceEndpoint = onForceEndpoint,
+        lyrics = lyrics,
+    )
 }
 
 private fun PlaybackSessionState.toProgressState(): PlaybackProgressState {

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -35,7 +35,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import org.hdhmc.saki.domain.model.PlaybackProgressState
-import org.hdhmc.saki.domain.model.PlaybackQueueItem
 import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.SongLyrics
@@ -57,6 +56,7 @@ fun SakiApp(
     val context = LocalContext.current
     var showServerManager by rememberSaveable { mutableStateOf(false) }
     var showNowPlaying by rememberSaveable { mutableStateOf(false) }
+    var showSettings by rememberSaveable { mutableStateOf(false) }
     val density = LocalDensity.current
     val appDensity = remember(density, uiState.textScale) {
         Density(
@@ -100,16 +100,15 @@ fun SakiApp(
                 else -> {
                     RootShell(
                         uiState = uiState,
-                        playbackProgressFlow = viewModel.playbackProgress,
                         snackbarHostState = snackbarHostState,
-                        showNowPlaying = showNowPlaying,
+                        showSettings = showSettings,
+                        onShowSettingsChange = { showSettings = it },
                         onManageServers = { showServerManager = true },
                         onOpenNowPlaying = {
                             if (uiState.playbackState.currentItem != null) {
                                 showNowPlaying = true
                             }
                         },
-                        onDismissNowPlaying = { showNowPlaying = false },
                         onSelectBrowseSection = viewModel::selectBrowseSection,
                         onSelectServer = viewModel::selectServer,
                         onSetSearchActive = viewModel::setSearchActive,
@@ -154,6 +153,22 @@ fun SakiApp(
                         onUpdateCustomBufferSeconds = viewModel::updateCustomBufferSeconds,
                         onExportConfig = viewModel::exportConfig,
                         onImportConfig = { uri -> viewModel.importConfig(uri) },
+                        onPausePlayback = viewModel::pausePlayback,
+                        onResumePlayback = viewModel::resumePlayback,
+                        onSkipToNext = viewModel::skipToNext,
+                        onSkipToPrevious = viewModel::skipToPrevious,
+                    )
+                    NowPlayingOverlayHost(
+                        visible = showNowPlaying,
+                        playbackState = uiState.playbackState,
+                        playbackProgressFlow = viewModel.playbackProgress,
+                        servers = uiState.servers,
+                        selectedServerId = uiState.selectedServerId,
+                        libraryIndexes = uiState.libraryIndexes,
+                        endpointStatus = endpointStatus,
+                        lyrics = uiState.currentLyrics,
+                        onDismiss = { showNowPlaying = false },
+                        onCloseSettings = { showSettings = false },
                         onOpenArtistFromPlayback = viewModel::openArtistFromPlayback,
                         onOpenAlbumFromPlayback = viewModel::openAlbumFromPlayback,
                         onPausePlayback = viewModel::pausePlayback,
@@ -165,7 +180,6 @@ fun SakiApp(
                         onToggleShuffle = viewModel::toggleShuffle,
                         onSkipToQueueItem = viewModel::skipToQueueItem,
                         onRemoveQueueItem = viewModel::removeQueueItem,
-                        endpointStatus = endpointStatus,
                         onReprobeEndpoints = viewModel::reprobeEndpoints,
                         onForceEndpoint = viewModel::forceEndpoint,
                     )
@@ -187,12 +201,11 @@ fun SakiApp(
 @Composable
 private fun RootShell(
     uiState: SakiAppUiState,
-    playbackProgressFlow: StateFlow<PlaybackProgressState>,
     snackbarHostState: SnackbarHostState,
-    showNowPlaying: Boolean,
+    showSettings: Boolean,
+    onShowSettingsChange: (Boolean) -> Unit,
     onManageServers: () -> Unit,
     onOpenNowPlaying: () -> Unit,
-    onDismissNowPlaying: () -> Unit,
     onSelectBrowseSection: (BrowseSection) -> Unit,
     onSelectServer: (Long) -> Unit,
     onSetSearchActive: (Boolean) -> Unit,
@@ -237,45 +250,20 @@ private fun RootShell(
     onUpdateCustomBufferSeconds: (Int) -> Unit,
     onExportConfig: (android.net.Uri) -> Unit,
     onImportConfig: (android.net.Uri) -> Unit,
-    onOpenArtistFromPlayback: (Long?, String?) -> Unit,
-    onOpenAlbumFromPlayback: (Long?, String?) -> Unit,
     onPausePlayback: () -> Unit,
     onResumePlayback: () -> Unit,
     onSkipToNext: () -> Unit,
     onSkipToPrevious: () -> Unit,
-    onSeekTo: (Long) -> Unit,
-    onCycleRepeatMode: () -> Unit,
-    onToggleShuffle: () -> Unit,
-    onSkipToQueueItem: (Int) -> Unit,
-    onRemoveQueueItem: (Int) -> Unit,
-    endpointStatus: EndpointStatus = EndpointStatus(),
-    onReprobeEndpoints: () -> Unit = {},
-    onForceEndpoint: (Long) -> Unit = {},
 ) {
     val currentOrQueuedTrack = uiState.playbackState.currentItem ?: uiState.playbackState.queue.firstOrNull()
     val shellBackgroundBrush = rememberBrowseBackgroundBrush()
-    var showSettings by rememberSaveable { mutableStateOf(false) }
     val density = LocalDensity.current
     val defaultCapsuleHeightPx = with(density) { 72.dp.roundToPx() }
     var capsuleHeightPx by remember { mutableIntStateOf(defaultCapsuleHeightPx) }
     val capsuleOverlayPadding = with(density) { capsuleHeightPx.toDp() }
-    val availableArtistIds = remember(uiState.libraryIndexes) {
-        uiState.libraryIndexes
-            ?.let { indexes ->
-                (
-                    indexes.shortcuts.map { it.id } +
-                        indexes.sections.flatMap { section -> section.artists.map { artist -> artist.id } }
-                    ).toSet()
-            }
-            .orEmpty()
-    }
 
-    BackHandler(enabled = showNowPlaying) {
-        onDismissNowPlaying()
-    }
-
-    BackHandler(enabled = !showNowPlaying && showSettings) {
-        showSettings = false
+    BackHandler(enabled = showSettings) {
+        onShowSettingsChange(false)
     }
 
     Box(
@@ -342,7 +330,7 @@ private fun RootShell(
                         onQueueSong = onQueueSong,
                         onPlaySongNext = onPlaySongNext,
                         onToggleSongDownload = onToggleSongDownload,
-                        onOpenSettings = { showSettings = true },
+                        onOpenSettings = { onShowSettingsChange(true) },
                         onImportConfig = onImportConfig,
                     )
                 }
@@ -381,70 +369,28 @@ private fun RootShell(
             }
         }
     }
-
-    uiState.playbackState.currentItem?.let { track ->
-        val canOpenArtistFromNowPlaying = track.artistId != null && (
-            uiState.libraryIndexes == null ||
-                track.serverId == null ||
-                track.serverId != uiState.selectedServerId ||
-                track.artistId in availableArtistIds
-            )
-        NowPlayingOverlayHost(
-            visible = showNowPlaying,
-            playbackState = uiState.playbackState,
-            playbackProgressFlow = playbackProgressFlow,
-            track = track,
-            onDismiss = onDismissNowPlaying,
-            canOpenArtist = canOpenArtistFromNowPlaying,
-            onOpenArtist = {
-                showSettings = false
-                onOpenArtistFromPlayback(track.serverId, track.artistId)
-                onDismissNowPlaying()
-            },
-            onOpenAlbum = {
-                showSettings = false
-                onOpenAlbumFromPlayback(track.serverId, track.albumId)
-                onDismissNowPlaying()
-            },
-            onPlayPause = {
-                if (uiState.playbackState.isPlaying) onPausePlayback() else onResumePlayback()
-            },
-            onSkipToNext = onSkipToNext,
-            onSkipToPrevious = onSkipToPrevious,
-            onSeekTo = onSeekTo,
-            onCycleRepeatMode = onCycleRepeatMode,
-            onToggleShuffle = onToggleShuffle,
-            onSkipToQueueItem = onSkipToQueueItem,
-            onRemoveQueueItem = onRemoveQueueItem,
-            currentServer = uiState.servers.firstOrNull { it.id == track.serverId },
-            servers = uiState.servers,
-            activeEndpointLabel = endpointStatus.activeEndpointLabel,
-            activeEndpointId = endpointStatus.activeEndpointId,
-            isEndpointForced = endpointStatus.isForced,
-            endpointProbeResults = endpointStatus.probeResults,
-            isProbing = endpointStatus.isProbing,
-            onReprobeEndpoints = onReprobeEndpoints,
-            onForceEndpoint = onForceEndpoint,
-            lyrics = uiState.currentLyrics,
-        )
-    }
 }
 
 /**
  * Isolates [playbackProgressFlow] collection so progress ticks only recompose
- * the overlay subtree, not the parent [RootShell].
+ * the overlay subtree, not [RootShell].
  */
 @Composable
 private fun NowPlayingOverlayHost(
     visible: Boolean,
     playbackState: PlaybackSessionState,
     playbackProgressFlow: StateFlow<PlaybackProgressState>,
-    track: PlaybackQueueItem,
+    servers: List<ServerConfig>,
+    selectedServerId: Long?,
+    libraryIndexes: org.hdhmc.saki.domain.model.LibraryIndexes?,
+    endpointStatus: EndpointStatus,
+    lyrics: SongLyrics?,
     onDismiss: () -> Unit,
-    canOpenArtist: Boolean,
-    onOpenArtist: () -> Unit,
-    onOpenAlbum: () -> Unit,
-    onPlayPause: () -> Unit,
+    onCloseSettings: () -> Unit,
+    onOpenArtistFromPlayback: (Long?, String?) -> Unit,
+    onOpenAlbumFromPlayback: (Long?, String?) -> Unit,
+    onPausePlayback: () -> Unit,
+    onResumePlayback: () -> Unit,
     onSkipToNext: () -> Unit,
     onSkipToPrevious: () -> Unit,
     onSeekTo: (Long) -> Unit,
@@ -452,17 +398,26 @@ private fun NowPlayingOverlayHost(
     onToggleShuffle: () -> Unit,
     onSkipToQueueItem: (Int) -> Unit,
     onRemoveQueueItem: (Int) -> Unit,
-    currentServer: ServerConfig?,
-    servers: List<ServerConfig>,
-    activeEndpointLabel: String?,
-    activeEndpointId: Long?,
-    isEndpointForced: Boolean,
-    endpointProbeResults: List<EndpointProbeInfo>,
-    isProbing: Boolean,
     onReprobeEndpoints: () -> Unit,
     onForceEndpoint: (Long) -> Unit,
-    lyrics: SongLyrics?,
 ) {
+    val track = playbackState.currentItem ?: return
+    val availableArtistIds = remember(libraryIndexes) {
+        libraryIndexes
+            ?.let { indexes ->
+                (
+                    indexes.shortcuts.map { it.id } +
+                        indexes.sections.flatMap { section -> section.artists.map { artist -> artist.id } }
+                    ).toSet()
+            }
+            .orEmpty()
+    }
+    val canOpenArtist = track.artistId != null && (
+        libraryIndexes == null ||
+            track.serverId == null ||
+            track.serverId != selectedServerId ||
+            track.artistId in availableArtistIds
+        )
     val progress = if (visible) {
         playbackProgressFlow.collectAsStateWithLifecycle().value
     } else {
@@ -475,9 +430,19 @@ private fun NowPlayingOverlayHost(
         track = track,
         onDismiss = onDismiss,
         canOpenArtist = canOpenArtist,
-        onOpenArtist = onOpenArtist,
-        onOpenAlbum = onOpenAlbum,
-        onPlayPause = onPlayPause,
+        onOpenArtist = {
+            onCloseSettings()
+            onOpenArtistFromPlayback(track.serverId, track.artistId)
+            onDismiss()
+        },
+        onOpenAlbum = {
+            onCloseSettings()
+            onOpenAlbumFromPlayback(track.serverId, track.albumId)
+            onDismiss()
+        },
+        onPlayPause = {
+            if (playbackState.isPlaying) onPausePlayback() else onResumePlayback()
+        },
         onSkipToNext = onSkipToNext,
         onSkipToPrevious = onSkipToPrevious,
         onSeekTo = onSeekTo,
@@ -485,13 +450,13 @@ private fun NowPlayingOverlayHost(
         onToggleShuffle = onToggleShuffle,
         onSkipToQueueItem = onSkipToQueueItem,
         onRemoveQueueItem = onRemoveQueueItem,
-        currentServer = currentServer,
+        currentServer = servers.firstOrNull { it.id == track.serverId },
         servers = servers,
-        activeEndpointLabel = activeEndpointLabel,
-        activeEndpointId = activeEndpointId,
-        isEndpointForced = isEndpointForced,
-        endpointProbeResults = endpointProbeResults,
-        isProbing = isProbing,
+        activeEndpointLabel = endpointStatus.activeEndpointLabel,
+        activeEndpointId = endpointStatus.activeEndpointId,
+        isEndpointForced = endpointStatus.isForced,
+        endpointProbeResults = endpointStatus.probeResults,
+        isProbing = endpointStatus.isProbing,
         onReprobeEndpoints = onReprobeEndpoints,
         onForceEndpoint = onForceEndpoint,
         lyrics = lyrics,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -32,13 +32,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import org.hdhmc.saki.domain.model.PlaybackProgressState
+import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.presentation.library.BrowseScreen
-import org.hdhmc.saki.presentation.library.NowPlayingOverlay
 import org.hdhmc.saki.presentation.library.NowPlayingCapsule
+import org.hdhmc.saki.presentation.library.NowPlayingOverlay
 import org.hdhmc.saki.presentation.serverconfig.ServerConfigRoute
 import org.hdhmc.saki.presentation.settings.SettingsScreen
-import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun SakiApp(
@@ -94,6 +97,7 @@ fun SakiApp(
                 else -> {
                     RootShell(
                         uiState = uiState,
+                        playbackProgress = viewModel.playbackProgress,
                         snackbarHostState = snackbarHostState,
                         showNowPlaying = showNowPlaying,
                         onManageServers = { showServerManager = true },
@@ -180,6 +184,7 @@ fun SakiApp(
 @Composable
 private fun RootShell(
     uiState: SakiAppUiState,
+    playbackProgress: StateFlow<PlaybackProgressState>,
     snackbarHostState: SnackbarHostState,
     showNowPlaying: Boolean,
     onManageServers: () -> Unit,
@@ -381,9 +386,15 @@ private fun RootShell(
                 track.serverId != uiState.selectedServerId ||
                 track.artistId in availableArtistIds
             )
+        val progress = if (showNowPlaying) {
+            playbackProgress.collectAsStateWithLifecycle().value
+        } else {
+            uiState.playbackState.toProgressState()
+        }
         NowPlayingOverlay(
             visible = showNowPlaying,
             playbackState = uiState.playbackState,
+            playbackProgress = progress,
             track = track,
             onDismiss = onDismissNowPlaying,
             canOpenArtist = canOpenArtistFromNowPlaying,
@@ -419,4 +430,12 @@ private fun RootShell(
             lyrics = uiState.currentLyrics,
         )
     }
+}
+
+private fun PlaybackSessionState.toProgressState(): PlaybackProgressState {
+    return PlaybackProgressState(
+        positionMs = positionMs,
+        durationMs = durationMs,
+        bufferedPositionMs = bufferedPositionMs,
+    )
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -20,6 +20,7 @@ import org.hdhmc.saki.domain.model.CachedSong
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
 import org.hdhmc.saki.domain.model.LibraryIndexes
 import org.hdhmc.saki.domain.model.regroupByLocale
+import org.hdhmc.saki.domain.model.PlaybackProgressState
 import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.Playlist
 import org.hdhmc.saki.domain.model.PlaylistSummary
@@ -88,6 +89,7 @@ class SakiAppViewModel @Inject constructor(
     val endpointStatus: StateFlow<EndpointStatus> = mutableEndpointStatus.asStateFlow()
 
     val uiState = mutableUiState.asStateFlow()
+    val playbackProgress: StateFlow<PlaybackProgressState> = playbackManager.playbackProgress
     val messages = snackbarMessages.asSharedFlow()
     val openNowPlayingRequests = openNowPlayingRequestsFlow.asSharedFlow()
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -125,6 +125,7 @@ import androidx.palette.graphics.Palette
 import org.hdhmc.saki.R
 import org.hdhmc.saki.presentation.EndpointProbeInfo
 import org.hdhmc.saki.domain.model.PlaybackQueueItem
+import org.hdhmc.saki.domain.model.PlaybackProgressState
 import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.RepeatModeSetting
 import org.hdhmc.saki.domain.model.ServerConfig
@@ -303,6 +304,7 @@ fun NowPlayingCapsule(
 fun NowPlayingOverlay(
     visible: Boolean,
     playbackState: PlaybackSessionState,
+    playbackProgress: PlaybackProgressState,
     track: PlaybackQueueItem,
     onDismiss: () -> Unit,
     canOpenArtist: Boolean,
@@ -426,13 +428,13 @@ fun NowPlayingOverlay(
         }
         val sliderInactiveColor = sliderActiveColor.copy(alpha = 0.25f)
         var sliderValue by remember(track.songId) {
-            mutableFloatStateOf(playbackState.positionMs.toFloat())
+            mutableFloatStateOf(playbackProgress.positionMs.toFloat())
         }
         var isDragging by remember(track.songId) { mutableStateOf(false) }
 
-        LaunchedEffect(playbackState.positionMs, track.songId) {
+        LaunchedEffect(playbackProgress.positionMs, track.songId) {
             if (!isDragging) {
-                sliderValue = playbackState.positionMs.toFloat()
+                sliderValue = playbackProgress.positionMs.toFloat()
             }
         }
 
@@ -665,7 +667,7 @@ fun NowPlayingOverlay(
                                 if (lyrics != null && lyrics.lines.isNotEmpty()) {
                                     SyncedLyricsView(
                                         lyrics = lyrics,
-                                        positionMs = playbackState.positionMs,
+                                        positionMs = playbackProgress.positionMs,
                                         isPlaying = playbackState.isPlaying,
                                         onSeekTo = onSeekTo,
                                         modifier = Modifier
@@ -775,9 +777,9 @@ fun NowPlayingOverlay(
                         onOpenArtist = onOpenArtist,
                         onOpenAlbum = onOpenAlbum,
                     )
-                    val duration = playbackState.durationMs.coerceAtLeast(1L).toFloat()
-                    val bufferFraction = if (playbackState.durationMs > 0) {
-                        (playbackState.bufferedPositionMs.toFloat() / duration).coerceIn(0f, 1f)
+                    val duration = playbackProgress.durationMs.coerceAtLeast(1L).toFloat()
+                    val bufferFraction = if (playbackProgress.durationMs > 0) {
+                        (playbackProgress.bufferedPositionMs.toFloat() / duration).coerceIn(0f, 1f)
                     } else 0f
                     val isCachedTrack = track.isCached || playbackState.isStreamCached
                     val sliderColors = if (isCachedTrack) {
@@ -867,7 +869,7 @@ fun NowPlayingOverlay(
                             horizontalArrangement = Arrangement.SpaceBetween,
                         ) {
                             Text(text = formatDuration(sliderValue.roundToLong()), color = MaterialTheme.colorScheme.onBackground)
-                            Text(text = formatDuration(playbackState.durationMs), color = MaterialTheme.colorScheme.onBackground)
+                            Text(text = formatDuration(playbackProgress.durationMs), color = MaterialTheme.colorScheme.onBackground)
                         }
                         Row(
                             modifier = Modifier.fillMaxWidth(),

--- a/scripts/perftest.sh
+++ b/scripts/perftest.sh
@@ -1,0 +1,146 @@
+#!/bin/sh
+# Standardized gfxinfo performance test for Saki.Android
+# Usage:
+#   Via adb:  adb shell sh /sdcard/perftest.sh [scenario] [output_dir]
+#   On device: sh /sdcard/perftest.sh [scenario] [output_dir]
+#
+# Scenarios: scroll | nowplaying | swipe | dismiss | all
+# Default: all, output to /sdcard/
+
+PKG="org.hdhmc.saki"
+SCENARIO="${1:-all}"
+OUT="${2:-/sdcard}"
+
+# Auto-detect screen size
+SIZE=$(wm size | grep "Physical" | awk '{print $3}')
+W=$(echo "$SIZE" | cut -d'x' -f1)
+H=$(echo "$SIZE" | cut -d'x' -f2)
+
+# Derived coordinates (proportional to screen)
+CX=$((W / 2))                # center X
+CY=$((H / 2))                # center Y
+SCROLL_Y1=$((H * 75 / 100))  # scroll start (75% from top)
+SCROLL_Y2=$((H * 25 / 100))  # scroll end (25% from top)
+SWIPE_X1=$((W * 80 / 100))   # cover swipe start X
+SWIPE_X2=$((W * 20 / 100))   # cover swipe end X
+BOTTOM_Y=$((H * 90 / 100))   # near bottom (for capsule tap)
+TOP_Y=$((H * 10 / 100))      # near top (for dismiss swipe)
+
+reset_gfx() {
+    dumpsys gfxinfo "$PKG" reset > /dev/null 2>&1
+    sleep 0.5
+}
+
+dump_gfx() {
+    local name="$1"
+    dumpsys gfxinfo "$PKG" > "${OUT}/gfxinfo-${name}.txt"
+    echo "Saved: ${OUT}/gfxinfo-${name}.txt"
+    grep -E "Total frames|Janky frames|50th|90th|95th|99th" "${OUT}/gfxinfo-${name}.txt"
+}
+
+wait_settle() {
+    sleep 1
+}
+
+# --- Scenarios ---
+
+test_scroll() {
+    echo "=== SCROLL TEST (song list, 10 swipes) ==="
+    reset_gfx
+    sleep 1
+    # 10 identical swipes, 300ms each, 500ms pause between
+    i=0
+    while [ $i -lt 10 ]; do
+        input swipe "$CX" "$SCROLL_Y1" "$CX" "$SCROLL_Y2" 300
+        sleep 0.5
+        i=$((i + 1))
+    done
+    # scroll back
+    i=0
+    while [ $i -lt 10 ]; do
+        input swipe "$CX" "$SCROLL_Y2" "$CX" "$SCROLL_Y1" 300
+        sleep 0.5
+        i=$((i + 1))
+    done
+    wait_settle
+    dump_gfx "scroll"
+}
+
+test_nowplaying() {
+    echo "=== NOW PLAYING OPEN TEST ==="
+    reset_gfx
+    sleep 1
+    # Tap capsule at bottom center to open Now Playing
+    input tap "$CX" "$BOTTOM_Y"
+    sleep 2
+    wait_settle
+    dump_gfx "nowplaying"
+}
+
+test_swipe() {
+    echo "=== COVER ART SWIPE TEST (6 swipes) ==="
+    # Assumes Now Playing is already open
+    reset_gfx
+    sleep 1
+    # 6 horizontal swipes on cover art
+    i=0
+    while [ $i -lt 3 ]; do
+        input swipe "$SWIPE_X1" "$CY" "$SWIPE_X2" "$CY" 250
+        sleep 1
+        i=$((i + 1))
+    done
+    i=0
+    while [ $i -lt 3 ]; do
+        input swipe "$SWIPE_X2" "$CY" "$SWIPE_X1" "$CY" 250
+        sleep 1
+        i=$((i + 1))
+    done
+    wait_settle
+    dump_gfx "swipe"
+}
+
+test_dismiss() {
+    echo "=== DISMISS NOW PLAYING TEST ==="
+    # Assumes Now Playing is open
+    reset_gfx
+    sleep 1
+    input keyevent BACK
+    sleep 2
+    wait_settle
+    dump_gfx "dismiss"
+}
+
+# --- Run ---
+
+case "$SCENARIO" in
+    scroll)
+        test_scroll
+        ;;
+    nowplaying)
+        test_nowplaying
+        ;;
+    swipe)
+        test_swipe
+        ;;
+    dismiss)
+        test_dismiss
+        ;;
+    all)
+        echo "Running all scenarios..."
+        echo ""
+        test_scroll
+        echo ""
+        test_nowplaying
+        echo ""
+        test_swipe
+        echo ""
+        test_dismiss
+        echo ""
+        echo "=== ALL DONE ==="
+        ;;
+    *)
+        echo "Unknown scenario: $SCENARIO"
+        echo "Usage: $0 [scroll|nowplaying|swipe|dismiss|all] [output_dir]"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Adds a lightweight playback progress flow for position, duration, and buffered position updates. The periodic playback loop now updates only progress instead of rebuilding the full playback state every 500ms, so Browse/UI state is not invalidated by playback ticks.

Structural playback state still syncs on player events and on cache, preference, or network changes to keep queue, quality, cache status, repeat/shuffle, and runtime info current.
