### PR TITLE
fix: stabilize Now Playing artwork pager and transitions

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -401,7 +401,17 @@ private fun NowPlayingOverlayHost(
     onReprobeEndpoints: () -> Unit,
     onForceEndpoint: (Long) -> Unit,
 ) {
-    val track = playbackState.currentItem ?: return
+    val activeTrack = playbackState.currentItem
+        ?: playbackState.queue.getOrNull(playbackState.currentIndex)
+    var stableTrack by remember { mutableStateOf(activeTrack) }
+    LaunchedEffect(visible, activeTrack) {
+        if (activeTrack != null) {
+            stableTrack = activeTrack
+        } else if (!visible) {
+            stableTrack = null
+        }
+    }
+    val track = activeTrack ?: stableTrack ?: return
     val availableArtistIds = remember(libraryIndexes) {
         libraryIndexes
             ?.let { indexes ->

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -401,13 +401,14 @@ private fun NowPlayingOverlayHost(
     onReprobeEndpoints: () -> Unit,
     onForceEndpoint: (Long) -> Unit,
 ) {
+    val hasValidQueuedTrack = playbackState.currentIndex in playbackState.queue.indices
     val activeTrack = playbackState.currentItem
         ?: playbackState.queue.getOrNull(playbackState.currentIndex)
     var stableTrack by remember { mutableStateOf(activeTrack) }
-    LaunchedEffect(visible, activeTrack) {
+    LaunchedEffect(visible, activeTrack, hasValidQueuedTrack) {
         if (activeTrack != null) {
             stableTrack = activeTrack
-        } else if (!visible) {
+        } else if (!visible || !hasValidQueuedTrack) {
             stableTrack = null
         }
     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
@@ -1,6 +1,5 @@
 package org.hdhmc.saki.presentation.library
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -15,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -41,12 +41,15 @@ fun ArtworkCard(
     cornerRadiusDp: Int = 24,
     requestSizePx: Int? = null,
 ) {
-    val fallbackBrush = Brush.linearGradient(
+    val colorScheme = MaterialTheme.colorScheme
+    val fallbackColors = remember(colorScheme.primary, colorScheme.tertiary) {
         listOf(
-            MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
-            MaterialTheme.colorScheme.tertiary.copy(alpha = 0.7f),
-        ),
-    )
+            colorScheme.primary.copy(alpha = 0.9f),
+            colorScheme.tertiary.copy(alpha = 0.7f),
+        )
+    }
+    val containerColor = colorScheme.surfaceVariant.copy(alpha = 0.34f)
+    val fallbackIconTint = colorScheme.onPrimary
     val context = LocalContext.current
     val imageModel = remember(model, requestSizePx, context) {
         if (model != null && requestSizePx != null) {
@@ -62,7 +65,7 @@ fun ArtworkCard(
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(cornerRadiusDp.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f),
+        color = containerColor,
     ) {
         if (imageModel != null) {
             AsyncImage(
@@ -75,15 +78,20 @@ fun ArtworkCard(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(fallbackBrush)
-                    .clip(RoundedCornerShape(cornerRadiusDp.dp)),
+                    .clip(RoundedCornerShape(cornerRadiusDp.dp))
+                    .drawWithCache {
+                        val fallbackBrush = Brush.linearGradient(fallbackColors)
+                        onDrawBehind {
+                            drawRect(fallbackBrush)
+                        }
+                    },
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     imageVector = Icons.Rounded.LibraryMusic,
                     contentDescription = null,
                     modifier = Modifier.size(42.dp),
-                    tint = MaterialTheme.colorScheme.onPrimary,
+                    tint = fallbackIconTint,
                 )
             }
         }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
@@ -1,5 +1,6 @@
 package org.hdhmc.saki.presentation.library
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -14,7 +15,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -41,15 +41,12 @@ fun ArtworkCard(
     cornerRadiusDp: Int = 24,
     requestSizePx: Int? = null,
 ) {
-    val colorScheme = MaterialTheme.colorScheme
-    val fallbackColors = remember(colorScheme.primary, colorScheme.tertiary) {
+    val fallbackBrush = Brush.linearGradient(
         listOf(
-            colorScheme.primary.copy(alpha = 0.9f),
-            colorScheme.tertiary.copy(alpha = 0.7f),
-        )
-    }
-    val containerColor = colorScheme.surfaceVariant.copy(alpha = 0.34f)
-    val fallbackIconTint = colorScheme.onPrimary
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+            MaterialTheme.colorScheme.tertiary.copy(alpha = 0.7f),
+        ),
+    )
     val context = LocalContext.current
     val imageModel = remember(model, requestSizePx, context) {
         if (model != null && requestSizePx != null) {
@@ -65,7 +62,7 @@ fun ArtworkCard(
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(cornerRadiusDp.dp),
-        color = containerColor,
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f),
     ) {
         if (imageModel != null) {
             AsyncImage(
@@ -78,20 +75,15 @@ fun ArtworkCard(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .clip(RoundedCornerShape(cornerRadiusDp.dp))
-                    .drawWithCache {
-                        val fallbackBrush = Brush.linearGradient(fallbackColors)
-                        onDrawBehind {
-                            drawRect(fallbackBrush)
-                        }
-                    },
+                    .background(fallbackBrush)
+                    .clip(RoundedCornerShape(cornerRadiusDp.dp)),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     imageVector = Icons.Rounded.LibraryMusic,
                     contentDescription = null,
                     modifier = Modifier.size(42.dp),
-                    tint = fallbackIconTint,
+                    tint = MaterialTheme.colorScheme.onPrimary,
                 )
             }
         }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
@@ -449,11 +450,18 @@ fun NowPlayingOverlay(
         )
         // Sync pager when track changes externally (button skip, queue tap)
         var lastTrackId by remember { mutableStateOf(track.songId) }
-        // Guard: suppress pager-driven skips during programmatic scroll
-        var suppressPagerSkip by remember { mutableStateOf(false) }
-        var programmaticPagerTargetPage by remember { mutableStateOf<Int?>(null) }
+        // A settled page is a playback intent only after a real user drag.
+        // Programmatic sync keeps the pager animated but never drives playback.
+        var programmaticPagerSync by remember { mutableStateOf(false) }
+        var userPagerDragSeen by remember { mutableStateOf(false) }
         var currentArtworkKeyPage by remember { mutableStateOf(playbackState.currentIndex.coerceAtLeast(0)) }
         var pinnedCurrentArtworkPage by remember { mutableStateOf<Int?>(null) }
+        val isArtworkPagerDragged by artworkPagerState.interactionSource.collectIsDraggedAsState()
+        LaunchedEffect(isArtworkPagerDragged, programmaticPagerSync) {
+            if (isArtworkPagerDragged && !programmaticPagerSync) {
+                userPagerDragSeen = true
+            }
+        }
         // Stabilize artwork during deferred queue expansion:
         // keep the current artwork keyed to the visible page until the pager can
         // move after any page-count change caused by queue item insertion. If
@@ -462,8 +470,6 @@ fun NowPlayingOverlay(
         LaunchedEffect(targetPage, track.songId, playbackState.queue) {
             if (track.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
                 val startPage = artworkPagerState.currentPage
-                suppressPagerSkip = true
-                programmaticPagerTargetPage = targetPage
                 pinnedCurrentArtworkPage = startPage
                 currentArtworkKeyPage = startPage
                 try {
@@ -476,28 +482,42 @@ fun NowPlayingOverlay(
                         artworkPagerState.currentPage != startPage ||
                         artworkPagerState.settledPage != startPage
                     if (!userMovedPager && artworkPagerState.currentPage != targetPage) {
-                        artworkPagerState.scrollToPage(targetPage)
+                        programmaticPagerSync = true
+                        userPagerDragSeen = false
+                        try {
+                            artworkPagerState.scrollToPage(targetPage)
+                            withFrameNanos { }
+                        } finally {
+                            programmaticPagerSync = false
+                        }
                     }
                     currentArtworkKeyPage = if (userMovedPager) targetPage else artworkPagerState.currentPage
                     pinnedCurrentArtworkPage = null
                     withFrameNanos { }
                 } finally {
                     pinnedCurrentArtworkPage = null
-                    programmaticPagerTargetPage = null
-                    suppressPagerSkip = false
                 }
             } else {
                 stableQueue = playbackState.queue
                 currentArtworkKeyPage = targetPage
             }
             if (track.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
-                suppressPagerSkip = true
-                programmaticPagerTargetPage = targetPage
+                programmaticPagerSync = true
+                userPagerDragSeen = false
                 try {
-                    artworkPagerState.animateScrollToPage(targetPage)
+                    artworkPagerState.animateScrollToPage(
+                        page = targetPage,
+                        animationSpec = tween(durationMillis = PROGRAMMATIC_ARTWORK_SCROLL_MS),
+                    )
+                    if (
+                        artworkPagerState.currentPage != targetPage ||
+                        artworkPagerState.settledPage != targetPage
+                    ) {
+                        artworkPagerState.scrollToPage(targetPage)
+                    }
+                    withFrameNanos { }
                 } finally {
-                    programmaticPagerTargetPage = null
-                    suppressPagerSkip = false
+                    programmaticPagerSync = false
                 }
             }
             lastTrackId = track.songId
@@ -509,7 +529,8 @@ fun NowPlayingOverlay(
             snapshotFlow { artworkPagerState.settledPage }
                 .distinctUntilChanged()
                 .collect { page ->
-                    if (suppressPagerSkip && page == programmaticPagerTargetPage) return@collect
+                    if (programmaticPagerSync || !userPagerDragSeen) return@collect
+                    userPagerDragSeen = false
                     if (page != currentPlaybackIndex && page in 0 until currentQueueSize) {
                         onSkipToQueueItem(page)
                     }
@@ -1418,6 +1439,7 @@ private data class ArtworkPresentation(
 }
 
 private const val ARTWORK_PRESENTATION_CACHE_ENTRIES = 64
+private const val PROGRAMMATIC_ARTWORK_SCROLL_MS = 220
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
 
 @Composable

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -451,15 +451,19 @@ fun NowPlayingOverlay(
         // Sync pager when track changes externally (button skip, queue tap)
         var lastTrackId by remember { mutableStateOf(track.songId) }
         // A settled page is a playback intent only after a real user drag.
-        // Programmatic sync keeps the pager animated but never drives playback.
+        // Programmatic sync keeps pager state aligned but never drives playback.
+        // A separate cover transition handles button/notification skip animation.
         var programmaticPagerSync by remember { mutableStateOf(false) }
         var userPagerDragSeen by remember { mutableStateOf(false) }
         var currentArtworkKeyPage by remember { mutableStateOf(playbackState.currentIndex.coerceAtLeast(0)) }
         var pinnedCurrentArtworkPage by remember { mutableStateOf<Int?>(null) }
+        var artworkTransitionSequence by remember { mutableStateOf(0) }
+        var programmaticArtworkTransition by remember { mutableStateOf<ProgrammaticArtworkTransition?>(null) }
         val isArtworkPagerDragged by artworkPagerState.interactionSource.collectIsDraggedAsState()
         LaunchedEffect(isArtworkPagerDragged, programmaticPagerSync) {
             if (isArtworkPagerDragged && !programmaticPagerSync) {
                 userPagerDragSeen = true
+                programmaticArtworkTransition = null
             }
         }
         // Stabilize artwork during deferred queue expansion:
@@ -502,19 +506,21 @@ fun NowPlayingOverlay(
                 currentArtworkKeyPage = targetPage
             }
             if (track.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
+                val startPage = artworkPagerState.currentPage
+                val direction = (targetPage - startPage).coerceIn(-1, 1)
+                if (direction != 0) {
+                    artworkTransitionSequence += 1
+                    programmaticArtworkTransition = ProgrammaticArtworkTransition(
+                        sequence = artworkTransitionSequence,
+                        from = stableQueue.getOrNull(startPage),
+                        to = playbackState.queue.getOrNull(targetPage) ?: track,
+                        direction = direction,
+                    )
+                }
                 programmaticPagerSync = true
                 userPagerDragSeen = false
                 try {
-                    artworkPagerState.animateScrollToPage(
-                        page = targetPage,
-                        animationSpec = tween(durationMillis = PROGRAMMATIC_ARTWORK_SCROLL_MS),
-                    )
-                    if (
-                        artworkPagerState.currentPage != targetPage ||
-                        artworkPagerState.settledPage != targetPage
-                    ) {
-                        artworkPagerState.scrollToPage(targetPage)
-                    }
+                    artworkPagerState.scrollToPage(targetPage)
                     withFrameNanos { }
                 } finally {
                     programmaticPagerSync = false
@@ -674,6 +680,20 @@ fun NowPlayingOverlay(
                                     cornerRadiusDp = 34,
                                 )
                             }
+                        }
+                        programmaticArtworkTransition?.let { transition ->
+                            ProgrammaticArtworkTransitionOverlay(
+                                transition = transition,
+                                serversById = serversById,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .clip(RoundedCornerShape(34.dp)),
+                                onFinished = {
+                                    if (programmaticArtworkTransition?.sequence == transition.sequence) {
+                                        programmaticArtworkTransition = null
+                                    }
+                                },
+                            )
                         }
                         // Lyrics overlay on artwork
                         androidx.compose.animation.AnimatedVisibility(
@@ -1438,8 +1458,79 @@ private data class ArtworkPresentation(
         get() = dominantColor != null || accentColor != null
 }
 
+private data class ProgrammaticArtworkTransition(
+    val sequence: Int,
+    val from: PlaybackQueueItem?,
+    val to: PlaybackQueueItem,
+    val direction: Int,
+)
+
+@Composable
+private fun ProgrammaticArtworkTransitionOverlay(
+    transition: ProgrammaticArtworkTransition,
+    serversById: Map<Long, ServerConfig>,
+    modifier: Modifier = Modifier,
+    onFinished: () -> Unit,
+) {
+    val latestOnFinished by rememberUpdatedState(onFinished)
+    var started by remember(transition.sequence) { mutableStateOf(false) }
+    val progress by animateFloatAsState(
+        targetValue = if (started) 1f else 0f,
+        animationSpec = tween(durationMillis = PROGRAMMATIC_ARTWORK_TRANSITION_MS),
+        label = "ProgrammaticArtworkTransitionProgress",
+        finishedListener = { latestOnFinished() },
+    )
+
+    LaunchedEffect(transition.sequence) {
+        started = true
+    }
+
+    BoxWithConstraints(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        val widthPx = with(LocalDensity.current) { maxWidth.toPx() }
+        val direction = transition.direction.coerceIn(-1, 1)
+        transition.from?.let { item ->
+            ProgrammaticArtworkTransitionCard(
+                item = item,
+                serversById = serversById,
+                modifier = Modifier.graphicsLayer {
+                    alpha = 1f - progress * 0.18f
+                    translationX = -direction * progress * widthPx
+                },
+            )
+        }
+        ProgrammaticArtworkTransitionCard(
+            item = transition.to,
+            serversById = serversById,
+            modifier = Modifier.graphicsLayer {
+                alpha = 0.82f + progress * 0.18f
+                translationX = direction * (1f - progress) * widthPx
+            },
+        )
+    }
+}
+
+@Composable
+private fun ProgrammaticArtworkTransitionCard(
+    item: PlaybackQueueItem,
+    serversById: Map<Long, ServerConfig>,
+    modifier: Modifier = Modifier,
+) {
+    ArtworkCard(
+        model = item.queueArtworkModel(item.serverId?.let { serversById[it] }),
+        contentDescription = item.title,
+        modifier = modifier
+            .aspectRatio(1f)
+            .fillMaxHeight()
+            .clip(RoundedCornerShape(34.dp)),
+        cornerRadiusDp = 34,
+    )
+}
+
 private const val ARTWORK_PRESENTATION_CACHE_ENTRIES = 64
-private const val PROGRAMMATIC_ARTWORK_SCROLL_MS = 220
+private const val PROGRAMMATIC_ARTWORK_TRANSITION_MS = 360
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
 
 @Composable

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
@@ -1341,22 +1340,6 @@ private fun PlaybackQueueItem.artworkIdentityKey(): String {
     ).joinToString("|")
 }
 
-private fun PlaybackQueueItem.artworkVisualIdentityKey(): String {
-    val hasArtwork =
-        !coverArtPath.isNullOrBlank() ||
-        !coverArtId.isNullOrBlank() ||
-        !artworkUri.isNullOrBlank()
-    if (!hasArtwork) {
-        return "fallback:${serverId?.toString().orEmpty()}"
-    }
-    return listOf(
-        serverId?.toString().orEmpty(),
-        coverArtId.orEmpty(),
-        coverArtPath.orEmpty(),
-        artworkUri.orEmpty(),
-    ).joinToString("|")
-}
-
 private data class NowPlayingVisualSnapshot(
     val queue: List<PlaybackQueueItem>,
     val currentIndex: Int,
@@ -1459,84 +1442,51 @@ private fun NowPlayingArtworkPagerHost(
     var lastTrackId by remember { mutableStateOf(currentTrack.songId) }
     // Programmatic sync keeps pager state aligned but never drives playback.
     // Any other settled page change comes from the user's pager gesture.
-    // A separate cover transition handles button/notification skip animation.
     var programmaticPagerSync by remember { mutableStateOf(false) }
-    var currentArtworkKeyPage by remember { mutableStateOf(targetPage) }
-    var pinnedCurrentArtworkPage by remember { mutableStateOf<Int?>(null) }
-    var artworkTransitionSequence by remember { mutableStateOf(0) }
-    var programmaticArtworkTransition by remember { mutableStateOf<ProgrammaticArtworkTransition?>(null) }
-    var programmaticArtworkTransitionCoversPager by remember { mutableStateOf(false) }
-    val isArtworkPagerDragged by artworkPagerState.interactionSource.collectIsDraggedAsState()
-
-    LaunchedEffect(isArtworkPagerDragged, programmaticPagerSync) {
-        if (isArtworkPagerDragged && !programmaticPagerSync) {
-            programmaticArtworkTransition = null
-            programmaticArtworkTransitionCoversPager = false
-        }
-    }
+    var lastProgrammaticSettledPage by remember { mutableStateOf<Int?>(null) }
 
     // Stabilize artwork during deferred queue expansion:
-    // keep the current artwork keyed to the visible page until the pager can
-    // move after any page-count change caused by queue item insertion. If
-    // the user starts swiping during this handoff, do not force it back.
+    // update the page count first, then move after any insertion before the
+    // current item. Track changes use the pager's own animation so there is
+    // only one artwork render path and no overlay handoff frame.
     LaunchedEffect(targetPage, currentTrack.songId, queueIdentity) {
         if (currentTrack.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
             val startPage = artworkPagerState.currentPage
-            pinnedCurrentArtworkPage = startPage
-            currentArtworkKeyPage = startPage
-            try {
-                stableQueue = queue
+            stableQueue = queue
+            withFrameNanos { }
+            while (artworkPagerState.isScrollInProgress) {
                 withFrameNanos { }
-                while (artworkPagerState.isScrollInProgress) {
-                    withFrameNanos { }
-                }
-                val userMovedPager =
-                    artworkPagerState.currentPage != startPage ||
+            }
+            val userMovedPager =
+                artworkPagerState.currentPage != startPage ||
                     artworkPagerState.settledPage != startPage
-                if (!userMovedPager && artworkPagerState.currentPage != targetPage) {
-                    programmaticPagerSync = true
-                    try {
-                        artworkPagerState.scrollToPage(targetPage)
-                        withFrameNanos { }
-                    } finally {
-                        programmaticPagerSync = false
-                    }
+            if (!userMovedPager && artworkPagerState.currentPage != targetPage) {
+                programmaticPagerSync = true
+                try {
+                    artworkPagerState.scrollToPage(targetPage)
+                    withFrameNanos { }
+                } finally {
+                    lastProgrammaticSettledPage = artworkPagerState.settledPage
+                    programmaticPagerSync = false
                 }
-                currentArtworkKeyPage = if (userMovedPager) targetPage else artworkPagerState.currentPage
-                pinnedCurrentArtworkPage = null
-                withFrameNanos { }
-            } finally {
-                pinnedCurrentArtworkPage = null
             }
         } else {
             stableQueue = queue
-            currentArtworkKeyPage = targetPage
         }
         if (currentTrack.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
-            val startPage = artworkPagerState.currentPage
-            val direction = (targetPage - startPage).coerceIn(-1, 1)
-            val fromItem = programmaticArtworkTransition?.to ?: stableQueue.getOrNull(startPage)
-            val toItem = queue.getOrNull(targetPage) ?: currentTrack
-            val artworkVisualChanged =
-                fromItem?.artworkVisualIdentityKey() != toItem.artworkVisualIdentityKey()
-            if (direction != 0 && artworkVisualChanged) {
-                artworkTransitionSequence += 1
-                programmaticArtworkTransition = ProgrammaticArtworkTransition(
-                    sequence = artworkTransitionSequence,
-                    from = fromItem,
-                    to = toItem,
-                    direction = direction,
-                )
-                programmaticArtworkTransitionCoversPager = true
-            } else {
-                programmaticArtworkTransition = null
-                programmaticArtworkTransitionCoversPager = false
-            }
+            stableQueue = queue
+            withFrameNanos { }
             programmaticPagerSync = true
             try {
-                artworkPagerState.scrollToPage(targetPage)
-                withFrameNanos { }
+                artworkPagerState.animateScrollToPage(
+                    page = targetPage,
+                    animationSpec = tween(
+                        durationMillis = PROGRAMMATIC_ARTWORK_SCROLL_MS,
+                        easing = FastOutSlowInEasing,
+                    ),
+                )
             } finally {
+                lastProgrammaticSettledPage = artworkPagerState.settledPage
                 programmaticPagerSync = false
             }
         }
@@ -1546,10 +1496,17 @@ private fun NowPlayingArtworkPagerHost(
     val currentPlaybackIndex by rememberUpdatedState(currentIndex)
     val currentQueueSize by rememberUpdatedState(queue.size)
     LaunchedEffect(artworkPagerState) {
-        snapshotFlow { artworkPagerState.settledPage }
+        snapshotFlow { artworkPagerState.settledPage to programmaticPagerSync }
             .distinctUntilChanged()
-            .collect { page ->
-                if (programmaticPagerSync) return@collect
+            .collect { (page, isProgrammatic) ->
+                if (isProgrammatic) {
+                    lastProgrammaticSettledPage = page
+                    return@collect
+                }
+                if (lastProgrammaticSettledPage == page) {
+                    lastProgrammaticSettledPage = null
+                    return@collect
+                }
                 if (page != currentPlaybackIndex && page in 0 until currentQueueSize) {
                     latestOnUserSelectQueueItem(page)
                 }
@@ -1564,139 +1521,20 @@ private fun NowPlayingArtworkPagerHost(
             state = artworkPagerState,
             modifier = Modifier
                 .fillMaxSize()
-                .graphicsLayer {
-                    alpha = if (programmaticArtworkTransitionCoversPager) 0f else 1f
-                }
                 .clip(RoundedCornerShape(34.dp)),
             pageSpacing = 16.dp,
             beyondViewportPageCount = 1,
             key = { page ->
-                if (page == currentArtworkKeyPage) {
-                    "current-${currentTrack.artworkVisualIdentityKey()}"
-                } else {
-                    stableQueue.getOrNull(page)?.let { "queue-${it.artworkVisualIdentityKey()}-$page" }
-                        ?: "empty-$page"
-                }
+                stableQueue.getOrNull(page)?.let { "queue-${it.mediaId}-$page" } ?: "empty-$page"
             },
         ) { page ->
-            val queueItem = stableQueue.getOrNull(page)
-            val artworkItem = if (page == pinnedCurrentArtworkPage) {
-                currentTrack
-            } else {
-                queueItem
-            }
             NowPlayingArtworkFrame(
-                item = artworkItem,
+                item = stableQueue.getOrNull(page),
                 serversById = serversById,
                 modifier = Modifier.fillMaxSize(),
                 onClick = { latestOnArtworkClick() },
             )
         }
-        programmaticArtworkTransition?.let { transition ->
-            ProgrammaticArtworkTransitionOverlay(
-                transition = transition,
-                serversById = serversById,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(RoundedCornerShape(34.dp)),
-                onRevealPager = {
-                    if (programmaticArtworkTransition?.sequence == transition.sequence) {
-                        programmaticArtworkTransitionCoversPager = false
-                    }
-                },
-                onFinished = {
-                    if (programmaticArtworkTransition?.sequence == transition.sequence) {
-                        programmaticArtworkTransition = null
-                        programmaticArtworkTransitionCoversPager = false
-                    }
-                },
-            )
-        }
-    }
-}
-
-private data class ProgrammaticArtworkTransition(
-    val sequence: Int,
-    val from: PlaybackQueueItem?,
-    val to: PlaybackQueueItem,
-    val direction: Int,
-)
-
-@Composable
-private fun ProgrammaticArtworkTransitionOverlay(
-    transition: ProgrammaticArtworkTransition,
-    serversById: Map<Long, ServerConfig>,
-    modifier: Modifier = Modifier,
-    onRevealPager: () -> Unit,
-    onFinished: () -> Unit,
-) {
-    val latestOnRevealPager by rememberUpdatedState(onRevealPager)
-    val latestOnFinished by rememberUpdatedState(onFinished)
-    var started by remember(transition.sequence) { mutableStateOf(false) }
-    var slideFinished by remember(transition.sequence) { mutableStateOf(false) }
-    var fadeStarted by remember(transition.sequence) { mutableStateOf(false) }
-    val progress by animateFloatAsState(
-        targetValue = if (started) 1f else 0f,
-        animationSpec = tween(
-            durationMillis = PROGRAMMATIC_ARTWORK_TRANSITION_MS,
-            easing = FastOutSlowInEasing,
-        ),
-        label = "ProgrammaticArtworkTransitionProgress",
-        finishedListener = { if (it == 1f) slideFinished = true },
-    )
-    val overlayAlpha by animateFloatAsState(
-        targetValue = if (fadeStarted) 0f else 1f,
-        animationSpec = tween(
-            durationMillis = PROGRAMMATIC_ARTWORK_FADE_OUT_MS,
-            easing = FastOutSlowInEasing,
-        ),
-        label = "ProgrammaticArtworkTransitionAlpha",
-        finishedListener = { if (it == 0f) latestOnFinished() },
-    )
-
-    LaunchedEffect(transition.sequence) {
-        started = true
-    }
-    LaunchedEffect(transition.sequence, slideFinished) {
-        if (slideFinished) {
-            withFrameNanos { }
-            latestOnRevealPager()
-            delay(PROGRAMMATIC_ARTWORK_REVEAL_HOLD_MS.toLong())
-            fadeStarted = true
-        }
-    }
-
-    BoxWithConstraints(
-        modifier = modifier.graphicsLayer { alpha = overlayAlpha },
-        contentAlignment = Alignment.Center,
-    ) {
-        val density = LocalDensity.current
-        val cardTravelPx = with(density) {
-            minOf(maxWidth.toPx(), maxHeight.toPx()) + PROGRAMMATIC_ARTWORK_PAGE_SPACING_DP.dp.toPx()
-        }
-        val direction = transition.direction.coerceIn(-1, 1)
-        transition.from?.let { item ->
-            NowPlayingArtworkFrame(
-                item = item,
-                serversById = serversById,
-                modifier = Modifier.fillMaxSize(),
-                contentModifier = Modifier.graphicsLayer {
-                    scaleX = 1f - progress * 0.03f
-                    scaleY = 1f - progress * 0.03f
-                    translationX = -direction * progress * cardTravelPx
-                },
-            )
-        }
-        NowPlayingArtworkFrame(
-            item = transition.to,
-            serversById = serversById,
-            modifier = Modifier.fillMaxSize(),
-            contentModifier = Modifier.graphicsLayer {
-                scaleX = 0.97f + progress * 0.03f
-                scaleY = 0.97f + progress * 0.03f
-                translationX = direction * (1f - progress) * cardTravelPx
-            },
-        )
     }
 }
 
@@ -1737,10 +1575,7 @@ private fun NowPlayingArtworkFrame(
 
 private const val ARTWORK_PRESENTATION_CACHE_ENTRIES = 64
 private const val ARTWORK_COLOR_TRANSITION_MS = 520
-private const val PROGRAMMATIC_ARTWORK_TRANSITION_MS = 420
-private const val PROGRAMMATIC_ARTWORK_REVEAL_HOLD_MS = 80
-private const val PROGRAMMATIC_ARTWORK_FADE_OUT_MS = 120
-private const val PROGRAMMATIC_ARTWORK_PAGE_SPACING_DP = 16
+private const val PROGRAMMATIC_ARTWORK_SCROLL_MS = 520
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
 
 @Composable

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -1341,6 +1341,22 @@ private fun PlaybackQueueItem.artworkIdentityKey(): String {
     ).joinToString("|")
 }
 
+private fun PlaybackQueueItem.artworkVisualIdentityKey(): String {
+    val hasArtwork =
+        !coverArtPath.isNullOrBlank() ||
+        !coverArtId.isNullOrBlank() ||
+        !artworkUri.isNullOrBlank()
+    if (!hasArtwork) {
+        return "fallback:${serverId?.toString().orEmpty()}"
+    }
+    return listOf(
+        serverId?.toString().orEmpty(),
+        coverArtId.orEmpty(),
+        coverArtPath.orEmpty(),
+        artworkUri.orEmpty(),
+    ).joinToString("|")
+}
+
 private data class NowPlayingVisualSnapshot(
     val queue: List<PlaybackQueueItem>,
     val currentIndex: Int,
@@ -1501,7 +1517,9 @@ private fun NowPlayingArtworkPagerHost(
             val direction = (targetPage - startPage).coerceIn(-1, 1)
             val fromItem = programmaticArtworkTransition?.to ?: stableQueue.getOrNull(startPage)
             val toItem = queue.getOrNull(targetPage) ?: currentTrack
-            if (direction != 0) {
+            val artworkVisualChanged =
+                fromItem?.artworkVisualIdentityKey() != toItem.artworkVisualIdentityKey()
+            if (direction != 0 && artworkVisualChanged) {
                 artworkTransitionSequence += 1
                 programmaticArtworkTransition = ProgrammaticArtworkTransition(
                     sequence = artworkTransitionSequence,
@@ -1510,6 +1528,9 @@ private fun NowPlayingArtworkPagerHost(
                     direction = direction,
                 )
                 programmaticArtworkTransitionCoversPager = true
+            } else {
+                programmaticArtworkTransition = null
+                programmaticArtworkTransitionCoversPager = false
             }
             programmaticPagerSync = true
             try {
@@ -1551,9 +1572,9 @@ private fun NowPlayingArtworkPagerHost(
             beyondViewportPageCount = 1,
             key = { page ->
                 if (page == currentArtworkKeyPage) {
-                    "current-${currentTrack.mediaId}"
+                    "current-${currentTrack.artworkVisualIdentityKey()}"
                 } else {
-                    stableQueue.getOrNull(page)?.let { "queue-${it.mediaId}-$page" }
+                    stableQueue.getOrNull(page)?.let { "queue-${it.artworkVisualIdentityKey()}-$page" }
                         ?: "empty-$page"
                 }
             },
@@ -1691,8 +1712,13 @@ private fun NowPlayingArtworkFrame(
         modifier = modifier,
         contentAlignment = Alignment.Center,
     ) {
+        val clickInteractionSource = remember { MutableInteractionSource() }
         val clickModifier = if (onClick != null) {
-            Modifier.clickable(onClick = onClick)
+            Modifier.clickable(
+                interactionSource = clickInteractionSource,
+                indication = null,
+                onClick = onClick,
+            )
         } else {
             Modifier
         }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -339,14 +339,21 @@ fun NowPlayingOverlay(
     var showMenu by remember(track.songId) { mutableStateOf(false) }
     var showLyrics by remember { mutableStateOf(false) }
     var showEndpointStatus by remember { mutableStateOf(false) }
+    val visualSnapshot = rememberNowPlayingVisualSnapshot(
+        queue = playbackState.queue,
+        currentIndex = playbackState.currentIndex,
+        currentTrack = track,
+    )
+    val visualCurrentServer = visualSnapshot.currentTrack.serverId?.let { serversById[it] }
+        ?: currentServer.takeIf { it?.id == visualSnapshot.currentTrack.serverId }
 
     // Preload adjacent artwork into Coil and palette caches.
     val context = LocalContext.current
-    val queue = playbackState.queue
-    val currentIdx = playbackState.currentIndex
+    val queue = visualSnapshot.queue
+    val currentIdx = visualSnapshot.currentIndex
     val prevSongId = queue.getOrNull(currentIdx - 1)?.songId
     val nextSongId = queue.getOrNull(currentIdx + 1)?.songId
-    LaunchedEffect(visible, track.songId, prevSongId, nextSongId, currentServer) {
+    LaunchedEffect(visible, visualSnapshot.currentTrack.songId, prevSongId, nextSongId, visualCurrentServer) {
         if (!visible) return@LaunchedEffect
         val adjacentIndices = listOfNotNull(
             if (currentIdx > 0) currentIdx - 1 else null,
@@ -402,7 +409,7 @@ fun NowPlayingOverlay(
         ),
     ) {
         val artwork = rememberArtworkPresentation(
-            fallbackModel = track.queueArtworkModel(currentServer),
+            fallbackModel = visualSnapshot.currentTrack.queueArtworkModel(visualCurrentServer),
         )
         val colorScheme = MaterialTheme.colorScheme
         val targetDominant = artwork.dominantColor ?: colorScheme.primary
@@ -558,9 +565,9 @@ fun NowPlayingOverlay(
                         contentAlignment = Alignment.Center,
                     ) {
                         NowPlayingArtworkPagerHost(
-                            queue = playbackState.queue,
-                            currentIndex = playbackState.currentIndex,
-                            currentTrack = track,
+                            queue = visualSnapshot.queue,
+                            currentIndex = visualSnapshot.currentIndex,
+                            currentTrack = visualSnapshot.currentTrack,
                             serversById = serversById,
                             modifier = Modifier.fillMaxSize(),
                             onArtworkClick = {
@@ -1332,6 +1339,76 @@ private fun PlaybackQueueItem.artworkIdentityKey(): String {
         coverArtPath.orEmpty(),
         artworkUri.orEmpty(),
     ).joinToString("|")
+}
+
+private data class NowPlayingVisualSnapshot(
+    val queue: List<PlaybackQueueItem>,
+    val currentIndex: Int,
+    val currentTrack: PlaybackQueueItem,
+)
+
+@Composable
+private fun rememberNowPlayingVisualSnapshot(
+    queue: List<PlaybackQueueItem>,
+    currentIndex: Int,
+    currentTrack: PlaybackQueueItem,
+): NowPlayingVisualSnapshot {
+    val candidate = remember(queue, currentIndex, currentTrack) {
+        buildNowPlayingVisualSnapshot(queue, currentIndex, currentTrack)
+    }
+    var snapshot by remember {
+        mutableStateOf(candidate ?: fallbackNowPlayingVisualSnapshot(queue, currentIndex, currentTrack))
+    }
+
+    LaunchedEffect(candidate) {
+        if (candidate != null) {
+            snapshot = candidate
+        }
+    }
+
+    return candidate ?: snapshot
+}
+
+private fun buildNowPlayingVisualSnapshot(
+    queue: List<PlaybackQueueItem>,
+    currentIndex: Int,
+    currentTrack: PlaybackQueueItem,
+): NowPlayingVisualSnapshot? {
+    if (currentIndex !in queue.indices) return null
+    if (queue[currentIndex].songId != currentTrack.songId) return null
+    return NowPlayingVisualSnapshot(
+        queue = queue.withVisualCurrentItem(currentIndex, currentTrack),
+        currentIndex = currentIndex,
+        currentTrack = currentTrack,
+    )
+}
+
+private fun fallbackNowPlayingVisualSnapshot(
+    queue: List<PlaybackQueueItem>,
+    currentIndex: Int,
+    currentTrack: PlaybackQueueItem,
+): NowPlayingVisualSnapshot {
+    val safeIndex = currentIndex.takeIf { it in queue.indices }
+    if (safeIndex != null && queue[safeIndex].songId == currentTrack.songId) {
+        return NowPlayingVisualSnapshot(
+            queue = queue.withVisualCurrentItem(safeIndex, currentTrack),
+            currentIndex = safeIndex,
+            currentTrack = currentTrack,
+        )
+    }
+    return NowPlayingVisualSnapshot(
+        queue = listOf(currentTrack),
+        currentIndex = 0,
+        currentTrack = currentTrack,
+    )
+}
+
+private fun List<PlaybackQueueItem>.withVisualCurrentItem(
+    currentIndex: Int,
+    currentTrack: PlaybackQueueItem,
+): List<PlaybackQueueItem> {
+    if (getOrNull(currentIndex) == currentTrack) return this
+    return toMutableList().also { it[currentIndex] = currentTrack }
 }
 
 private data class ArtworkPresentation(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -468,11 +468,10 @@ fun NowPlayingOverlay(
         )
         // Sync pager when track changes externally (button skip, queue tap)
         var lastTrackId by remember { mutableStateOf(track.songId) }
-        // A settled page is a playback intent only after a real user drag.
         // Programmatic sync keeps pager state aligned but never drives playback.
+        // Any other settled page change comes from the user's pager gesture.
         // A separate cover transition handles button/notification skip animation.
         var programmaticPagerSync by remember { mutableStateOf(false) }
-        var userPagerDragSeen by remember { mutableStateOf(false) }
         var currentArtworkKeyPage by remember { mutableStateOf(playbackState.currentIndex.coerceAtLeast(0)) }
         var pinnedCurrentArtworkPage by remember { mutableStateOf<Int?>(null) }
         var artworkTransitionSequence by remember { mutableStateOf(0) }
@@ -480,7 +479,6 @@ fun NowPlayingOverlay(
         val isArtworkPagerDragged by artworkPagerState.interactionSource.collectIsDraggedAsState()
         LaunchedEffect(isArtworkPagerDragged, programmaticPagerSync) {
             if (isArtworkPagerDragged && !programmaticPagerSync) {
-                userPagerDragSeen = true
                 programmaticArtworkTransition = null
             }
         }
@@ -505,7 +503,6 @@ fun NowPlayingOverlay(
                         artworkPagerState.settledPage != startPage
                     if (!userMovedPager && artworkPagerState.currentPage != targetPage) {
                         programmaticPagerSync = true
-                        userPagerDragSeen = false
                         try {
                             artworkPagerState.scrollToPage(targetPage)
                             withFrameNanos { }
@@ -526,17 +523,18 @@ fun NowPlayingOverlay(
             if (track.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
                 val startPage = artworkPagerState.currentPage
                 val direction = (targetPage - startPage).coerceIn(-1, 1)
+                val fromItem = programmaticArtworkTransition?.to ?: stableQueue.getOrNull(startPage)
+                val toItem = playbackState.queue.getOrNull(targetPage) ?: track
                 if (direction != 0) {
                     artworkTransitionSequence += 1
                     programmaticArtworkTransition = ProgrammaticArtworkTransition(
                         sequence = artworkTransitionSequence,
-                        from = stableQueue.getOrNull(startPage),
-                        to = playbackState.queue.getOrNull(targetPage) ?: track,
+                        from = fromItem,
+                        to = toItem,
                         direction = direction,
                     )
                 }
                 programmaticPagerSync = true
-                userPagerDragSeen = false
                 try {
                     artworkPagerState.scrollToPage(targetPage)
                     withFrameNanos { }
@@ -553,8 +551,7 @@ fun NowPlayingOverlay(
             snapshotFlow { artworkPagerState.settledPage }
                 .distinctUntilChanged()
                 .collect { page ->
-                    if (programmaticPagerSync || !userPagerDragSeen) return@collect
-                    userPagerDragSeen = false
+                    if (programmaticPagerSync) return@collect
                     if (page != currentPlaybackIndex && page in 0 until currentQueueSize) {
                         onSkipToQueueItem(page)
                     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -4,6 +4,8 @@ import android.util.LruCache
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
@@ -403,8 +405,24 @@ fun NowPlayingOverlay(
             fallbackModel = track.queueArtworkModel(currentServer),
         )
         val colorScheme = MaterialTheme.colorScheme
-        val dominant = artwork.dominantColor ?: colorScheme.primary
-        val accent = artwork.accentColor ?: colorScheme.tertiary
+        val targetDominant = artwork.dominantColor ?: colorScheme.primary
+        val targetAccent = artwork.accentColor ?: colorScheme.tertiary
+        val dominant by animateColorAsState(
+            targetValue = targetDominant,
+            animationSpec = tween(
+                durationMillis = ARTWORK_COLOR_TRANSITION_MS,
+                easing = FastOutSlowInEasing,
+            ),
+            label = "NowPlayingDominantColor",
+        )
+        val accent by animateColorAsState(
+            targetValue = targetAccent,
+            animationSpec = tween(
+                durationMillis = ARTWORK_COLOR_TRANSITION_MS,
+                easing = FastOutSlowInEasing,
+            ),
+            label = "NowPlayingAccentColor",
+        )
         val background = remember(dominant, accent, colorScheme) {
             Brush.verticalGradient(
                 listOf(
@@ -644,6 +662,9 @@ fun NowPlayingOverlay(
                             state = artworkPagerState,
                             modifier = Modifier
                                 .fillMaxSize()
+                                .graphicsLayer {
+                                    alpha = if (programmaticArtworkTransition == null) 1f else 0f
+                                }
                                 .clip(RoundedCornerShape(34.dp)),
                             pageSpacing = 16.dp,
                             beyondViewportPageCount = 1,
@@ -1476,7 +1497,10 @@ private fun ProgrammaticArtworkTransitionOverlay(
     var started by remember(transition.sequence) { mutableStateOf(false) }
     val progress by animateFloatAsState(
         targetValue = if (started) 1f else 0f,
-        animationSpec = tween(durationMillis = PROGRAMMATIC_ARTWORK_TRANSITION_MS),
+        animationSpec = tween(
+            durationMillis = PROGRAMMATIC_ARTWORK_TRANSITION_MS,
+            easing = FastOutSlowInEasing,
+        ),
         label = "ProgrammaticArtworkTransitionProgress",
         finishedListener = { latestOnFinished() },
     )
@@ -1489,15 +1513,20 @@ private fun ProgrammaticArtworkTransitionOverlay(
         modifier = modifier,
         contentAlignment = Alignment.Center,
     ) {
-        val widthPx = with(LocalDensity.current) { maxWidth.toPx() }
+        val density = LocalDensity.current
+        val cardTravelPx = with(density) {
+            minOf(maxWidth.toPx(), maxHeight.toPx()) + PROGRAMMATIC_ARTWORK_PAGE_SPACING_DP.dp.toPx()
+        }
         val direction = transition.direction.coerceIn(-1, 1)
         transition.from?.let { item ->
             ProgrammaticArtworkTransitionCard(
                 item = item,
                 serversById = serversById,
                 modifier = Modifier.graphicsLayer {
-                    alpha = 1f - progress * 0.18f
-                    translationX = -direction * progress * widthPx
+                    alpha = 1f
+                    scaleX = 1f - progress * 0.03f
+                    scaleY = 1f - progress * 0.03f
+                    translationX = -direction * progress * cardTravelPx
                 },
             )
         }
@@ -1505,8 +1534,10 @@ private fun ProgrammaticArtworkTransitionOverlay(
             item = transition.to,
             serversById = serversById,
             modifier = Modifier.graphicsLayer {
-                alpha = 0.82f + progress * 0.18f
-                translationX = direction * (1f - progress) * widthPx
+                alpha = 1f
+                scaleX = 0.97f + progress * 0.03f
+                scaleY = 0.97f + progress * 0.03f
+                translationX = direction * (1f - progress) * cardTravelPx
             },
         )
     }
@@ -1530,7 +1561,9 @@ private fun ProgrammaticArtworkTransitionCard(
 }
 
 private const val ARTWORK_PRESENTATION_CACHE_ENTRIES = 64
-private const val PROGRAMMATIC_ARTWORK_TRANSITION_MS = 360
+private const val ARTWORK_COLOR_TRANSITION_MS = 520
+private const val PROGRAMMATIC_ARTWORK_TRANSITION_MS = 420
+private const val PROGRAMMATIC_ARTWORK_PAGE_SPACING_DP = 16
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
 
 @Composable
@@ -1538,12 +1571,11 @@ private fun rememberArtworkPresentation(
     fallbackModel: Any?,
 ): ArtworkPresentation {
     val context = LocalContext.current.applicationContext
-    return produceState(
-        initialValue = ArtworkPresentation(),
-        key1 = fallbackModel,
-    ) {
-        value = loadArtworkPresentation(context, fallbackModel)
-    }.value
+    var presentation by remember { mutableStateOf(ArtworkPresentation()) }
+    LaunchedEffect(fallbackModel) {
+        presentation = loadArtworkPresentation(context, fallbackModel)
+    }
+    return presentation
 }
 
 private suspend fun loadArtworkPresentation(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -476,10 +476,12 @@ fun NowPlayingOverlay(
         var pinnedCurrentArtworkPage by remember { mutableStateOf<Int?>(null) }
         var artworkTransitionSequence by remember { mutableStateOf(0) }
         var programmaticArtworkTransition by remember { mutableStateOf<ProgrammaticArtworkTransition?>(null) }
+        var programmaticArtworkTransitionCoversPager by remember { mutableStateOf(false) }
         val isArtworkPagerDragged by artworkPagerState.interactionSource.collectIsDraggedAsState()
         LaunchedEffect(isArtworkPagerDragged, programmaticPagerSync) {
             if (isArtworkPagerDragged && !programmaticPagerSync) {
                 programmaticArtworkTransition = null
+                programmaticArtworkTransitionCoversPager = false
             }
         }
         // Stabilize artwork during deferred queue expansion:
@@ -533,6 +535,7 @@ fun NowPlayingOverlay(
                         to = toItem,
                         direction = direction,
                     )
+                    programmaticArtworkTransitionCoversPager = true
                 }
                 programmaticPagerSync = true
                 try {
@@ -660,7 +663,7 @@ fun NowPlayingOverlay(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .graphicsLayer {
-                                    alpha = if (programmaticArtworkTransition == null) 1f else 0f
+                                    alpha = if (programmaticArtworkTransitionCoversPager) 0f else 1f
                                 }
                                 .clip(RoundedCornerShape(34.dp)),
                             pageSpacing = 16.dp,
@@ -674,30 +677,21 @@ fun NowPlayingOverlay(
                                 }
                             },
                         ) { page ->
-                            Box(
-                                modifier = Modifier.fillMaxSize(),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                val queueItem = stableQueue.getOrNull(page)
-                                val artworkItem = if (page == pinnedCurrentArtworkPage) {
-                                    track
-                                } else {
-                                    queueItem
-                                }
-                                ArtworkCard(
-                                    model = artworkItem?.queueArtworkModel(artworkItem.serverId?.let { serversById[it] }),
-                                    contentDescription = artworkItem?.title,
-                                    modifier = Modifier
-                                        .aspectRatio(1f)
-                                        .fillMaxHeight()
-                                        .clip(RoundedCornerShape(34.dp))
-                                        .clickable {
-                                            if (showLyrics) showLyrics = false
-                                            else if (hasLyrics) showLyrics = true
-                                        },
-                                    cornerRadiusDp = 34,
-                                )
+                            val queueItem = stableQueue.getOrNull(page)
+                            val artworkItem = if (page == pinnedCurrentArtworkPage) {
+                                track
+                            } else {
+                                queueItem
                             }
+                            NowPlayingArtworkFrame(
+                                item = artworkItem,
+                                serversById = serversById,
+                                modifier = Modifier.fillMaxSize(),
+                                onClick = {
+                                    if (showLyrics) showLyrics = false
+                                    else if (hasLyrics) showLyrics = true
+                                },
+                            )
                         }
                         programmaticArtworkTransition?.let { transition ->
                             ProgrammaticArtworkTransitionOverlay(
@@ -706,9 +700,15 @@ fun NowPlayingOverlay(
                                 modifier = Modifier
                                     .fillMaxSize()
                                     .clip(RoundedCornerShape(34.dp)),
+                                onRevealPager = {
+                                    if (programmaticArtworkTransition?.sequence == transition.sequence) {
+                                        programmaticArtworkTransitionCoversPager = false
+                                    }
+                                },
                                 onFinished = {
                                     if (programmaticArtworkTransition?.sequence == transition.sequence) {
                                         programmaticArtworkTransition = null
+                                        programmaticArtworkTransitionCoversPager = false
                                     }
                                 },
                             )
@@ -1488,10 +1488,14 @@ private fun ProgrammaticArtworkTransitionOverlay(
     transition: ProgrammaticArtworkTransition,
     serversById: Map<Long, ServerConfig>,
     modifier: Modifier = Modifier,
+    onRevealPager: () -> Unit,
     onFinished: () -> Unit,
 ) {
+    val latestOnRevealPager by rememberUpdatedState(onRevealPager)
     val latestOnFinished by rememberUpdatedState(onFinished)
     var started by remember(transition.sequence) { mutableStateOf(false) }
+    var slideFinished by remember(transition.sequence) { mutableStateOf(false) }
+    var fadeStarted by remember(transition.sequence) { mutableStateOf(false) }
     val progress by animateFloatAsState(
         targetValue = if (started) 1f else 0f,
         animationSpec = tween(
@@ -1499,15 +1503,32 @@ private fun ProgrammaticArtworkTransitionOverlay(
             easing = FastOutSlowInEasing,
         ),
         label = "ProgrammaticArtworkTransitionProgress",
-        finishedListener = { latestOnFinished() },
+        finishedListener = { if (it == 1f) slideFinished = true },
+    )
+    val overlayAlpha by animateFloatAsState(
+        targetValue = if (fadeStarted) 0f else 1f,
+        animationSpec = tween(
+            durationMillis = PROGRAMMATIC_ARTWORK_FADE_OUT_MS,
+            easing = FastOutSlowInEasing,
+        ),
+        label = "ProgrammaticArtworkTransitionAlpha",
+        finishedListener = { if (it == 0f) latestOnFinished() },
     )
 
     LaunchedEffect(transition.sequence) {
         started = true
     }
+    LaunchedEffect(transition.sequence, slideFinished) {
+        if (slideFinished) {
+            withFrameNanos { }
+            latestOnRevealPager()
+            delay(PROGRAMMATIC_ARTWORK_REVEAL_HOLD_MS.toLong())
+            fadeStarted = true
+        }
+    }
 
     BoxWithConstraints(
-        modifier = modifier,
+        modifier = modifier.graphicsLayer { alpha = overlayAlpha },
         contentAlignment = Alignment.Center,
     ) {
         val density = LocalDensity.current
@@ -1516,22 +1537,22 @@ private fun ProgrammaticArtworkTransitionOverlay(
         }
         val direction = transition.direction.coerceIn(-1, 1)
         transition.from?.let { item ->
-            ProgrammaticArtworkTransitionCard(
+            NowPlayingArtworkFrame(
                 item = item,
                 serversById = serversById,
-                modifier = Modifier.graphicsLayer {
-                    alpha = 1f
+                modifier = Modifier.fillMaxSize(),
+                contentModifier = Modifier.graphicsLayer {
                     scaleX = 1f - progress * 0.03f
                     scaleY = 1f - progress * 0.03f
                     translationX = -direction * progress * cardTravelPx
                 },
             )
         }
-        ProgrammaticArtworkTransitionCard(
+        NowPlayingArtworkFrame(
             item = transition.to,
             serversById = serversById,
-            modifier = Modifier.graphicsLayer {
-                alpha = 1f
+            modifier = Modifier.fillMaxSize(),
+            contentModifier = Modifier.graphicsLayer {
                 scaleX = 0.97f + progress * 0.03f
                 scaleY = 0.97f + progress * 0.03f
                 translationX = direction * (1f - progress) * cardTravelPx
@@ -1541,25 +1562,40 @@ private fun ProgrammaticArtworkTransitionOverlay(
 }
 
 @Composable
-private fun ProgrammaticArtworkTransitionCard(
-    item: PlaybackQueueItem,
+private fun NowPlayingArtworkFrame(
+    item: PlaybackQueueItem?,
     serversById: Map<Long, ServerConfig>,
     modifier: Modifier = Modifier,
+    contentModifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
 ) {
-    ArtworkCard(
-        model = item.queueArtworkModel(item.serverId?.let { serversById[it] }),
-        contentDescription = item.title,
-        modifier = modifier
-            .aspectRatio(1f)
-            .fillMaxHeight()
-            .clip(RoundedCornerShape(34.dp)),
-        cornerRadiusDp = 34,
-    )
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        val clickModifier = if (onClick != null) {
+            Modifier.clickable(onClick = onClick)
+        } else {
+            Modifier
+        }
+        ArtworkCard(
+            model = item?.queueArtworkModel(item.serverId?.let { serversById[it] }),
+            contentDescription = item?.title,
+            modifier = contentModifier
+                .aspectRatio(1f)
+                .fillMaxHeight()
+                .clip(RoundedCornerShape(34.dp))
+                .then(clickModifier),
+            cornerRadiusDp = 34,
+        )
+    }
 }
 
 private const val ARTWORK_PRESENTATION_CACHE_ENTRIES = 64
 private const val ARTWORK_COLOR_TRANSITION_MS = 520
 private const val PROGRAMMATIC_ARTWORK_TRANSITION_MS = 420
+private const val PROGRAMMATIC_ARTWORK_REVEAL_HOLD_MS = 80
+private const val PROGRAMMATIC_ARTWORK_FADE_OUT_MS = 120
 private const val PROGRAMMATIC_ARTWORK_PAGE_SPACING_DP = 16
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -460,107 +460,6 @@ fun NowPlayingOverlay(
             }
         }
 
-        // Artwork pager state synced with playback queue
-        var stableQueue by remember { mutableStateOf(playbackState.queue) }
-        val artworkPagerState = rememberPagerState(
-            initialPage = playbackState.currentIndex.coerceAtLeast(0),
-            pageCount = { stableQueue.size.coerceAtLeast(1) },
-        )
-        // Sync pager when track changes externally (button skip, queue tap)
-        var lastTrackId by remember { mutableStateOf(track.songId) }
-        // Programmatic sync keeps pager state aligned but never drives playback.
-        // Any other settled page change comes from the user's pager gesture.
-        // A separate cover transition handles button/notification skip animation.
-        var programmaticPagerSync by remember { mutableStateOf(false) }
-        var currentArtworkKeyPage by remember { mutableStateOf(playbackState.currentIndex.coerceAtLeast(0)) }
-        var pinnedCurrentArtworkPage by remember { mutableStateOf<Int?>(null) }
-        var artworkTransitionSequence by remember { mutableStateOf(0) }
-        var programmaticArtworkTransition by remember { mutableStateOf<ProgrammaticArtworkTransition?>(null) }
-        var programmaticArtworkTransitionCoversPager by remember { mutableStateOf(false) }
-        val isArtworkPagerDragged by artworkPagerState.interactionSource.collectIsDraggedAsState()
-        LaunchedEffect(isArtworkPagerDragged, programmaticPagerSync) {
-            if (isArtworkPagerDragged && !programmaticPagerSync) {
-                programmaticArtworkTransition = null
-                programmaticArtworkTransitionCoversPager = false
-            }
-        }
-        // Stabilize artwork during deferred queue expansion:
-        // keep the current artwork keyed to the visible page until the pager can
-        // move after any page-count change caused by queue item insertion. If
-        // the user starts swiping during this handoff, do not force it back.
-        val targetPage = playbackState.currentIndex.coerceAtLeast(0)
-        LaunchedEffect(targetPage, track.songId, playbackState.queue) {
-            if (track.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
-                val startPage = artworkPagerState.currentPage
-                pinnedCurrentArtworkPage = startPage
-                currentArtworkKeyPage = startPage
-                try {
-                    stableQueue = playbackState.queue
-                    withFrameNanos { }
-                    while (artworkPagerState.isScrollInProgress) {
-                        withFrameNanos { }
-                    }
-                    val userMovedPager =
-                        artworkPagerState.currentPage != startPage ||
-                        artworkPagerState.settledPage != startPage
-                    if (!userMovedPager && artworkPagerState.currentPage != targetPage) {
-                        programmaticPagerSync = true
-                        try {
-                            artworkPagerState.scrollToPage(targetPage)
-                            withFrameNanos { }
-                        } finally {
-                            programmaticPagerSync = false
-                        }
-                    }
-                    currentArtworkKeyPage = if (userMovedPager) targetPage else artworkPagerState.currentPage
-                    pinnedCurrentArtworkPage = null
-                    withFrameNanos { }
-                } finally {
-                    pinnedCurrentArtworkPage = null
-                }
-            } else {
-                stableQueue = playbackState.queue
-                currentArtworkKeyPage = targetPage
-            }
-            if (track.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
-                val startPage = artworkPagerState.currentPage
-                val direction = (targetPage - startPage).coerceIn(-1, 1)
-                val fromItem = programmaticArtworkTransition?.to ?: stableQueue.getOrNull(startPage)
-                val toItem = playbackState.queue.getOrNull(targetPage) ?: track
-                if (direction != 0) {
-                    artworkTransitionSequence += 1
-                    programmaticArtworkTransition = ProgrammaticArtworkTransition(
-                        sequence = artworkTransitionSequence,
-                        from = fromItem,
-                        to = toItem,
-                        direction = direction,
-                    )
-                    programmaticArtworkTransitionCoversPager = true
-                }
-                programmaticPagerSync = true
-                try {
-                    artworkPagerState.scrollToPage(targetPage)
-                    withFrameNanos { }
-                } finally {
-                    programmaticPagerSync = false
-                }
-            }
-            lastTrackId = track.songId
-        }
-        // When user swipes pager, trigger skip
-        val currentPlaybackIndex by rememberUpdatedState(playbackState.currentIndex)
-        val currentQueueSize by rememberUpdatedState(playbackState.queue.size)
-        LaunchedEffect(artworkPagerState) {
-            snapshotFlow { artworkPagerState.settledPage }
-                .distinctUntilChanged()
-                .collect { page ->
-                    if (programmaticPagerSync) return@collect
-                    if (page != currentPlaybackIndex && page in 0 until currentQueueSize) {
-                        onSkipToQueueItem(page)
-                    }
-                }
-        }
-
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
@@ -658,61 +557,18 @@ fun NowPlayingOverlay(
                             .fillMaxWidth(),
                         contentAlignment = Alignment.Center,
                     ) {
-                        HorizontalPager(
-                            state = artworkPagerState,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .graphicsLayer {
-                                    alpha = if (programmaticArtworkTransitionCoversPager) 0f else 1f
-                                }
-                                .clip(RoundedCornerShape(34.dp)),
-                            pageSpacing = 16.dp,
-                            beyondViewportPageCount = 1,
-                            key = { page ->
-                                if (page == currentArtworkKeyPage) {
-                                    "current-${track.mediaId}"
-                                } else {
-                                    stableQueue.getOrNull(page)?.let { "queue-${it.mediaId}-$page" }
-                                        ?: "empty-$page"
-                                }
+                        NowPlayingArtworkPagerHost(
+                            queue = playbackState.queue,
+                            currentIndex = playbackState.currentIndex,
+                            currentTrack = track,
+                            serversById = serversById,
+                            modifier = Modifier.fillMaxSize(),
+                            onArtworkClick = {
+                                if (showLyrics) showLyrics = false
+                                else if (hasLyrics) showLyrics = true
                             },
-                        ) { page ->
-                            val queueItem = stableQueue.getOrNull(page)
-                            val artworkItem = if (page == pinnedCurrentArtworkPage) {
-                                track
-                            } else {
-                                queueItem
-                            }
-                            NowPlayingArtworkFrame(
-                                item = artworkItem,
-                                serversById = serversById,
-                                modifier = Modifier.fillMaxSize(),
-                                onClick = {
-                                    if (showLyrics) showLyrics = false
-                                    else if (hasLyrics) showLyrics = true
-                                },
-                            )
-                        }
-                        programmaticArtworkTransition?.let { transition ->
-                            ProgrammaticArtworkTransitionOverlay(
-                                transition = transition,
-                                serversById = serversById,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .clip(RoundedCornerShape(34.dp)),
-                                onRevealPager = {
-                                    if (programmaticArtworkTransition?.sequence == transition.sequence) {
-                                        programmaticArtworkTransitionCoversPager = false
-                                    }
-                                },
-                                onFinished = {
-                                    if (programmaticArtworkTransition?.sequence == transition.sequence) {
-                                        programmaticArtworkTransition = null
-                                        programmaticArtworkTransitionCoversPager = false
-                                    }
-                                },
-                            )
-                        }
+                            onUserSelectQueueItem = onSkipToQueueItem,
+                        )
                         // Lyrics overlay on artwork
                         androidx.compose.animation.AnimatedVisibility(
                             visible = showLyrics && hasLyrics,
@@ -1468,12 +1324,197 @@ private fun PlaybackQueueItem.queueArtworkModel(server: ServerConfig?): Any? {
     }
 }
 
+private fun PlaybackQueueItem.artworkIdentityKey(): String {
+    return listOf(
+        mediaId,
+        serverId?.toString().orEmpty(),
+        coverArtId.orEmpty(),
+        coverArtPath.orEmpty(),
+        artworkUri.orEmpty(),
+    ).joinToString("|")
+}
+
 private data class ArtworkPresentation(
     val dominantColor: Color? = null,
     val accentColor: Color? = null,
 ) {
     val hasColors: Boolean
         get() = dominantColor != null || accentColor != null
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun NowPlayingArtworkPagerHost(
+    queue: List<PlaybackQueueItem>,
+    currentIndex: Int,
+    currentTrack: PlaybackQueueItem,
+    serversById: Map<Long, ServerConfig>,
+    modifier: Modifier = Modifier,
+    onArtworkClick: () -> Unit,
+    onUserSelectQueueItem: (Int) -> Unit,
+) {
+    val targetPage = currentIndex.coerceAtLeast(0)
+    val queueIdentity = remember(queue) { queue.map { it.artworkIdentityKey() } }
+    val latestOnArtworkClick by rememberUpdatedState(onArtworkClick)
+    val latestOnUserSelectQueueItem by rememberUpdatedState(onUserSelectQueueItem)
+    var stableQueue by remember { mutableStateOf(queue) }
+    val artworkPagerState = rememberPagerState(
+        initialPage = targetPage,
+        pageCount = { stableQueue.size.coerceAtLeast(1) },
+    )
+
+    var lastTrackId by remember { mutableStateOf(currentTrack.songId) }
+    // Programmatic sync keeps pager state aligned but never drives playback.
+    // Any other settled page change comes from the user's pager gesture.
+    // A separate cover transition handles button/notification skip animation.
+    var programmaticPagerSync by remember { mutableStateOf(false) }
+    var currentArtworkKeyPage by remember { mutableStateOf(targetPage) }
+    var pinnedCurrentArtworkPage by remember { mutableStateOf<Int?>(null) }
+    var artworkTransitionSequence by remember { mutableStateOf(0) }
+    var programmaticArtworkTransition by remember { mutableStateOf<ProgrammaticArtworkTransition?>(null) }
+    var programmaticArtworkTransitionCoversPager by remember { mutableStateOf(false) }
+    val isArtworkPagerDragged by artworkPagerState.interactionSource.collectIsDraggedAsState()
+
+    LaunchedEffect(isArtworkPagerDragged, programmaticPagerSync) {
+        if (isArtworkPagerDragged && !programmaticPagerSync) {
+            programmaticArtworkTransition = null
+            programmaticArtworkTransitionCoversPager = false
+        }
+    }
+
+    // Stabilize artwork during deferred queue expansion:
+    // keep the current artwork keyed to the visible page until the pager can
+    // move after any page-count change caused by queue item insertion. If
+    // the user starts swiping during this handoff, do not force it back.
+    LaunchedEffect(targetPage, currentTrack.songId, queueIdentity) {
+        if (currentTrack.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
+            val startPage = artworkPagerState.currentPage
+            pinnedCurrentArtworkPage = startPage
+            currentArtworkKeyPage = startPage
+            try {
+                stableQueue = queue
+                withFrameNanos { }
+                while (artworkPagerState.isScrollInProgress) {
+                    withFrameNanos { }
+                }
+                val userMovedPager =
+                    artworkPagerState.currentPage != startPage ||
+                    artworkPagerState.settledPage != startPage
+                if (!userMovedPager && artworkPagerState.currentPage != targetPage) {
+                    programmaticPagerSync = true
+                    try {
+                        artworkPagerState.scrollToPage(targetPage)
+                        withFrameNanos { }
+                    } finally {
+                        programmaticPagerSync = false
+                    }
+                }
+                currentArtworkKeyPage = if (userMovedPager) targetPage else artworkPagerState.currentPage
+                pinnedCurrentArtworkPage = null
+                withFrameNanos { }
+            } finally {
+                pinnedCurrentArtworkPage = null
+            }
+        } else {
+            stableQueue = queue
+            currentArtworkKeyPage = targetPage
+        }
+        if (currentTrack.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
+            val startPage = artworkPagerState.currentPage
+            val direction = (targetPage - startPage).coerceIn(-1, 1)
+            val fromItem = programmaticArtworkTransition?.to ?: stableQueue.getOrNull(startPage)
+            val toItem = queue.getOrNull(targetPage) ?: currentTrack
+            if (direction != 0) {
+                artworkTransitionSequence += 1
+                programmaticArtworkTransition = ProgrammaticArtworkTransition(
+                    sequence = artworkTransitionSequence,
+                    from = fromItem,
+                    to = toItem,
+                    direction = direction,
+                )
+                programmaticArtworkTransitionCoversPager = true
+            }
+            programmaticPagerSync = true
+            try {
+                artworkPagerState.scrollToPage(targetPage)
+                withFrameNanos { }
+            } finally {
+                programmaticPagerSync = false
+            }
+        }
+        lastTrackId = currentTrack.songId
+    }
+
+    val currentPlaybackIndex by rememberUpdatedState(currentIndex)
+    val currentQueueSize by rememberUpdatedState(queue.size)
+    LaunchedEffect(artworkPagerState) {
+        snapshotFlow { artworkPagerState.settledPage }
+            .distinctUntilChanged()
+            .collect { page ->
+                if (programmaticPagerSync) return@collect
+                if (page != currentPlaybackIndex && page in 0 until currentQueueSize) {
+                    latestOnUserSelectQueueItem(page)
+                }
+            }
+    }
+
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        HorizontalPager(
+            state = artworkPagerState,
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    alpha = if (programmaticArtworkTransitionCoversPager) 0f else 1f
+                }
+                .clip(RoundedCornerShape(34.dp)),
+            pageSpacing = 16.dp,
+            beyondViewportPageCount = 1,
+            key = { page ->
+                if (page == currentArtworkKeyPage) {
+                    "current-${currentTrack.mediaId}"
+                } else {
+                    stableQueue.getOrNull(page)?.let { "queue-${it.mediaId}-$page" }
+                        ?: "empty-$page"
+                }
+            },
+        ) { page ->
+            val queueItem = stableQueue.getOrNull(page)
+            val artworkItem = if (page == pinnedCurrentArtworkPage) {
+                currentTrack
+            } else {
+                queueItem
+            }
+            NowPlayingArtworkFrame(
+                item = artworkItem,
+                serversById = serversById,
+                modifier = Modifier.fillMaxSize(),
+                onClick = { latestOnArtworkClick() },
+            )
+        }
+        programmaticArtworkTransition?.let { transition ->
+            ProgrammaticArtworkTransitionOverlay(
+                transition = transition,
+                serversById = serversById,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(34.dp)),
+                onRevealPager = {
+                    if (programmaticArtworkTransition?.sequence == transition.sequence) {
+                        programmaticArtworkTransitionCoversPager = false
+                    }
+                },
+                onFinished = {
+                    if (programmaticArtworkTransition?.sequence == transition.sequence) {
+                        programmaticArtworkTransition = null
+                        programmaticArtworkTransitionCoversPager = false
+                    }
+                },
+            )
+        }
+    }
 }
 
 private data class ProgrammaticArtworkTransition(


### PR DESCRIPTION
## Summary

This PR fixes the Now Playing artwork pager state and transition pipeline. The original #206 symptom was that programmatic skips could be interpreted as pager gestures and trigger an extra queue skip, but the investigation exposed a broader issue: artwork, background palette, and pager state were all reacting directly to transient playback frames during track changes.

The branch now makes playback state the single source of truth while keeping the artwork UI visually stable through Media3 transition frames.

## Changes

- Fix programmatic skip handling so button/notification next/previous updates the artwork pager without triggering `onSkipToQueueItem` again.
- Move Now Playing artwork pager logic into a dedicated `NowPlayingArtworkPagerHost`.
- Add a stable visual snapshot for artwork/background state, so transient `currentItem`, queue, or index mismatch frames do not blank or reset the cover.
- Keep `NowPlayingOverlayHost` mounted through brief `currentItem == null` transition frames instead of tearing down the overlay.
- Replace the separate artwork overlay transition with the `HorizontalPager`'s own animated scroll path.
  - This removes the handoff frame that caused subtle cover displacement.
  - It also fixes the default-artwork flicker seen on tracks without cover art.
- Animate Now Playing background palette changes so large cover color changes do not hard-cut the backdrop.
- Keep adjacent artwork preloading aligned with the stable visual queue.

## Behavior Notes

- User swiping the artwork pager still drives queue selection.
- Programmatic pager movement from playback changes is guarded and does not drive playback.
- Tracks with real cover art and tracks using the default fallback artwork now use the same final pager render path.
- The current fix intentionally prioritizes correctness and visual stability; further animation tuning can be done in a follow-up PR.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Manual testing confirmed the default-artwork flicker is resolved and covered tracks no longer show the subtle handoff displacement.

Build was not run locally; CI should verify compilation.

Closes #206.
