### PR TITLE
fix: improve Now Playing artwork motion

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
-import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -1642,6 +1641,11 @@ private fun NowPlayingArtworkPagerHost(
                         page = visualTargetPage,
                         motionState = motionState,
                         distancePages = distancePages,
+                        velocityBoostPagesPerSecond = if (visualTargetPage > artworkPagerState.currentArtworkPosition()) {
+                            ARTWORK_BUTTON_SKIP_INITIAL_VELOCITY_PAGES
+                        } else {
+                            -ARTWORK_BUTTON_SKIP_INITIAL_VELOCITY_PAGES
+                        },
                     )
                 }
             } finally {
@@ -1797,8 +1801,10 @@ private const val ARTWORK_PRESENTATION_CACHE_ENTRIES = 64
 private const val ARTWORK_PREWARM_RADIUS_PAGES = 3
 private const val ARTWORK_BACKGROUND_SETTLE_MS = 180
 private const val ARTWORK_BUTTON_SKIP_CONFIRM_TIMEOUT_MS = 900L
+private const val ARTWORK_BUTTON_SKIP_INITIAL_VELOCITY_PAGES = 3.5f
 private const val PROGRAMMATIC_ARTWORK_SPRING_BASE_STIFFNESS = 140f
 private const val PROGRAMMATIC_ARTWORK_SPRING_DISTANCE_STIFFNESS = 60f
+private const val PROGRAMMATIC_ARTWORK_MAX_INITIAL_VELOCITY_PAGES = 8f
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
 
 private object FixedArtworkMotionDurationScale : MotionDurationScale {
@@ -1810,16 +1816,27 @@ private suspend fun PagerState.animateArtworkMotionToPage(
     page: Int,
     motionState: NowPlayingArtworkMotionState,
     distancePages: Float,
+    velocityBoostPagesPerSecond: Float = 0f,
 ) {
     val safePageCount = pageCount.coerceAtLeast(1)
     val targetPage = page.coerceIn(0, safePageCount - 1)
     val targetPosition = targetPage.toFloat()
-    val startPosition = (currentPage + currentPageOffsetFraction)
-        .coerceIn(0f, (safePageCount - 1).toFloat())
-    val startVelocity = motionState.velocity
+    val startPosition = currentArtworkPosition(safePageCount)
+    val inheritedVelocity = motionState.velocity
         .takeUnless { it.isNaN() || it.isInfinite() }
         ?: 0f
+    val boostedVelocity = when {
+        velocityBoostPagesPerSecond == 0f -> inheritedVelocity
+        inheritedVelocity * velocityBoostPagesPerSecond > 0f -> inheritedVelocity + velocityBoostPagesPerSecond
+        else -> velocityBoostPagesPerSecond
+    }
+    val startVelocity = boostedVelocity
+        .coerceIn(
+            -PROGRAMMATIC_ARTWORK_MAX_INITIAL_VELOCITY_PAGES,
+            PROGRAMMATIC_ARTWORK_MAX_INITIAL_VELOCITY_PAGES,
+        )
     val pagerState = this
+    var previousPosition = startPosition
 
     scroll {
         updateTargetPage(targetPage)
@@ -1830,26 +1847,38 @@ private suspend fun PagerState.animateArtworkMotionToPage(
             animationSpec = programmaticArtworkScrollSpec(distancePages),
         ) { value, velocity ->
             val position = value.coerceIn(0f, (safePageCount - 1).toFloat())
-            motionState.position = position
+            val deltaPx = (position - previousPosition) * pagerState.artworkPageDistancePx()
+            if (deltaPx != 0f) {
+                scrollBy(deltaPx)
+            }
+            previousPosition = position
+            motionState.position = pagerState.currentArtworkPosition(safePageCount)
             motionState.velocity = velocity
-            pagerState.updateArtworkPagerPosition(this, position, safePageCount)
+        }
+        val remainingPx = (targetPosition - pagerState.currentArtworkPosition(safePageCount)) *
+            pagerState.artworkPageDistancePx()
+        if (abs(remainingPx) > 0.5f) {
+            scrollBy(remainingPx)
         }
         motionState.position = targetPosition
         motionState.velocity = 0f
-        pagerState.updateArtworkPagerPosition(this, targetPosition, safePageCount)
     }
 }
 
-private fun PagerState.updateArtworkPagerPosition(
-    scrollScope: ScrollScope,
-    absolutePosition: Float,
-    pageCount: Int,
-) {
-    val page = absolutePosition.roundToInt().coerceIn(0, pageCount - 1)
-    val offset = (absolutePosition - page).coerceIn(-0.5f, 0.5f)
-    with(scrollScope) {
-        updateCurrentPage(page, offset)
+private fun PagerState.currentArtworkPosition(pageCount: Int = this.pageCount.coerceAtLeast(1)): Float {
+    return (currentPage + currentPageOffsetFraction)
+        .coerceIn(0f, (pageCount - 1).coerceAtLeast(0).toFloat())
+}
+
+private fun PagerState.artworkPageDistancePx(): Float {
+    val visiblePages = layoutInfo.visiblePagesInfo.sortedBy { page -> page.index }
+    val adjacentPages = visiblePages
+        .zipWithNext()
+        .firstOrNull { (first, second) -> second.index == first.index + 1 }
+    val measuredDistance = adjacentPages?.let { (first, second) ->
+        abs(second.offset - first.offset).toFloat()
     }
+    return (measuredDistance ?: layoutInfo.pageSize.toFloat()).coerceAtLeast(1f)
 }
 
 private fun programmaticArtworkScrollSpec(distancePages: Float) = spring<Float>(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -1405,8 +1405,13 @@ private fun List<PlaybackQueueItem>.withVisualCurrentItem(
     currentIndex: Int,
     currentTrack: PlaybackQueueItem,
 ): List<PlaybackQueueItem> {
-    if (getOrNull(currentIndex) == currentTrack) return this
+    val currentItem = getOrNull(currentIndex) ?: return this
+    if (currentItem == currentTrack || currentItem.hasSameArtworkVisual(currentTrack)) return this
     return toMutableList().also { it[currentIndex] = currentTrack }
+}
+
+private fun PlaybackQueueItem.hasSameArtworkVisual(other: PlaybackQueueItem): Boolean {
+    return title == other.title && artworkIdentityKey() == other.artworkIdentityKey()
 }
 
 private class NowPlayingArtworkMotionState(initialPosition: Float) {

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -352,6 +352,32 @@ fun NowPlayingOverlay(
         currentTrack = track,
     )
     val artworkMotionState = rememberNowPlayingArtworkMotionState(visualSnapshot.currentIndex, visible)
+    var visualSkipRequest by remember { mutableStateOf<ArtworkPageRequest?>(null) }
+    fun requestVisualSkip(delta: Int) {
+        val queue = visualSnapshot.queue
+        val basePage = visualSkipRequest
+            ?.page
+            ?.takeIf { it in queue.indices }
+            ?: visualSnapshot.currentIndex
+        val targetPage = basePage + delta
+        if (targetPage in queue.indices) {
+            visualSkipRequest = ArtworkPageRequest(
+                page = targetPage,
+                sequence = (visualSkipRequest?.sequence ?: 0) + 1,
+            ).takeUnless { targetPage == visualSnapshot.currentIndex }
+        }
+    }
+    LaunchedEffect(visualSkipRequest, visualSnapshot.currentIndex) {
+        val request = visualSkipRequest ?: return@LaunchedEffect
+        if (visualSnapshot.currentIndex == request.page) {
+            visualSkipRequest = null
+            return@LaunchedEffect
+        }
+        delay(ARTWORK_BUTTON_SKIP_CONFIRM_TIMEOUT_MS)
+        if (visualSkipRequest == request && visualSnapshot.currentIndex != request.page) {
+            visualSkipRequest = null
+        }
+    }
     val visualCurrentServer = visualSnapshot.currentTrack.serverId?.let { serversById[it] }
         ?: currentServer.takeIf { it?.id == visualSnapshot.currentTrack.serverId }
 
@@ -571,6 +597,7 @@ fun NowPlayingOverlay(
                             currentTrack = visualSnapshot.currentTrack,
                             serversById = serversById,
                             motionState = artworkMotionState,
+                            visualSkipRequest = visualSkipRequest,
                             modifier = Modifier.fillMaxSize(),
                             onArtworkClick = {
                                 if (showLyrics) showLyrics = false
@@ -804,10 +831,13 @@ fun NowPlayingOverlay(
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             PlayerActionButton(
-                                Icons.Rounded.SkipPrevious,
-                                stringResource(R.string.player_previous),
-                                onSkipToPrevious,
-                                compactControls,
+                                icon = Icons.Rounded.SkipPrevious,
+                                label = stringResource(R.string.player_previous),
+                                onClick = {
+                                    requestVisualSkip(-1)
+                                    onSkipToPrevious()
+                                },
+                                compact = compactControls,
                             )
                             Spacer(Modifier.width(14.dp))
                             Surface(
@@ -845,10 +875,13 @@ fun NowPlayingOverlay(
                             }
                             Spacer(Modifier.width(14.dp))
                             PlayerActionButton(
-                                Icons.Rounded.SkipNext,
-                                stringResource(R.string.player_next),
-                                onSkipToNext,
-                                compactControls,
+                                icon = Icons.Rounded.SkipNext,
+                                label = stringResource(R.string.player_next),
+                                onClick = {
+                                    requestVisualSkip(1)
+                                    onSkipToNext()
+                                },
+                                compact = compactControls,
                             )
                         }
                         // Tech info bar
@@ -1437,6 +1470,11 @@ private data class ArtworkColors(
     val accent: Color,
 )
 
+private data class ArtworkPageRequest(
+    val page: Int,
+    val sequence: Int,
+)
+
 private data class ArtworkPresentationRequest(
     val key: String,
     val model: Any?,
@@ -1562,11 +1600,15 @@ private fun NowPlayingArtworkPagerHost(
     currentTrack: PlaybackQueueItem,
     serversById: Map<Long, ServerConfig>,
     motionState: NowPlayingArtworkMotionState,
+    visualSkipRequest: ArtworkPageRequest?,
     modifier: Modifier = Modifier,
     onArtworkClick: () -> Unit,
     onUserSelectQueueItem: (Int) -> Unit,
 ) {
     val targetPage = currentIndex.coerceAtLeast(0)
+    val requestedVisualPage = visualSkipRequest?.page?.takeIf { it in queue.indices }
+    val visualTargetPage = requestedVisualPage ?: targetPage
+    val visualSkipSequence = visualSkipRequest?.sequence
     val queueIdentity = remember(queue) { queue.map { it.artworkIdentityKey() } }
     val latestOnArtworkClick by rememberUpdatedState(onArtworkClick)
     val latestOnUserSelectQueueItem by rememberUpdatedState(onUserSelectQueueItem)
@@ -1586,8 +1628,28 @@ private fun NowPlayingArtworkPagerHost(
     // update the page count first, then move after any insertion before the
     // current item. Track changes use the pager's own animation so there is
     // only one artwork render path and no overlay handoff frame.
-    LaunchedEffect(targetPage, currentTrack.songId, queueIdentity) {
-        if (currentTrack.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
+    LaunchedEffect(visualTargetPage, visualSkipSequence, currentTrack.songId, queueIdentity) {
+        val isLocalVisualSkip = requestedVisualPage != null && requestedVisualPage != targetPage
+        if (isLocalVisualSkip && artworkPagerState.currentPage != visualTargetPage) {
+            stableQueue = queue
+            programmaticPagerSync = true
+            try {
+                val distancePages = abs(
+                    visualTargetPage - (artworkPagerState.currentPage + artworkPagerState.currentPageOffsetFraction),
+                )
+                withContext(FixedArtworkMotionDurationScale) {
+                    artworkPagerState.animateArtworkMotionToPage(
+                        page = visualTargetPage,
+                        motionState = motionState,
+                        distancePages = distancePages,
+                    )
+                }
+            } finally {
+                lastProgrammaticSettledPage = artworkPagerState.settledPage
+                programmaticPagerSync = false
+            }
+        }
+        if (!isLocalVisualSkip && currentTrack.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
             val startPage = artworkPagerState.currentPage
             while (artworkPagerState.isScrollInProgress) {
                 withFrameNanos { }
@@ -1612,7 +1674,7 @@ private fun NowPlayingArtworkPagerHost(
         } else {
             stableQueue = queue
         }
-        if (currentTrack.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
+        if (!isLocalVisualSkip && currentTrack.songId != lastTrackId && artworkPagerState.currentPage != targetPage) {
             stableQueue = queue
             withFrameNanos { }
             programmaticPagerSync = true
@@ -1734,6 +1796,7 @@ private fun NowPlayingArtworkFrame(
 private const val ARTWORK_PRESENTATION_CACHE_ENTRIES = 64
 private const val ARTWORK_PREWARM_RADIUS_PAGES = 3
 private const val ARTWORK_BACKGROUND_SETTLE_MS = 180
+private const val ARTWORK_BUTTON_SKIP_CONFIRM_TIMEOUT_MS = 900L
 private const val PROGRAMMATIC_ARTWORK_SPRING_BASE_STIFFNESS = 140f
 private const val PROGRAMMATIC_ARTWORK_SPRING_DISTANCE_STIFFNESS = 60f
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -4,7 +4,7 @@ import android.util.LruCache
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
@@ -98,6 +98,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
@@ -139,6 +140,7 @@ import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.allowHardware
 import coil3.toBitmap
+import kotlin.coroutines.CoroutineContext
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.floor
@@ -422,21 +424,15 @@ fun NowPlayingOverlay(
             fallbackDominant = colorScheme.primary,
             fallbackAccent = colorScheme.tertiary,
         )
-        val dominant by animateColorAsState(
+        val dominant = rememberFixedMotionColor(
             targetValue = artworkColors.dominant,
-            animationSpec = tween(
-                durationMillis = ARTWORK_BACKGROUND_COLOR_SMOOTH_MS,
-                easing = FastOutSlowInEasing,
-            ),
-            label = "NowPlayingDominantColor",
+            durationMillis = ARTWORK_BACKGROUND_COLOR_SMOOTH_MS,
+            easing = FastOutSlowInEasing,
         )
-        val accent by animateColorAsState(
+        val accent = rememberFixedMotionColor(
             targetValue = artworkColors.accent,
-            animationSpec = tween(
-                durationMillis = ARTWORK_BACKGROUND_COLOR_SMOOTH_MS,
-                easing = FastOutSlowInEasing,
-            ),
-            label = "NowPlayingAccentColor",
+            durationMillis = ARTWORK_BACKGROUND_COLOR_SMOOTH_MS,
+            easing = FastOutSlowInEasing,
         )
         val background = remember(dominant, accent, colorScheme) {
             Brush.verticalGradient(
@@ -1440,6 +1436,31 @@ private data class ArtworkPresentationRequest(
 )
 
 @Composable
+private fun rememberFixedMotionColor(
+    targetValue: Color,
+    durationMillis: Int,
+    easing: Easing,
+): Color {
+    var color by remember { mutableStateOf(targetValue) }
+    LaunchedEffect(targetValue, durationMillis, easing) {
+        if (durationMillis <= 0) {
+            color = targetValue
+            return@LaunchedEffect
+        }
+        val startColor = color
+        val startNanos = withFrameNanos { it }
+        var fraction: Float
+        do {
+            val frameNanos = withFrameNanos { it }
+            fraction = ((frameNanos - startNanos) / 1_000_000f / durationMillis)
+                .coerceIn(0f, 1f)
+            color = lerp(startColor, targetValue, easing.transform(fraction))
+        } while (fraction < 1f)
+    }
+    return color
+}
+
+@Composable
 private fun rememberMotionArtworkColors(
     queue: List<PlaybackQueueItem>,
     serversById: Map<Long, ServerConfig>,
@@ -1568,10 +1589,12 @@ private fun NowPlayingArtworkPagerHost(
                 val distancePages = abs(
                     targetPage - (artworkPagerState.currentPage + artworkPagerState.currentPageOffsetFraction),
                 )
-                artworkPagerState.animateScrollToPage(
-                    page = targetPage,
-                    animationSpec = programmaticArtworkScrollSpec(distancePages),
-                )
+                withContext(FixedArtworkMotionDurationScale) {
+                    artworkPagerState.animateScrollToPage(
+                        page = targetPage,
+                        animationSpec = programmaticArtworkScrollSpec(distancePages),
+                    )
+                }
             } finally {
                 lastProgrammaticSettledPage = artworkPagerState.settledPage
                 programmaticPagerSync = false
@@ -1681,6 +1704,11 @@ private const val PROGRAMMATIC_ARTWORK_SCROLL_MAX_MS = 680
 private const val PROGRAMMATIC_ARTWORK_SCROLL_BASE_MS = 210
 private const val PROGRAMMATIC_ARTWORK_SCROLL_DISTANCE_MS = 280
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
+
+private object FixedArtworkMotionDurationScale : MotionDurationScale {
+    override val key: CoroutineContext.Key<*> = MotionDurationScale.Key
+    override val scaleFactor: Float = 1f
+}
 
 private fun programmaticArtworkScrollSpec(distancePages: Float) = tween<Float>(
     durationMillis = (

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -351,7 +351,7 @@ fun NowPlayingOverlay(
         currentIndex = playbackState.currentIndex,
         currentTrack = track,
     )
-    val artworkMotionState = rememberNowPlayingArtworkMotionState(visualSnapshot.currentIndex)
+    val artworkMotionState = rememberNowPlayingArtworkMotionState(visualSnapshot.currentIndex, visible)
     val visualCurrentServer = visualSnapshot.currentTrack.serverId?.let { serversById[it] }
         ?: currentServer.takeIf { it?.id == visualSnapshot.currentTrack.serverId }
 
@@ -417,13 +417,17 @@ fun NowPlayingOverlay(
         ),
     ) {
         val colorScheme = MaterialTheme.colorScheme
-        val artworkColors = rememberMotionArtworkColors(
+        val rawArtworkColors = rememberMotionArtworkColors(
             queue = visualSnapshot.queue,
             serversById = serversById,
             position = artworkMotionState.position,
             freezePresentationUpdates = artworkMotionState.isScrollInProgress,
             fallbackDominant = colorScheme.primary,
             fallbackAccent = colorScheme.tertiary,
+        )
+        val artworkColors = rememberDisplayedArtworkColors(
+            targetColors = rawArtworkColors,
+            followImmediately = artworkMotionState.isScrollInProgress || !visible,
         )
         val dominant = artworkColors.dominant
         val accent = artworkColors.accent
@@ -1421,8 +1425,11 @@ private class NowPlayingArtworkMotionState(initialPosition: Float) {
 }
 
 @Composable
-private fun rememberNowPlayingArtworkMotionState(currentIndex: Int): NowPlayingArtworkMotionState {
-    return remember { NowPlayingArtworkMotionState(currentIndex.coerceAtLeast(0).toFloat()) }
+private fun rememberNowPlayingArtworkMotionState(
+    currentIndex: Int,
+    visible: Boolean,
+): NowPlayingArtworkMotionState {
+    return remember(visible) { NowPlayingArtworkMotionState(currentIndex.coerceAtLeast(0).toFloat()) }
 }
 
 private data class ArtworkColors(
@@ -1434,6 +1441,38 @@ private data class ArtworkPresentationRequest(
     val key: String,
     val model: Any?,
 )
+
+@Composable
+private fun rememberDisplayedArtworkColors(
+    targetColors: ArtworkColors,
+    followImmediately: Boolean,
+): ArtworkColors {
+    var displayedColors by remember { mutableStateOf(targetColors) }
+
+    LaunchedEffect(targetColors, followImmediately) {
+        if (followImmediately) {
+            displayedColors = targetColors
+            return@LaunchedEffect
+        }
+        if (displayedColors == targetColors) return@LaunchedEffect
+
+        val startColors = displayedColors
+        withContext(FixedArtworkMotionDurationScale) {
+            animate(
+                initialValue = 0f,
+                targetValue = 1f,
+                animationSpec = tween(ARTWORK_BACKGROUND_SETTLE_MS),
+            ) { fraction, _ ->
+                displayedColors = ArtworkColors(
+                    dominant = lerp(startColors.dominant, targetColors.dominant, fraction),
+                    accent = lerp(startColors.accent, targetColors.accent, fraction),
+                )
+            }
+        }
+    }
+
+    return if (followImmediately) targetColors else displayedColors
+}
 
 @Composable
 private fun rememberMotionArtworkColors(
@@ -1488,7 +1527,10 @@ private fun rememberMotionArtworkColors(
     fun colorsFor(page: Int): ArtworkColors {
         val item = queue.getOrNull(page)
         val key = item?.artworkIdentityKey()
-        val presentation = key?.let { appliedPresentations[it] } ?: ArtworkPresentation()
+        val cachedPresentation = item
+            ?.queueArtworkModel(item.serverId?.let { serversById[it] })
+            ?.cachedArtworkPresentation()
+        val presentation = key?.let { appliedPresentations[it] ?: cachedPresentation } ?: ArtworkPresentation()
         return ArtworkColors(
             dominant = presentation.dominantColor ?: fallbackDominant,
             accent = presentation.accentColor ?: fallbackAccent,
@@ -1689,6 +1731,7 @@ private fun NowPlayingArtworkFrame(
 
 private const val ARTWORK_PRESENTATION_CACHE_ENTRIES = 64
 private const val ARTWORK_PREWARM_RADIUS_PAGES = 3
+private const val ARTWORK_BACKGROUND_SETTLE_MS = 180
 private const val PROGRAMMATIC_ARTWORK_SPRING_BASE_STIFFNESS = 140f
 private const val PROGRAMMATIC_ARTWORK_SPRING_DISTANCE_STIFFNESS = 60f
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
@@ -1777,6 +1820,10 @@ private fun Any.artworkPresentationCacheKey(): String {
         is File -> "file:$absolutePath"
         else -> "model:${this}"
     }
+}
+
+private fun Any.cachedArtworkPresentation(): ArtworkPresentation? {
+    return artworkPresentationCache.get(artworkPresentationCacheKey())
 }
 
 private suspend fun decodeArtworkPresentation(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -4,8 +4,7 @@ import android.util.LruCache
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Easing
-import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
@@ -24,6 +23,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -47,6 +47,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -146,7 +147,6 @@ import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
-import kotlin.math.sqrt
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -359,14 +359,14 @@ fun NowPlayingOverlay(
     val context = LocalContext.current
     val queue = visualSnapshot.queue
     val currentIdx = visualSnapshot.currentIndex
-    val prevSongId = queue.getOrNull(currentIdx - 1)?.songId
-    val nextSongId = queue.getOrNull(currentIdx + 1)?.songId
-    LaunchedEffect(visible, visualSnapshot.currentTrack.songId, prevSongId, nextSongId, visualCurrentServer) {
+    val prewarmArtworkKeys = remember(queue, currentIdx) {
+        (currentIdx - ARTWORK_PREWARM_RADIUS_PAGES..currentIdx + ARTWORK_PREWARM_RADIUS_PAGES)
+            .mapNotNull { index -> queue.getOrNull(index)?.artworkIdentityKey() }
+    }
+    LaunchedEffect(visible, visualSnapshot.currentTrack.artworkIdentityKey(), prewarmArtworkKeys, visualCurrentServer) {
         if (!visible) return@LaunchedEffect
-        val adjacentIndices = listOfNotNull(
-            if (currentIdx > 0) currentIdx - 1 else null,
-            if (currentIdx < queue.lastIndex) currentIdx + 1 else null,
-        ).distinct()
+        val adjacentIndices = (currentIdx - ARTWORK_PREWARM_RADIUS_PAGES..currentIdx + ARTWORK_PREWARM_RADIUS_PAGES)
+            .filter { it in queue.indices && it != currentIdx }
         for (i in adjacentIndices) {
             val item = queue[i]
             val server = item.serverId?.let { serversById[it] }
@@ -421,19 +421,12 @@ fun NowPlayingOverlay(
             queue = visualSnapshot.queue,
             serversById = serversById,
             position = artworkMotionState.position,
+            freezePresentationUpdates = artworkMotionState.isScrollInProgress,
             fallbackDominant = colorScheme.primary,
             fallbackAccent = colorScheme.tertiary,
         )
-        val dominant = rememberFixedMotionColor(
-            targetValue = artworkColors.dominant,
-            durationMillis = ARTWORK_BACKGROUND_COLOR_SMOOTH_MS,
-            easing = FastOutSlowInEasing,
-        )
-        val accent = rememberFixedMotionColor(
-            targetValue = artworkColors.accent,
-            durationMillis = ARTWORK_BACKGROUND_COLOR_SMOOTH_MS,
-            easing = FastOutSlowInEasing,
-        )
+        val dominant = artworkColors.dominant
+        val accent = artworkColors.accent
         val background = remember(dominant, accent, colorScheme) {
             Brush.verticalGradient(
                 listOf(
@@ -1418,6 +1411,8 @@ private fun List<PlaybackQueueItem>.withVisualCurrentItem(
 
 private class NowPlayingArtworkMotionState(initialPosition: Float) {
     var position by mutableFloatStateOf(initialPosition)
+    var velocity by mutableFloatStateOf(0f)
+    var isScrollInProgress by mutableStateOf(false)
 }
 
 @Composable
@@ -1436,35 +1431,11 @@ private data class ArtworkPresentationRequest(
 )
 
 @Composable
-private fun rememberFixedMotionColor(
-    targetValue: Color,
-    durationMillis: Int,
-    easing: Easing,
-): Color {
-    var color by remember { mutableStateOf(targetValue) }
-    LaunchedEffect(targetValue, durationMillis, easing) {
-        if (durationMillis <= 0) {
-            color = targetValue
-            return@LaunchedEffect
-        }
-        val startColor = color
-        val startNanos = withFrameNanos { it }
-        var fraction: Float
-        do {
-            val frameNanos = withFrameNanos { it }
-            fraction = ((frameNanos - startNanos) / 1_000_000f / durationMillis)
-                .coerceIn(0f, 1f)
-            color = lerp(startColor, targetValue, easing.transform(fraction))
-        } while (fraction < 1f)
-    }
-    return color
-}
-
-@Composable
 private fun rememberMotionArtworkColors(
     queue: List<PlaybackQueueItem>,
     serversById: Map<Long, ServerConfig>,
     position: Float,
+    freezePresentationUpdates: Boolean,
     fallbackDominant: Color,
     fallbackAccent: Color,
 ): ArtworkColors {
@@ -1474,13 +1445,15 @@ private fun rememberMotionArtworkColors(
 
     val context = LocalContext.current.applicationContext
     var presentations by remember { mutableStateOf<Map<String, ArtworkPresentation>>(emptyMap()) }
+    var appliedPresentations by remember { mutableStateOf<Map<String, ArtworkPresentation>>(emptyMap()) }
     val clampedPosition = position.coerceIn(0f, queue.lastIndex.toFloat())
     val fromPage = floor(clampedPosition).toInt().coerceIn(0, queue.lastIndex)
     val toPage = ceil(clampedPosition).toInt().coerceIn(0, queue.lastIndex)
     val fraction = (clampedPosition - fromPage).coerceIn(0f, 1f)
-    val pageRequests = remember(queue, serversById, fromPage, toPage) {
-        listOf(fromPage, toPage)
-            .distinct()
+    val centerPage = clampedPosition.roundToInt().coerceIn(0, queue.lastIndex)
+    val pageRequests = remember(queue, serversById, centerPage) {
+        (centerPage - ARTWORK_PREWARM_RADIUS_PAGES..centerPage + ARTWORK_PREWARM_RADIUS_PAGES)
+            .filter { it in queue.indices }
             .associateWith { page ->
                 val item = queue[page]
                 ArtworkPresentationRequest(
@@ -1491,17 +1464,26 @@ private fun rememberMotionArtworkColors(
     }
 
     LaunchedEffect(pageRequests) {
+        var loadedPresentations = presentations
         for (request in pageRequests.values) {
-            if (request.key !in presentations) {
-                presentations = presentations + (request.key to loadArtworkPresentation(context, request.model))
+            if (request.key !in loadedPresentations) {
+                val presentation = loadArtworkPresentation(context, request.model)
+                loadedPresentations = loadedPresentations + (request.key to presentation)
+                presentations = loadedPresentations
             }
+        }
+    }
+
+    LaunchedEffect(freezePresentationUpdates, presentations) {
+        if (!freezePresentationUpdates) {
+            appliedPresentations = presentations
         }
     }
 
     fun colorsFor(page: Int): ArtworkColors {
         val item = queue.getOrNull(page)
         val key = item?.artworkIdentityKey()
-        val presentation = key?.let { presentations[it] } ?: ArtworkPresentation()
+        val presentation = key?.let { appliedPresentations[it] } ?: ArtworkPresentation()
         return ArtworkColors(
             dominant = presentation.dominantColor ?: fallbackDominant,
             accent = presentation.accentColor ?: fallbackAccent,
@@ -1590,9 +1572,10 @@ private fun NowPlayingArtworkPagerHost(
                     targetPage - (artworkPagerState.currentPage + artworkPagerState.currentPageOffsetFraction),
                 )
                 withContext(FixedArtworkMotionDurationScale) {
-                    artworkPagerState.animateScrollToPage(
+                    artworkPagerState.animateArtworkMotionToPage(
                         page = targetPage,
-                        animationSpec = programmaticArtworkScrollSpec(distancePages),
+                        motionState = motionState,
+                        distancePages = distancePages,
                     )
                 }
             } finally {
@@ -1606,14 +1589,16 @@ private fun NowPlayingArtworkPagerHost(
     LaunchedEffect(artworkPagerState, motionState) {
         snapshotFlow {
             val maxPage = (artworkPagerState.pageCount - 1).coerceAtLeast(0)
-            (
+            val position = (
                 artworkPagerState.currentPage +
                     artworkPagerState.currentPageOffsetFraction
                 ).coerceIn(0f, maxPage.toFloat())
+            position to artworkPagerState.isScrollInProgress
         }
             .distinctUntilChanged()
-            .collect { position ->
+            .collect { (position, isScrollInProgress) ->
                 motionState.position = position
+                motionState.isScrollInProgress = isScrollInProgress
             }
     }
 
@@ -1698,11 +1683,9 @@ private fun NowPlayingArtworkFrame(
 }
 
 private const val ARTWORK_PRESENTATION_CACHE_ENTRIES = 64
-private const val ARTWORK_BACKGROUND_COLOR_SMOOTH_MS = 140
-private const val PROGRAMMATIC_ARTWORK_SCROLL_MIN_MS = 260
-private const val PROGRAMMATIC_ARTWORK_SCROLL_MAX_MS = 680
-private const val PROGRAMMATIC_ARTWORK_SCROLL_BASE_MS = 210
-private const val PROGRAMMATIC_ARTWORK_SCROLL_DISTANCE_MS = 280
+private const val ARTWORK_PREWARM_RADIUS_PAGES = 3
+private const val PROGRAMMATIC_ARTWORK_SPRING_BASE_STIFFNESS = 140f
+private const val PROGRAMMATIC_ARTWORK_SPRING_DISTANCE_STIFFNESS = 60f
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
 
 private object FixedArtworkMotionDurationScale : MotionDurationScale {
@@ -1710,14 +1693,58 @@ private object FixedArtworkMotionDurationScale : MotionDurationScale {
     override val scaleFactor: Float = 1f
 }
 
-private fun programmaticArtworkScrollSpec(distancePages: Float) = tween<Float>(
-    durationMillis = (
-        PROGRAMMATIC_ARTWORK_SCROLL_BASE_MS +
-            sqrt(distancePages.coerceAtLeast(0.01f)) * PROGRAMMATIC_ARTWORK_SCROLL_DISTANCE_MS
-        )
-        .roundToInt()
-        .coerceIn(PROGRAMMATIC_ARTWORK_SCROLL_MIN_MS, PROGRAMMATIC_ARTWORK_SCROLL_MAX_MS),
-    easing = FastOutSlowInEasing,
+private suspend fun PagerState.animateArtworkMotionToPage(
+    page: Int,
+    motionState: NowPlayingArtworkMotionState,
+    distancePages: Float,
+) {
+    val safePageCount = pageCount.coerceAtLeast(1)
+    val targetPage = page.coerceIn(0, safePageCount - 1)
+    val targetPosition = targetPage.toFloat()
+    val startPosition = (currentPage + currentPageOffsetFraction)
+        .coerceIn(0f, (safePageCount - 1).toFloat())
+    val startVelocity = motionState.velocity
+        .takeUnless { it.isNaN() || it.isInfinite() }
+        ?: 0f
+    val pagerState = this
+
+    scroll {
+        updateTargetPage(targetPage)
+        animate(
+            initialValue = startPosition,
+            targetValue = targetPosition,
+            initialVelocity = startVelocity,
+            animationSpec = programmaticArtworkScrollSpec(distancePages),
+        ) { value, velocity ->
+            val position = value.coerceIn(0f, (safePageCount - 1).toFloat())
+            motionState.position = position
+            motionState.velocity = velocity
+            pagerState.updateArtworkPagerPosition(this, position, safePageCount)
+        }
+        motionState.position = targetPosition
+        motionState.velocity = 0f
+        pagerState.updateArtworkPagerPosition(this, targetPosition, safePageCount)
+    }
+}
+
+private fun PagerState.updateArtworkPagerPosition(
+    scrollScope: ScrollScope,
+    absolutePosition: Float,
+    pageCount: Int,
+) {
+    val page = absolutePosition.roundToInt().coerceIn(0, pageCount - 1)
+    val offset = (absolutePosition - page).coerceIn(-0.5f, 0.5f)
+    with(scrollScope) {
+        updateCurrentPage(page, offset)
+    }
+}
+
+private fun programmaticArtworkScrollSpec(distancePages: Float) = spring<Float>(
+    dampingRatio = Spring.DampingRatioNoBouncy,
+    stiffness = (
+        PROGRAMMATIC_ARTWORK_SPRING_BASE_STIFFNESS +
+            distancePages.coerceIn(0f, 3f) * PROGRAMMATIC_ARTWORK_SPRING_DISTANCE_STIFFNESS
+        ),
 )
 
 private suspend fun loadArtworkPresentation(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -141,6 +141,7 @@ import coil3.request.ImageRequest
 import coil3.request.allowHardware
 import coil3.toBitmap
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.floor
@@ -1494,7 +1495,7 @@ private fun rememberDisplayedArtworkColors(
         if (displayedColors == targetColors) return@LaunchedEffect
 
         val startColors = displayedColors
-        withContext(FixedArtworkMotionDurationScale) {
+        withFixedArtworkMotionDurationScale {
             animate(
                 initialValue = 0f,
                 targetValue = 1f,
@@ -1547,8 +1548,10 @@ private fun rememberMotionArtworkColors(
     LaunchedEffect(pageRequests) {
         var loadedPresentations = presentations
         for (request in pageRequests.values) {
-            if (request.key !in loadedPresentations) {
-                val presentation = loadArtworkPresentation(context, request.model)
+            val model = request.model ?: continue
+            if (loadedPresentations[request.key]?.hasColors != true) {
+                val presentation = loadArtworkPresentation(context, model)
+                if (!presentation.hasColors) continue
                 loadedPresentations = loadedPresentations + (request.key to presentation)
                 presentations = loadedPresentations
             }
@@ -1567,7 +1570,10 @@ private fun rememberMotionArtworkColors(
         val cachedPresentation = item
             ?.queueArtworkModel(item.serverId?.let { serversById[it] })
             ?.cachedArtworkPresentation()
-        val presentation = key?.let { appliedPresentations[it] ?: cachedPresentation } ?: ArtworkPresentation()
+        val presentation = key
+            ?.let { appliedPresentations[it]?.takeIf { presentation -> presentation.hasColors } }
+            ?: cachedPresentation?.takeIf { presentation -> presentation.hasColors }
+            ?: ArtworkPresentation()
         return ArtworkColors(
             dominant = presentation.dominantColor ?: fallbackDominant,
             accent = presentation.accentColor ?: fallbackAccent,
@@ -1636,7 +1642,7 @@ private fun NowPlayingArtworkPagerHost(
                 val distancePages = abs(
                     visualTargetPage - (artworkPagerState.currentPage + artworkPagerState.currentPageOffsetFraction),
                 )
-                withContext(FixedArtworkMotionDurationScale) {
+                withFixedArtworkMotionDurationScale {
                     artworkPagerState.animateArtworkMotionToPage(
                         page = visualTargetPage,
                         motionState = motionState,
@@ -1686,7 +1692,7 @@ private fun NowPlayingArtworkPagerHost(
                 val distancePages = abs(
                     targetPage - (artworkPagerState.currentPage + artworkPagerState.currentPageOffsetFraction),
                 )
-                withContext(FixedArtworkMotionDurationScale) {
+                withFixedArtworkMotionDurationScale {
                     artworkPagerState.animateArtworkMotionToPage(
                         page = targetPage,
                         motionState = motionState,
@@ -1810,6 +1816,16 @@ private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ART
 private object FixedArtworkMotionDurationScale : MotionDurationScale {
     override val key: CoroutineContext.Key<*> = MotionDurationScale.Key
     override val scaleFactor: Float = 1f
+}
+
+private suspend fun withFixedArtworkMotionDurationScale(block: suspend () -> Unit) {
+    if (coroutineContext[MotionDurationScale.Key]?.scaleFactor == 0f) {
+        block()
+    } else {
+        withContext(FixedArtworkMotionDurationScale) {
+            block()
+        }
+    }
 }
 
 private suspend fun PagerState.animateArtworkMotionToPage(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -1589,8 +1589,6 @@ private fun NowPlayingArtworkPagerHost(
     LaunchedEffect(targetPage, currentTrack.songId, queueIdentity) {
         if (currentTrack.songId == lastTrackId && artworkPagerState.currentPage != targetPage) {
             val startPage = artworkPagerState.currentPage
-            stableQueue = queue
-            withFrameNanos { }
             while (artworkPagerState.isScrollInProgress) {
                 withFrameNanos { }
             }
@@ -1600,12 +1598,16 @@ private fun NowPlayingArtworkPagerHost(
             if (!userMovedPager && artworkPagerState.currentPage != targetPage) {
                 programmaticPagerSync = true
                 try {
+                    stableQueue = queue
                     artworkPagerState.scrollToPage(targetPage)
+                    motionState.position = targetPage.toFloat()
                     withFrameNanos { }
                 } finally {
                     lastProgrammaticSettledPage = artworkPagerState.settledPage
                     programmaticPagerSync = false
                 }
+            } else {
+                stableQueue = queue
             }
         } else {
             stableQueue = queue

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -107,6 +107,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
@@ -138,7 +139,12 @@ import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.allowHardware
 import coil3.toBitmap
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.roundToInt
 import kotlin.math.roundToLong
+import kotlin.math.sqrt
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -343,6 +349,7 @@ fun NowPlayingOverlay(
         currentIndex = playbackState.currentIndex,
         currentTrack = track,
     )
+    val artworkMotionState = rememberNowPlayingArtworkMotionState(visualSnapshot.currentIndex)
     val visualCurrentServer = visualSnapshot.currentTrack.serverId?.let { serversById[it] }
         ?: currentServer.takeIf { it?.id == visualSnapshot.currentTrack.serverId }
 
@@ -407,24 +414,26 @@ fun NowPlayingOverlay(
             targetOffsetY = { fullHeight -> fullHeight / 3 },
         ),
     ) {
-        val artwork = rememberArtworkPresentation(
-            fallbackModel = visualSnapshot.currentTrack.queueArtworkModel(visualCurrentServer),
-        )
         val colorScheme = MaterialTheme.colorScheme
-        val targetDominant = artwork.dominantColor ?: colorScheme.primary
-        val targetAccent = artwork.accentColor ?: colorScheme.tertiary
+        val artworkColors = rememberMotionArtworkColors(
+            queue = visualSnapshot.queue,
+            serversById = serversById,
+            position = artworkMotionState.position,
+            fallbackDominant = colorScheme.primary,
+            fallbackAccent = colorScheme.tertiary,
+        )
         val dominant by animateColorAsState(
-            targetValue = targetDominant,
+            targetValue = artworkColors.dominant,
             animationSpec = tween(
-                durationMillis = ARTWORK_COLOR_TRANSITION_MS,
+                durationMillis = ARTWORK_BACKGROUND_COLOR_SMOOTH_MS,
                 easing = FastOutSlowInEasing,
             ),
             label = "NowPlayingDominantColor",
         )
         val accent by animateColorAsState(
-            targetValue = targetAccent,
+            targetValue = artworkColors.accent,
             animationSpec = tween(
-                durationMillis = ARTWORK_COLOR_TRANSITION_MS,
+                durationMillis = ARTWORK_BACKGROUND_COLOR_SMOOTH_MS,
                 easing = FastOutSlowInEasing,
             ),
             label = "NowPlayingAccentColor",
@@ -568,6 +577,7 @@ fun NowPlayingOverlay(
                             currentIndex = visualSnapshot.currentIndex,
                             currentTrack = visualSnapshot.currentTrack,
                             serversById = serversById,
+                            motionState = artworkMotionState,
                             modifier = Modifier.fillMaxSize(),
                             onArtworkClick = {
                                 if (showLyrics) showLyrics = false
@@ -1410,6 +1420,82 @@ private fun List<PlaybackQueueItem>.withVisualCurrentItem(
     return toMutableList().also { it[currentIndex] = currentTrack }
 }
 
+private class NowPlayingArtworkMotionState(initialPosition: Float) {
+    var position by mutableFloatStateOf(initialPosition)
+}
+
+@Composable
+private fun rememberNowPlayingArtworkMotionState(currentIndex: Int): NowPlayingArtworkMotionState {
+    return remember { NowPlayingArtworkMotionState(currentIndex.coerceAtLeast(0).toFloat()) }
+}
+
+private data class ArtworkColors(
+    val dominant: Color,
+    val accent: Color,
+)
+
+private data class ArtworkPresentationRequest(
+    val key: String,
+    val model: Any?,
+)
+
+@Composable
+private fun rememberMotionArtworkColors(
+    queue: List<PlaybackQueueItem>,
+    serversById: Map<Long, ServerConfig>,
+    position: Float,
+    fallbackDominant: Color,
+    fallbackAccent: Color,
+): ArtworkColors {
+    if (queue.isEmpty()) {
+        return ArtworkColors(fallbackDominant, fallbackAccent)
+    }
+
+    val context = LocalContext.current.applicationContext
+    var presentations by remember { mutableStateOf<Map<String, ArtworkPresentation>>(emptyMap()) }
+    val clampedPosition = position.coerceIn(0f, queue.lastIndex.toFloat())
+    val fromPage = floor(clampedPosition).toInt().coerceIn(0, queue.lastIndex)
+    val toPage = ceil(clampedPosition).toInt().coerceIn(0, queue.lastIndex)
+    val fraction = (clampedPosition - fromPage).coerceIn(0f, 1f)
+    val pageRequests = remember(queue, serversById, fromPage, toPage) {
+        listOf(fromPage, toPage)
+            .distinct()
+            .associateWith { page ->
+                val item = queue[page]
+                ArtworkPresentationRequest(
+                    key = item.artworkIdentityKey(),
+                    model = item.queueArtworkModel(item.serverId?.let { serversById[it] }),
+                )
+            }
+    }
+
+    LaunchedEffect(pageRequests) {
+        for (request in pageRequests.values) {
+            if (request.key !in presentations) {
+                presentations = presentations + (request.key to loadArtworkPresentation(context, request.model))
+            }
+        }
+    }
+
+    fun colorsFor(page: Int): ArtworkColors {
+        val item = queue.getOrNull(page)
+        val key = item?.artworkIdentityKey()
+        val presentation = key?.let { presentations[it] } ?: ArtworkPresentation()
+        return ArtworkColors(
+            dominant = presentation.dominantColor ?: fallbackDominant,
+            accent = presentation.accentColor ?: fallbackAccent,
+        )
+    }
+
+    val fromColors = colorsFor(fromPage)
+    if (fromPage == toPage) return fromColors
+    val toColors = colorsFor(toPage)
+    return ArtworkColors(
+        dominant = lerp(fromColors.dominant, toColors.dominant, fraction),
+        accent = lerp(fromColors.accent, toColors.accent, fraction),
+    )
+}
+
 private data class ArtworkPresentation(
     val dominantColor: Color? = null,
     val accentColor: Color? = null,
@@ -1425,6 +1511,7 @@ private fun NowPlayingArtworkPagerHost(
     currentIndex: Int,
     currentTrack: PlaybackQueueItem,
     serversById: Map<Long, ServerConfig>,
+    motionState: NowPlayingArtworkMotionState,
     modifier: Modifier = Modifier,
     onArtworkClick: () -> Unit,
     onUserSelectQueueItem: (Int) -> Unit,
@@ -1478,12 +1565,12 @@ private fun NowPlayingArtworkPagerHost(
             withFrameNanos { }
             programmaticPagerSync = true
             try {
+                val distancePages = abs(
+                    targetPage - (artworkPagerState.currentPage + artworkPagerState.currentPageOffsetFraction),
+                )
                 artworkPagerState.animateScrollToPage(
                     page = targetPage,
-                    animationSpec = tween(
-                        durationMillis = PROGRAMMATIC_ARTWORK_SCROLL_MS,
-                        easing = FastOutSlowInEasing,
-                    ),
+                    animationSpec = programmaticArtworkScrollSpec(distancePages),
                 )
             } finally {
                 lastProgrammaticSettledPage = artworkPagerState.settledPage
@@ -1491,6 +1578,20 @@ private fun NowPlayingArtworkPagerHost(
             }
         }
         lastTrackId = currentTrack.songId
+    }
+
+    LaunchedEffect(artworkPagerState, motionState) {
+        snapshotFlow {
+            val maxPage = (artworkPagerState.pageCount - 1).coerceAtLeast(0)
+            (
+                artworkPagerState.currentPage +
+                    artworkPagerState.currentPageOffsetFraction
+                ).coerceIn(0f, maxPage.toFloat())
+        }
+            .distinctUntilChanged()
+            .collect { position ->
+                motionState.position = position
+            }
     }
 
     val currentPlaybackIndex by rememberUpdatedState(currentIndex)
@@ -1574,21 +1675,22 @@ private fun NowPlayingArtworkFrame(
 }
 
 private const val ARTWORK_PRESENTATION_CACHE_ENTRIES = 64
-private const val ARTWORK_COLOR_TRANSITION_MS = 520
-private const val PROGRAMMATIC_ARTWORK_SCROLL_MS = 520
+private const val ARTWORK_BACKGROUND_COLOR_SMOOTH_MS = 140
+private const val PROGRAMMATIC_ARTWORK_SCROLL_MIN_MS = 260
+private const val PROGRAMMATIC_ARTWORK_SCROLL_MAX_MS = 680
+private const val PROGRAMMATIC_ARTWORK_SCROLL_BASE_MS = 210
+private const val PROGRAMMATIC_ARTWORK_SCROLL_DISTANCE_MS = 280
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
 
-@Composable
-private fun rememberArtworkPresentation(
-    fallbackModel: Any?,
-): ArtworkPresentation {
-    val context = LocalContext.current.applicationContext
-    var presentation by remember { mutableStateOf(ArtworkPresentation()) }
-    LaunchedEffect(fallbackModel) {
-        presentation = loadArtworkPresentation(context, fallbackModel)
-    }
-    return presentation
-}
+private fun programmaticArtworkScrollSpec(distancePages: Float) = tween<Float>(
+    durationMillis = (
+        PROGRAMMATIC_ARTWORK_SCROLL_BASE_MS +
+            sqrt(distancePages.coerceAtLeast(0.01f)) * PROGRAMMATIC_ARTWORK_SCROLL_DISTANCE_MS
+        )
+        .roundToInt()
+        .coerceIn(PROGRAMMATIC_ARTWORK_SCROLL_MIN_MS, PROGRAMMATIC_ARTWORK_SCROLL_MAX_MS),
+    easing = FastOutSlowInEasing,
+)
 
 private suspend fun loadArtworkPresentation(
     context: android.content.Context,


### PR DESCRIPTION
## Summary
- Smooth Now Playing artwork transitions by keeping artwork rendering on the pager path and tracking pager position for background colors.
- Stabilize artwork state during transient playback, deferred queue expansion, default-cover, and palette-loading frames to avoid flashes.
- Start full-screen skip-button artwork motion immediately with a local visual target, then let playback state confirm the real current item.
- Drive programmatic artwork motion through pager pixel scrolling with a directional velocity boost so button skips feel closer to hand swipes.

Closes #209
