### PR TITLE
feat: add offline degraded browsing state

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -100,6 +100,7 @@ fun SakiApp(
                 else -> {
                     RootShell(
                         uiState = uiState,
+                        endpointStatus = endpointStatus,
                         snackbarHostState = snackbarHostState,
                         showSettings = showSettings,
                         onShowSettingsChange = { showSettings = it },
@@ -128,6 +129,7 @@ fun SakiApp(
                         onPlaySongs = viewModel::playSongs,
                         onQueueSong = viewModel::queueSong,
                         onPlaySongNext = viewModel::playSongNext,
+                        onOfflineSongUnavailable = viewModel::showOfflineSongUnavailable,
                         onToggleSongDownload = viewModel::toggleSongDownload,
                         onPlayCachedSong = viewModel::playCachedSong,
                         onPlayCachedQueue = viewModel::playCachedQueue,
@@ -201,6 +203,7 @@ fun SakiApp(
 @Composable
 private fun RootShell(
     uiState: SakiAppUiState,
+    endpointStatus: EndpointStatus,
     snackbarHostState: SnackbarHostState,
     showSettings: Boolean,
     onShowSettingsChange: (Boolean) -> Unit,
@@ -225,6 +228,7 @@ private fun RootShell(
     onPlaySongs: (List<org.hdhmc.saki.domain.model.Song>, Int) -> Unit,
     onQueueSong: (org.hdhmc.saki.domain.model.Song) -> Unit,
     onPlaySongNext: (org.hdhmc.saki.domain.model.Song) -> Unit,
+    onOfflineSongUnavailable: () -> Unit,
     onToggleSongDownload: (org.hdhmc.saki.domain.model.Song) -> Unit,
     onPlayCachedSong: (org.hdhmc.saki.domain.model.CachedSong) -> Unit,
     onPlayCachedQueue: (List<org.hdhmc.saki.domain.model.CachedSong>, Int) -> Unit,
@@ -308,6 +312,7 @@ private fun RootShell(
                 } else {
                     BrowseScreen(
                         uiState = uiState,
+                        isOfflineDegraded = endpointStatus.isOfflineDegraded,
                         contentPadding = PaddingValues(),
                         bottomOverlayPadding = capsuleOverlayPadding,
                         onManageServers = onManageServers,
@@ -329,6 +334,7 @@ private fun RootShell(
                         onPlaySongs = onPlaySongs,
                         onQueueSong = onQueueSong,
                         onPlaySongNext = onPlaySongNext,
+                        onOfflineSongUnavailable = onOfflineSongUnavailable,
                         onToggleSongDownload = onToggleSongDownload,
                         onOpenSettings = { onShowSettingsChange(true) },
                         onImportConfig = onImportConfig,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -749,6 +749,10 @@ class SakiAppViewModel @Inject constructor(
         }
     }
 
+    fun showOfflineSongUnavailable() {
+        snackbarMessages.tryEmit(SnackbarMessage(UiText.resource(R.string.message_song_unavailable_offline)))
+    }
+
     fun deleteCachedSong(cacheId: String) {
         viewModelScope.launch {
             runCatching {
@@ -1584,7 +1588,13 @@ data class EndpointStatus(
     val isForced: Boolean = false,
     val probeResults: List<EndpointProbeInfo> = emptyList(),
     val isProbing: Boolean = false,
-)
+) {
+    val isOfflineDegraded: Boolean
+        get() = !isProbing &&
+            activeEndpointId == null &&
+            probeResults.isNotEmpty() &&
+            probeResults.none { it.reachable }
+}
 
 data class EndpointProbeInfo(
     val id: Long,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -1591,7 +1591,6 @@ data class EndpointStatus(
 ) {
     val isOfflineDegraded: Boolean
         get() = !isProbing &&
-            activeEndpointId == null &&
             probeResults.isNotEmpty() &&
             probeResults.none { it.reachable }
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -75,6 +76,7 @@ fun ArtistDetailScreen(
     isLoading: Boolean,
     error: String?,
     bottomOverlayPadding: Dp = 0.dp,
+    isOfflineDegraded: Boolean = false,
     onOpenAlbum: (String) -> Unit,
     onPlaySongs: (List<Song>, Int) -> Unit,
     onShowActions: (Song) -> Unit,
@@ -98,12 +100,15 @@ fun ArtistDetailScreen(
                         )
                     }
                     itemsIndexed(topSongs, key = { _, s -> s.id }) { index, song ->
+                        val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
                         SongRow(
                             song = song,
                             server = server,
                             cachedSong = cachedSongsBySongId[song.id],
                             isStreamCached = song.id in streamCachedSongIds,
                             isDownloading = song.id in downloadingSongIds,
+                            isOfflineDegraded = isOfflineDegraded,
+                            isOfflinePlayable = isOfflinePlayable,
                             onClick = { onPlaySongs(topSongs, index) },
                             onMore = { onShowActions(song) },
                         )
@@ -139,6 +144,7 @@ fun AlbumDetailScreen(
     isLoading: Boolean,
     error: String?,
     bottomOverlayPadding: Dp = 0.dp,
+    isOfflineDegraded: Boolean = false,
     onPlaySongs: (List<Song>, Int) -> Unit,
     onShowActions: (Song) -> Unit,
 ) {
@@ -163,16 +169,31 @@ fun AlbumDetailScreen(
                         title = stringResource(R.string.library_track_list),
                         subtitle = album.genre ?: stringResource(R.string.library_album_details),
                         actionLabel = stringResource(R.string.library_play_album),
-                        onAction = { if (album.songs.isNotEmpty()) onPlaySongs(album.songs, 0) },
+                        onAction = {
+                            if (album.songs.isNotEmpty()) {
+                                val startIndex = if (isOfflineDegraded) {
+                                    album.songs.firstOfflinePlayableIndex(
+                                        cachedSongsBySongId,
+                                        streamCachedSongIds,
+                                    )
+                                } else {
+                                    0
+                                }
+                                onPlaySongs(album.songs, startIndex)
+                            }
+                        },
                     )
                 }
                 itemsIndexed(album.songs, key = { _, s -> s.id }) { index, song ->
+                    val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
                     SongRow(
                         song = song,
                         server = server,
                         cachedSong = cachedSongsBySongId[song.id],
                         isStreamCached = song.id in streamCachedSongIds,
                         isDownloading = song.id in downloadingSongIds,
+                        isOfflineDegraded = isOfflineDegraded,
+                        isOfflinePlayable = isOfflinePlayable,
                         onClick = { onPlaySongs(album.songs, index) },
                         onMore = { onShowActions(song) },
                     )
@@ -192,6 +213,7 @@ fun PlaylistDetailScreen(
     isLoading: Boolean,
     error: String?,
     bottomOverlayPadding: Dp = 0.dp,
+    isOfflineDegraded: Boolean = false,
     onPlaySongs: (List<Song>, Int) -> Unit,
     onShowActions: (Song) -> Unit,
 ) {
@@ -215,16 +237,31 @@ fun PlaylistDetailScreen(
                         title = stringResource(R.string.library_tracks),
                         subtitle = stringResource(R.string.library_playlist_sequence),
                         actionLabel = stringResource(R.string.library_play_playlist),
-                        onAction = { if (playlist.songs.isNotEmpty()) onPlaySongs(playlist.songs, 0) },
+                        onAction = {
+                            if (playlist.songs.isNotEmpty()) {
+                                val startIndex = if (isOfflineDegraded) {
+                                    playlist.songs.firstOfflinePlayableIndex(
+                                        cachedSongsBySongId,
+                                        streamCachedSongIds,
+                                    )
+                                } else {
+                                    0
+                                }
+                                onPlaySongs(playlist.songs, startIndex)
+                            }
+                        },
                     )
                 }
                 itemsIndexed(playlist.songs, key = { index, s -> "${s.id}_$index" }) { index, song ->
+                    val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
                     SongRow(
                         song = song,
                         server = server,
                         cachedSong = cachedSongsBySongId[song.id],
                         isStreamCached = song.id in streamCachedSongIds,
                         isDownloading = song.id in downloadingSongIds,
+                        isOfflineDegraded = isOfflineDegraded,
+                        isOfflinePlayable = isOfflinePlayable,
                         onClick = { onPlaySongs(playlist.songs, index) },
                         onMore = { onShowActions(song) },
                     )
@@ -411,6 +448,18 @@ private fun AlbumMiniCard(album: AlbumSummary, server: ServerConfig, onOpenAlbum
     }
 }
 
+private fun Song.isOfflinePlayable(
+    cachedSongsBySongId: Map<String, CachedSong>,
+    streamCachedSongIds: Set<String>,
+): Boolean = cachedSongsBySongId.containsKey(id) || id in streamCachedSongIds
+
+private fun List<Song>.firstOfflinePlayableIndex(
+    cachedSongsBySongId: Map<String, CachedSong>,
+    streamCachedSongIds: Set<String>,
+): Int = indexOfFirst { song ->
+    song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
+}
+
 @Composable
 fun SongRow(
     song: Song,
@@ -418,13 +467,17 @@ fun SongRow(
     cachedSong: CachedSong?,
     isStreamCached: Boolean,
     isDownloading: Boolean,
+    isOfflineDegraded: Boolean = false,
+    isOfflinePlayable: Boolean = true,
     onClick: () -> Unit,
     onMore: () -> Unit,
 ) {
+    val isUnavailableOffline = isOfflineDegraded && !isOfflinePlayable
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .clip(MaterialTheme.shapes.large)
+            .alpha(if (isUnavailableOffline) 0.5f else 1f)
             .clickable(onClick = onClick)
             .padding(vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -457,6 +510,13 @@ fun SongRow(
                     isDownloading -> CircularProgressIndicator(
                         modifier = Modifier.size(12.dp),
                         strokeWidth = 2.dp,
+                    )
+
+                    isUnavailableOffline -> Icon(
+                        Icons.Rounded.ErrorOutline,
+                        contentDescription = stringResource(R.string.library_unavailable_offline),
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
                 Text(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -145,6 +145,7 @@ fun AlbumDetailScreen(
     error: String?,
     bottomOverlayPadding: Dp = 0.dp,
     isOfflineDegraded: Boolean = false,
+    onOfflineSongUnavailable: () -> Unit = {},
     onPlaySongs: (List<Song>, Int) -> Unit,
     onShowActions: (Song) -> Unit,
 ) {
@@ -171,15 +172,19 @@ fun AlbumDetailScreen(
                         actionLabel = stringResource(R.string.library_play_album),
                         onAction = {
                             if (album.songs.isNotEmpty()) {
-                                val startIndex = if (isOfflineDegraded) {
-                                    album.songs.firstOfflinePlayableIndex(
+                                if (isOfflineDegraded) {
+                                    val startIndex = album.songs.firstOfflinePlayableIndexOrNull(
                                         cachedSongsBySongId,
                                         streamCachedSongIds,
                                     )
+                                    if (startIndex != null) {
+                                        onPlaySongs(album.songs, startIndex)
+                                    } else {
+                                        onOfflineSongUnavailable()
+                                    }
                                 } else {
-                                    0
+                                    onPlaySongs(album.songs, 0)
                                 }
-                                onPlaySongs(album.songs, startIndex)
                             }
                         },
                     )
@@ -214,6 +219,7 @@ fun PlaylistDetailScreen(
     error: String?,
     bottomOverlayPadding: Dp = 0.dp,
     isOfflineDegraded: Boolean = false,
+    onOfflineSongUnavailable: () -> Unit = {},
     onPlaySongs: (List<Song>, Int) -> Unit,
     onShowActions: (Song) -> Unit,
 ) {
@@ -239,15 +245,19 @@ fun PlaylistDetailScreen(
                         actionLabel = stringResource(R.string.library_play_playlist),
                         onAction = {
                             if (playlist.songs.isNotEmpty()) {
-                                val startIndex = if (isOfflineDegraded) {
-                                    playlist.songs.firstOfflinePlayableIndex(
+                                if (isOfflineDegraded) {
+                                    val startIndex = playlist.songs.firstOfflinePlayableIndexOrNull(
                                         cachedSongsBySongId,
                                         streamCachedSongIds,
                                     )
+                                    if (startIndex != null) {
+                                        onPlaySongs(playlist.songs, startIndex)
+                                    } else {
+                                        onOfflineSongUnavailable()
+                                    }
                                 } else {
-                                    0
+                                    onPlaySongs(playlist.songs, 0)
                                 }
-                                onPlaySongs(playlist.songs, startIndex)
                             }
                         },
                     )
@@ -446,18 +456,6 @@ private fun AlbumMiniCard(album: AlbumSummary, server: ServerConfig, onOpenAlbum
             )
         }
     }
-}
-
-private fun Song.isOfflinePlayable(
-    cachedSongsBySongId: Map<String, CachedSong>,
-    streamCachedSongIds: Set<String>,
-): Boolean = cachedSongsBySongId.containsKey(id) || id in streamCachedSongIds
-
-private fun List<Song>.firstOfflinePlayableIndex(
-    cachedSongsBySongId: Map<String, CachedSong>,
-    streamCachedSongIds: Set<String>,
-): Int = indexOfFirst { song ->
-    song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
 }
 
 @Composable

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -116,6 +117,7 @@ import kotlinx.coroutines.flow.map
 @Composable
 fun BrowseScreen(
     uiState: SakiAppUiState,
+    isOfflineDegraded: Boolean,
     contentPadding: PaddingValues,
     bottomOverlayPadding: Dp = 0.dp,
     onManageServers: () -> Unit,
@@ -137,6 +139,7 @@ fun BrowseScreen(
     onPlaySongs: (List<Song>, Int) -> Unit,
     onQueueSong: (Song) -> Unit,
     onPlaySongNext: (Song) -> Unit,
+    onOfflineSongUnavailable: () -> Unit,
     onToggleSongDownload: (Song) -> Unit,
     onOpenSettings: () -> Unit,
     onImportConfig: (android.net.Uri) -> Unit,
@@ -151,6 +154,17 @@ fun BrowseScreen(
     }
     var actionSong by remember { mutableStateOf<Song?>(null) }
     var detailSong by remember { mutableStateOf<Song?>(null) }
+    val offlineAwarePlaySongs: (List<Song>, Int) -> Unit = { songs, startIndex ->
+        playOfflineAwareSongs(
+            songs = songs,
+            startIndex = startIndex,
+            isOfflineDegraded = isOfflineDegraded,
+            cachedSongsBySongId = cachedSongsBySongId,
+            streamCachedSongIds = uiState.streamCachedSongIds,
+            onPlaySongs = onPlaySongs,
+            onUnavailable = onOfflineSongUnavailable,
+        )
+    }
 
     BackHandler(
         enabled = uiState.selectedArtist != null ||
@@ -184,6 +198,9 @@ fun BrowseScreen(
                 onImportBackup = { importLauncher.launch(arrayOf("application/json", "*/*")) },
             )
         } else {
+            if (isOfflineDegraded) {
+                OfflineModeBanner(modifier = Modifier.padding(top = 10.dp, bottom = 2.dp))
+            }
             AnimatedContent(
                 targetState = BrowseDetailTarget(
                     hasArtist = uiState.selectedArtist != null,
@@ -216,7 +233,8 @@ fun BrowseScreen(
                         isLoading = uiState.isAlbumLoading,
                         error = uiState.albumError?.asString(),
                         bottomOverlayPadding = bottomOverlayPadding,
-                        onPlaySongs = onPlaySongs,
+                        isOfflineDegraded = isOfflineDegraded,
+                        onPlaySongs = offlineAwarePlaySongs,
                         onShowActions = { actionSong = it },
                     )
 
@@ -230,8 +248,9 @@ fun BrowseScreen(
                         isLoading = uiState.isArtistLoading,
                         error = uiState.artistError?.asString(),
                         bottomOverlayPadding = bottomOverlayPadding,
+                        isOfflineDegraded = isOfflineDegraded,
                         onOpenAlbum = onOpenAlbum,
-                        onPlaySongs = onPlaySongs,
+                        onPlaySongs = offlineAwarePlaySongs,
                         onShowActions = { actionSong = it },
                     )
 
@@ -244,7 +263,8 @@ fun BrowseScreen(
                         isLoading = uiState.isPlaylistLoading,
                         error = uiState.playlistError?.asString(),
                         bottomOverlayPadding = bottomOverlayPadding,
-                        onPlaySongs = onPlaySongs,
+                        isOfflineDegraded = isOfflineDegraded,
+                        onPlaySongs = offlineAwarePlaySongs,
                         onShowActions = { actionSong = it },
                     )
 
@@ -253,6 +273,7 @@ fun BrowseScreen(
                         uiState = uiState,
                         currentServer = currentServer,
                         cachedSongsBySongId = cachedSongsBySongId,
+                        isOfflineDegraded = isOfflineDegraded,
                         bottomOverlayPadding = bottomOverlayPadding,
                         onSelectBrowseSection = onSelectBrowseSection,
                         onSetSearchActive = onSetSearchActive,
@@ -267,6 +288,7 @@ fun BrowseScreen(
                         onOpenAlbum = onOpenAlbum,
                         onOpenPlaylist = onOpenPlaylist,
                         onPlaySongs = onPlaySongs,
+                        onOfflineSongUnavailable = onOfflineSongUnavailable,
                         onShowSongActions = { actionSong = it },
                         onOpenSettings = onOpenSettings,
                     )
@@ -276,17 +298,30 @@ fun BrowseScreen(
     }
 
     actionSong?.let { song ->
+        val isDownloaded = cachedSongsBySongId.containsKey(song.id)
+        val isOfflinePlayable = song.isOfflinePlayable(
+            cachedSongsBySongId = cachedSongsBySongId,
+            streamCachedSongIds = uiState.streamCachedSongIds,
+        )
         SongActionsSheet(
             song = song,
-            isDownloaded = cachedSongsBySongId.containsKey(song.id),
+            isDownloaded = isDownloaded,
             isDownloading = song.id in uiState.downloadingSongIds,
             onDismiss = { actionSong = null },
             onPlayNext = {
-                onPlaySongNext(song)
+                if (isOfflineDegraded && !isOfflinePlayable) {
+                    onOfflineSongUnavailable()
+                } else {
+                    onPlaySongNext(song)
+                }
                 actionSong = null
             },
             onToggleDownload = {
-                onToggleSongDownload(song)
+                if (isOfflineDegraded && !isDownloaded) {
+                    onOfflineSongUnavailable()
+                } else {
+                    onToggleSongDownload(song)
+                }
                 actionSong = null
             },
             onDetails = {
@@ -294,7 +329,11 @@ fun BrowseScreen(
                 actionSong = null
             },
             onQueueSong = {
-                onQueueSong(song)
+                if (isOfflineDegraded && !isOfflinePlayable) {
+                    onOfflineSongUnavailable()
+                } else {
+                    onQueueSong(song)
+                }
                 actionSong = null
             },
         )
@@ -311,6 +350,23 @@ private data class BrowseDetailTarget(
     val hasPlaylist: Boolean,
 )
 
+@Composable
+private fun OfflineModeBanner(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.92f),
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+    ) {
+        Text(
+            text = stringResource(R.string.browse_offline_degraded_banner),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            style = MaterialTheme.typography.bodySmall,
+            maxLines = 2,
+        )
+    }
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun BrowsePager(
@@ -318,6 +374,7 @@ private fun BrowsePager(
     uiState: SakiAppUiState,
     currentServer: ServerConfig,
     cachedSongsBySongId: Map<String, CachedSong>,
+    isOfflineDegraded: Boolean,
     bottomOverlayPadding: Dp,
     onSelectBrowseSection: (BrowseSection) -> Unit,
     onSetSearchActive: (Boolean) -> Unit,
@@ -332,6 +389,7 @@ private fun BrowsePager(
     onOpenAlbum: (String) -> Unit,
     onOpenPlaylist: (String) -> Unit,
     onPlaySongs: (List<Song>, Int) -> Unit,
+    onOfflineSongUnavailable: () -> Unit,
     onShowSongActions: (Song) -> Unit,
     onOpenSettings: () -> Unit,
 ) {
@@ -381,6 +439,7 @@ private fun BrowsePager(
                 cachedSongsBySongId = cachedSongsBySongId,
                 streamCachedSongIds = uiState.streamCachedSongIds,
                 downloadingSongIds = uiState.downloadingSongIds,
+                isOfflineDegraded = isOfflineDegraded,
                 bottomOverlayPadding = bottomOverlayPadding,
                 onSearchQuery = onUpdateSearchQuery,
                 onRemoveRecentSearchQuery = onRemoveRecentSearchQuery,
@@ -388,6 +447,7 @@ private fun BrowsePager(
                 onOpenArtist = onOpenArtist,
                 onOpenAlbum = onOpenAlbum,
                 onPlaySongs = onPlaySongs,
+                onOfflineSongUnavailable = onOfflineSongUnavailable,
                 onShowSongActions = onShowSongActions,
             )
         } else {
@@ -471,10 +531,12 @@ private fun BrowsePager(
                                 cachedSongsBySongId = cachedSongsBySongId,
                                 streamCachedSongIds = uiState.streamCachedSongIds,
                                 downloadingSongIds = uiState.downloadingSongIds,
+                                isOfflineDegraded = isOfflineDegraded,
                                 isLoading = uiState.isSongsLoading,
                                 error = uiState.songsError?.asString(),
                                 bottomOverlayPadding = bottomOverlayPadding,
                                 onPlaySongs = onPlaySongs,
+                                onOfflineSongUnavailable = onOfflineSongUnavailable,
                                 onShowSongActions = onShowSongActions,
                             )
                         }
@@ -555,6 +617,7 @@ private fun SearchResultsPage(
     cachedSongsBySongId: Map<String, CachedSong>,
     streamCachedSongIds: Set<String>,
     downloadingSongIds: Set<String>,
+    isOfflineDegraded: Boolean,
     bottomOverlayPadding: Dp,
     onSearchQuery: (String) -> Unit,
     onRemoveRecentSearchQuery: (String) -> Unit,
@@ -562,6 +625,7 @@ private fun SearchResultsPage(
     onOpenArtist: (String) -> Unit,
     onOpenAlbum: (String) -> Unit,
     onPlaySongs: (List<Song>, Int) -> Unit,
+    onOfflineSongUnavailable: () -> Unit,
     onShowSongActions: (Song) -> Unit,
 ) {
     val trimmedQuery = query.trim()
@@ -656,13 +720,26 @@ private fun SearchResultsPage(
                         )
                     }
                     itemsIndexed(visibleSongs, key = { _, s -> "song-${s.id}" }) { index, song ->
+                        val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
                         SongRow(
                             song = song,
                             server = currentServer,
                             cachedSong = cachedSongsBySongId[song.id],
                             isStreamCached = song.id in streamCachedSongIds,
                             isDownloading = song.id in downloadingSongIds,
-                            onClick = { onPlaySongs(results.songs, index) },
+                            isOfflineDegraded = isOfflineDegraded,
+                            isOfflinePlayable = isOfflinePlayable,
+                            onClick = {
+                                playOfflineAwareSongs(
+                                    songs = results.songs,
+                                    startIndex = index,
+                                    isOfflineDegraded = isOfflineDegraded,
+                                    cachedSongsBySongId = cachedSongsBySongId,
+                                    streamCachedSongIds = streamCachedSongIds,
+                                    onPlaySongs = onPlaySongs,
+                                    onUnavailable = onOfflineSongUnavailable,
+                                )
+                            },
                             onMore = { onShowSongActions(song) },
                         )
                     }
@@ -1292,10 +1369,12 @@ private fun SongsPage(
     cachedSongsBySongId: Map<String, CachedSong>,
     streamCachedSongIds: Set<String>,
     downloadingSongIds: Set<String>,
+    isOfflineDegraded: Boolean,
     isLoading: Boolean,
     error: String?,
     bottomOverlayPadding: Dp,
     onPlaySongs: (List<Song>, Int) -> Unit,
+    onOfflineSongUnavailable: () -> Unit,
     onShowSongActions: (Song) -> Unit,
 ) {
     if (isLoading && songs.isEmpty()) {
@@ -1318,16 +1397,64 @@ private fun SongsPage(
         contentPadding = bottomContentPadding(bottomOverlayPadding),
     ) {
         itemsIndexed(songs, key = { _, s -> s.id }) { index, song ->
+            val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
             SongRow(
                 song = song,
                 server = server,
                 cachedSong = cachedSongsBySongId[song.id],
                 isStreamCached = song.id in streamCachedSongIds,
                 isDownloading = song.id in downloadingSongIds,
-                onClick = { onPlaySongs(songs, index) },
+                isOfflineDegraded = isOfflineDegraded,
+                isOfflinePlayable = isOfflinePlayable,
+                onClick = {
+                    playOfflineAwareSongs(
+                        songs = songs,
+                        startIndex = index,
+                        isOfflineDegraded = isOfflineDegraded,
+                        cachedSongsBySongId = cachedSongsBySongId,
+                        streamCachedSongIds = streamCachedSongIds,
+                        onPlaySongs = onPlaySongs,
+                        onUnavailable = onOfflineSongUnavailable,
+                    )
+                },
                 onMore = { onShowSongActions(song) },
             )
         }
+    }
+}
+
+private fun Song.isOfflinePlayable(
+    cachedSongsBySongId: Map<String, CachedSong>,
+    streamCachedSongIds: Set<String>,
+): Boolean = id in cachedSongsBySongId || id in streamCachedSongIds
+
+private fun playOfflineAwareSongs(
+    songs: List<Song>,
+    startIndex: Int,
+    isOfflineDegraded: Boolean,
+    cachedSongsBySongId: Map<String, CachedSong>,
+    streamCachedSongIds: Set<String>,
+    onPlaySongs: (List<Song>, Int) -> Unit,
+    onUnavailable: () -> Unit,
+) {
+    if (!isOfflineDegraded) {
+        onPlaySongs(songs, startIndex)
+        return
+    }
+    val startSong = songs.getOrNull(startIndex)
+    if (startSong == null || !startSong.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)) {
+        onUnavailable()
+        return
+    }
+
+    val playableSongs = songs.filter { song -> song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds) }
+    val playableStartIndex = songs.take(startIndex).count { song ->
+        song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
+    }
+    if (playableSongs.isEmpty()) {
+        onUnavailable()
+    } else {
+        onPlaySongs(playableSongs, playableStartIndex)
     }
 }
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -234,6 +234,7 @@ fun BrowseScreen(
                         error = uiState.albumError?.asString(),
                         bottomOverlayPadding = bottomOverlayPadding,
                         isOfflineDegraded = isOfflineDegraded,
+                        onOfflineSongUnavailable = onOfflineSongUnavailable,
                         onPlaySongs = offlineAwarePlaySongs,
                         onShowActions = { actionSong = it },
                     )
@@ -264,6 +265,7 @@ fun BrowseScreen(
                         error = uiState.playlistError?.asString(),
                         bottomOverlayPadding = bottomOverlayPadding,
                         isOfflineDegraded = isOfflineDegraded,
+                        onOfflineSongUnavailable = onOfflineSongUnavailable,
                         onPlaySongs = offlineAwarePlaySongs,
                         onShowActions = { actionSong = it },
                     )
@@ -1422,11 +1424,6 @@ private fun SongsPage(
         }
     }
 }
-
-private fun Song.isOfflinePlayable(
-    cachedSongsBySongId: Map<String, CachedSong>,
-    streamCachedSongIds: Set<String>,
-): Boolean = id in cachedSongsBySongId || id in streamCachedSongIds
 
 private fun playOfflineAwareSongs(
     songs: List<Song>,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/OfflinePlaybackAvailability.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/OfflinePlaybackAvailability.kt
@@ -1,0 +1,19 @@
+package org.hdhmc.saki.presentation.library
+
+import org.hdhmc.saki.domain.model.CachedSong
+import org.hdhmc.saki.domain.model.Song
+
+internal fun Song.isOfflinePlayable(
+    cachedSongsBySongId: Map<String, CachedSong>,
+    streamCachedSongIds: Set<String>,
+): Boolean = id in cachedSongsBySongId || id in streamCachedSongIds
+
+internal fun List<Song>.firstOfflinePlayableIndexOrNull(
+    cachedSongsBySongId: Map<String, CachedSong>,
+    streamCachedSongIds: Set<String>,
+): Int? {
+    val index = indexOfFirst { song ->
+        song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
+    }
+    return index.takeIf { it >= 0 }
+}

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -128,6 +128,7 @@
     <string name="library_playlist_sequence">播放列表顺序</string>
     <string name="library_play_playlist">播放列表</string>
     <string name="library_available_offline">可离线播放</string>
+    <string name="library_unavailable_offline">离线不可用</string>
     <string name="library_unknown_artist_album">未知艺术家 · 未知专辑</string>
     <string name="library_more_actions">更多操作</string>
     <string name="library_play_next">下一首播放</string>
@@ -168,6 +169,7 @@
     <string name="browse_needs_server_body">请先添加 Subsonic 服务器，然后浏览艺术家、专辑、播放列表和歌曲。</string>
     <string name="browse_add_server">添加服务器</string>
     <string name="browse_import_backup">导入备份</string>
+    <string name="browse_offline_degraded_banner">离线模式 - 正在显示缓存数据。仅已下载或完整缓存的歌曲可播放。</string>
     <string name="browse_search_placeholder">搜索 %1$s</string>
     <string name="browse_close_search">关闭搜索</string>
     <string name="browse_search_server">搜索此服务器</string>
@@ -259,6 +261,7 @@
     <string name="error_cache_song">无法缓存歌曲。</string>
     <string name="error_play_cached_song">无法播放缓存歌曲。</string>
     <string name="error_start_offline_playback">无法开始离线播放。</string>
+    <string name="message_song_unavailable_offline">这首歌当前无法离线播放。</string>
     <string name="message_removed_cached_file">已移除缓存文件。</string>
     <string name="error_remove_cached_file">无法移除缓存文件。</string>
     <string name="message_no_downloads_to_clear">没有可清除的下载。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
     <string name="library_playlist_sequence">Playlist sequence</string>
     <string name="library_play_playlist">Play playlist</string>
     <string name="library_available_offline">Available offline</string>
+    <string name="library_unavailable_offline">Unavailable offline</string>
     <string name="library_unknown_artist_album">Unknown artist • Unknown album</string>
     <string name="library_more_actions">More actions</string>
     <string name="library_play_next">Play next</string>
@@ -176,6 +177,7 @@
     <string name="browse_needs_server_body">Add a Subsonic server first, then swipe through artists, albums, playlists, and songs.</string>
     <string name="browse_add_server">Add server</string>
     <string name="browse_import_backup">Import backup</string>
+    <string name="browse_offline_degraded_banner">Offline - showing cached data. Only downloaded or fully cached songs can play.</string>
     <string name="browse_search_placeholder">Search %1$s</string>
     <string name="browse_close_search">Close search</string>
     <string name="browse_search_server">Search this server</string>
@@ -267,6 +269,7 @@
     <string name="error_cache_song">Unable to cache the song.</string>
     <string name="error_play_cached_song">Unable to play the cached song.</string>
     <string name="error_start_offline_playback">Unable to start offline playback.</string>
+    <string name="message_song_unavailable_offline">This song is not available offline.</string>
     <string name="message_removed_cached_file">Removed cached file.</string>
     <string name="error_remove_cached_file">Unable to remove the cached file.</string>
     <string name="message_no_downloads_to_clear">No downloads to clear.</string>


### PR DESCRIPTION
## Summary

Implements the first phase of #108 by adding an offline degraded browsing state when all endpoints are unreachable.

## Changes

- Detect offline degraded mode from endpoint probe results, including forced-endpoint cases.
- Show an offline banner in Browse when the server is unreachable but cached data is still available.
- Mark songs that are not playable offline with a dimmed row state and unavailable icon.
- Gate offline playback actions so only downloaded songs or fully stream-cached songs can start playback.
- Filter offline playback queues to playable songs only.
- Show a snackbar when the user tries to play, queue, or play-next a song that is unavailable offline.
- Share offline-playability helper logic across Browse screens to keep the behavior consistent.

#108
