### PR TITLE
feat: restore playback queue from local snapshot

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/FileLocalPlayQueueRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/FileLocalPlayQueueRepository.kt
@@ -1,0 +1,153 @@
+package org.hdhmc.saki.data.repository
+
+import android.content.Context
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import org.hdhmc.saki.di.IoDispatcher
+import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshot
+import org.hdhmc.saki.domain.model.Song
+import org.hdhmc.saki.domain.repository.LocalPlayQueueRepository
+
+@Singleton
+class FileLocalPlayQueueRepository @Inject constructor(
+    @param:ApplicationContext context: Context,
+    moshi: Moshi,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : LocalPlayQueueRepository {
+    private val directory = File(context.filesDir, "play_queue_snapshots")
+    private val adapter = moshi.adapter(LocalPlayQueueSnapshotDto::class.java)
+
+    override suspend fun get(serverId: Long): LocalPlayQueueSnapshot? = withContext(ioDispatcher) {
+        val file = snapshotFile(serverId)
+        if (!file.isFile) return@withContext null
+        runCatching {
+            adapter.fromJson(file.readText())?.toDomain()
+        }.getOrNull()
+    }
+
+    override suspend fun save(snapshot: LocalPlayQueueSnapshot): Unit = withContext(ioDispatcher) {
+        if (snapshot.songs.isEmpty()) {
+            snapshotFile(snapshot.serverId).delete()
+            return@withContext
+        }
+        directory.mkdirs()
+        val target = snapshotFile(snapshot.serverId)
+        val temp = File(directory, "${target.name}.tmp")
+        temp.writeText(adapter.toJson(snapshot.toDto()))
+        if (target.exists() && !target.delete()) {
+            temp.delete()
+            error("Unable to replace local play queue snapshot for server ${snapshot.serverId}.")
+        }
+        if (!temp.renameTo(target)) {
+            temp.delete()
+            error("Unable to write local play queue snapshot for server ${snapshot.serverId}.")
+        }
+    }
+
+    override suspend fun clear(serverId: Long): Unit = withContext(ioDispatcher) {
+        snapshotFile(serverId).delete()
+    }
+
+    private fun snapshotFile(serverId: Long): File = File(directory, "server_$serverId.json")
+}
+
+@JsonClass(generateAdapter = true)
+internal data class LocalPlayQueueSnapshotDto(
+    val serverId: Long,
+    val songs: List<LocalPlayQueueSongDto>,
+    val currentSongId: String?,
+    val positionMs: Long,
+    val updatedAt: Long,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class LocalPlayQueueSongDto(
+    val id: String,
+    val parentId: String?,
+    val title: String,
+    val album: String?,
+    val albumId: String?,
+    val artist: String?,
+    val artistId: String?,
+    val coverArtId: String?,
+    val durationSeconds: Int?,
+    val track: Int?,
+    val discNumber: Int?,
+    val year: Int?,
+    val genre: String?,
+    val bitRate: Int?,
+    val sampleRate: Int?,
+    val suffix: String?,
+    val contentType: String?,
+    val sizeBytes: Long?,
+    val path: String?,
+    val created: String?,
+)
+
+private fun LocalPlayQueueSnapshot.toDto() = LocalPlayQueueSnapshotDto(
+    serverId = serverId,
+    songs = songs.map(Song::toDto),
+    currentSongId = currentSongId,
+    positionMs = positionMs,
+    updatedAt = updatedAt,
+)
+
+private fun LocalPlayQueueSnapshotDto.toDomain() = LocalPlayQueueSnapshot(
+    serverId = serverId,
+    songs = songs.map(LocalPlayQueueSongDto::toDomain),
+    currentSongId = currentSongId,
+    positionMs = positionMs,
+    updatedAt = updatedAt,
+)
+
+private fun Song.toDto() = LocalPlayQueueSongDto(
+    id = id,
+    parentId = parentId,
+    title = title,
+    album = album,
+    albumId = albumId,
+    artist = artist,
+    artistId = artistId,
+    coverArtId = coverArtId,
+    durationSeconds = durationSeconds,
+    track = track,
+    discNumber = discNumber,
+    year = year,
+    genre = genre,
+    bitRate = bitRate,
+    sampleRate = sampleRate,
+    suffix = suffix,
+    contentType = contentType,
+    sizeBytes = sizeBytes,
+    path = path,
+    created = created,
+)
+
+private fun LocalPlayQueueSongDto.toDomain() = Song(
+    id = id,
+    parentId = parentId,
+    title = title,
+    album = album,
+    albumId = albumId,
+    artist = artist,
+    artistId = artistId,
+    coverArtId = coverArtId,
+    durationSeconds = durationSeconds,
+    track = track,
+    discNumber = discNumber,
+    year = year,
+    genre = genre,
+    bitRate = bitRate,
+    sampleRate = sampleRate,
+    suffix = suffix,
+    contentType = contentType,
+    sizeBytes = sizeBytes,
+    path = path,
+    created = created,
+)

--- a/app/src/main/java/org/hdhmc/saki/data/repository/FileLocalPlayQueueRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/FileLocalPlayQueueRepository.kt
@@ -15,17 +15,26 @@ import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.domain.repository.LocalPlayQueueRepository
 
 @Singleton
-class FileLocalPlayQueueRepository @Inject constructor(
-    @param:ApplicationContext context: Context,
+class FileLocalPlayQueueRepository internal constructor(
+    private val directory: File,
     moshi: Moshi,
-    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : LocalPlayQueueRepository {
-    private val directory = File(context.filesDir, "play_queue_snapshots")
     private val adapter = moshi.adapter(LocalPlayQueueSnapshotDto::class.java)
 
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+        moshi: Moshi,
+        @IoDispatcher ioDispatcher: CoroutineDispatcher,
+    ) : this(
+        directory = File(context.filesDir, SNAPSHOT_DIRECTORY),
+        moshi = moshi,
+        ioDispatcher = ioDispatcher,
+    )
+
     override suspend fun get(serverId: Long): LocalPlayQueueSnapshot? = withContext(ioDispatcher) {
-        val file = snapshotFile(serverId)
-        if (!file.isFile) return@withContext null
+        val file = readableSnapshotFile(serverId) ?: return@withContext null
         runCatching {
             adapter.fromJson(file.readText())?.toDomain()
         }.getOrNull()
@@ -34,27 +43,68 @@ class FileLocalPlayQueueRepository @Inject constructor(
     override suspend fun save(snapshot: LocalPlayQueueSnapshot): Unit = withContext(ioDispatcher) {
         if (snapshot.songs.isEmpty()) {
             snapshotFile(snapshot.serverId).delete()
+            snapshotBackupFile(snapshot.serverId).delete()
             return@withContext
         }
         directory.mkdirs()
         val target = snapshotFile(snapshot.serverId)
-        val temp = File(directory, "${target.name}.tmp")
-        temp.writeText(adapter.toJson(snapshot.toDto()))
-        if (target.exists() && !target.delete()) {
-            temp.delete()
-            error("Unable to replace local play queue snapshot for server ${snapshot.serverId}.")
-        }
-        if (!temp.renameTo(target)) {
-            temp.delete()
-            error("Unable to write local play queue snapshot for server ${snapshot.serverId}.")
-        }
+        writeSnapshotFile(
+            target = target,
+            backup = snapshotBackupFile(snapshot.serverId),
+            json = adapter.toJson(snapshot.toDto()),
+            serverId = snapshot.serverId,
+        )
     }
 
     override suspend fun clear(serverId: Long): Unit = withContext(ioDispatcher) {
         snapshotFile(serverId).delete()
+        snapshotBackupFile(serverId).delete()
     }
 
     private fun snapshotFile(serverId: Long): File = File(directory, "server_$serverId.json")
+
+    private fun snapshotBackupFile(serverId: Long): File = File(directory, "server_$serverId.json.bak")
+
+    private fun readableSnapshotFile(serverId: Long): File? {
+        val target = snapshotFile(serverId)
+        if (target.isFile) return target
+
+        val backup = snapshotBackupFile(serverId)
+        if (!backup.isFile) return null
+        backup.renameTo(target)
+        return if (target.isFile) target else backup
+    }
+
+    private fun writeSnapshotFile(
+        target: File,
+        backup: File,
+        json: String,
+        serverId: Long,
+    ) {
+        val temp = File.createTempFile("${target.name}.", ".tmp", directory)
+        try {
+            temp.writeText(json)
+            if (backup.exists() && !backup.delete()) {
+                error("Unable to clear stale local play queue snapshot backup for server $serverId.")
+            }
+            if (target.exists() && !target.renameTo(backup)) {
+                error("Unable to prepare local play queue snapshot replacement for server $serverId.")
+            }
+            if (!temp.renameTo(target)) {
+                if (backup.exists() && !target.exists()) {
+                    backup.renameTo(target)
+                }
+                error("Unable to write local play queue snapshot for server $serverId.")
+            }
+            backup.delete()
+        } finally {
+            temp.delete()
+        }
+    }
+
+    private companion object {
+        const val SNAPSHOT_DIRECTORY = "play_queue_snapshots"
+    }
 }
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/org/hdhmc/saki/di/RepositoryModule.kt
+++ b/app/src/main/java/org/hdhmc/saki/di/RepositoryModule.kt
@@ -9,9 +9,11 @@ import org.hdhmc.saki.data.repository.DefaultLibraryCacheRepository
 import org.hdhmc.saki.data.repository.DefaultServerConfigRepository
 import org.hdhmc.saki.data.repository.DefaultStreamCacheRepository
 import org.hdhmc.saki.data.repository.DefaultSubsonicRepository
+import org.hdhmc.saki.data.repository.FileLocalPlayQueueRepository
 import org.hdhmc.saki.domain.repository.AppPreferencesRepository
 import org.hdhmc.saki.domain.repository.CachedSongRepository
 import org.hdhmc.saki.domain.repository.LibraryCacheRepository
+import org.hdhmc.saki.domain.repository.LocalPlayQueueRepository
 import org.hdhmc.saki.domain.repository.PlaybackManager
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
 import org.hdhmc.saki.domain.repository.ServerConfigRepository
@@ -61,6 +63,11 @@ abstract class RepositoryModule {
     abstract fun bindLibraryCacheRepository(
         repository: DefaultLibraryCacheRepository,
     ): LibraryCacheRepository
+
+    @Binds
+    abstract fun bindLocalPlayQueueRepository(
+        repository: FileLocalPlayQueueRepository,
+    ): LocalPlayQueueRepository
 
     @Binds
     @UnstableApi

--- a/app/src/main/java/org/hdhmc/saki/domain/model/LocalPlayQueueSnapshot.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/LocalPlayQueueSnapshot.kt
@@ -1,0 +1,9 @@
+package org.hdhmc.saki.domain.model
+
+data class LocalPlayQueueSnapshot(
+    val serverId: Long,
+    val songs: List<Song>,
+    val currentSongId: String?,
+    val positionMs: Long,
+    val updatedAt: Long,
+)

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/LocalPlayQueueRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/LocalPlayQueueRepository.kt
@@ -1,0 +1,11 @@
+package org.hdhmc.saki.domain.repository
+
+import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshot
+
+interface LocalPlayQueueRepository {
+    suspend fun get(serverId: Long): LocalPlayQueueSnapshot?
+
+    suspend fun save(snapshot: LocalPlayQueueSnapshot)
+
+    suspend fun clear(serverId: Long)
+}

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -13,6 +13,7 @@ import androidx.media3.session.MediaController
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.ListenableFuture
+import org.hdhmc.saki.data.remote.EndpointSelector
 import org.hdhmc.saki.data.remote.NetworkType
 import org.hdhmc.saki.data.remote.NetworkTypeProvider
 import org.hdhmc.saki.di.DefaultDispatcher
@@ -63,6 +64,7 @@ class DefaultPlaybackManager @Inject constructor(
     private val cachedSongRepository: CachedSongRepository,
     private val streamCacheRepository: StreamCacheRepository,
     private val networkTypeProvider: NetworkTypeProvider,
+    private val endpointSelector: EndpointSelector,
 ) : PlaybackManager {
     private val scope = CoroutineScope(SupervisorJob() + mainDispatcher)
     private val controllerMutex = Mutex()
@@ -102,10 +104,23 @@ class DefaultPlaybackManager @Inject constructor(
         }
     }
 
+    private fun playbackQuality(serverId: Long): StreamQuality {
+        return if (shouldPreferLocalCache(serverId)) {
+            StreamQuality.entries.last()
+        } else {
+            effectiveQuality()
+        }
+    }
+
+    private fun shouldPreferLocalCache(serverId: Long): Boolean {
+        val probeResults = endpointSelector.getLastProbeResults(serverId)
+        return probeResults.isNotEmpty() && probeResults.none { result -> result.reachable }
+    }
+
     private fun resolveQualityForSong(
         serverId: Long,
         songId: String,
-        preferred: StreamQuality = effectiveQuality(),
+        preferred: StreamQuality,
     ): StreamQuality {
         val cachedKey = streamCacheRepository.findCachedQualityKey(serverId, songId, preferred)
         return if (cachedKey != null) StreamQuality.fromStorageKey(cachedKey) else preferred
@@ -132,7 +147,7 @@ class DefaultPlaybackManager @Inject constructor(
     }
 
     private suspend fun PlaybackRequest.toPreferredMediaItemOrNull(): MediaItem? {
-        val preferredQuality = effectiveQuality()
+        val preferredQuality = playbackQuality(serverId)
         val cachedSong = cachedSongRepository.getPlayableCachedSong(serverId, songId, preferredQuality)
         if (cachedSong != null) {
             return cachedSong.toCachedMediaItem()
@@ -214,7 +229,7 @@ class DefaultPlaybackManager @Inject constructor(
         require(songs.isNotEmpty()) { "Playback queue cannot be empty." }
         val safeStartIndex = startIndex.coerceIn(songs.indices)
         val startSong = songs[safeStartIndex]
-        val preferredQuality = effectiveQuality()
+        val preferredQuality = playbackQuality(serverId)
         val startCachedSong = cachedSongRepository.getPlayableCachedSong(serverId, startSong.id, preferredQuality)
         val startMediaItem = startSong.toPreferredMediaItem(
             serverId = serverId,
@@ -397,7 +412,7 @@ class DefaultPlaybackManager @Inject constructor(
         if (songs.isEmpty()) return
         cancelDeferredQueueLoad()
         shuffleDisplayOrder = null
-        val preferredQuality = effectiveQuality()
+        val preferredQuality = playbackQuality(serverId)
         val cachedSongsById = cachedSongRepository.getPlayableCachedSongs(serverId, preferredQuality)
         val mediaItems = songs.map { song ->
             song.toPreferredMediaItem(
@@ -455,7 +470,7 @@ class DefaultPlaybackManager @Inject constructor(
         if (songs.isEmpty()) return
         cancelDeferredQueueLoad(clearPendingShuffleState = true)
         clearShuffleIfActive()
-        val preferredQuality = effectiveQuality()
+        val preferredQuality = playbackQuality(serverId)
         val cachedSongsById = cachedSongRepository.getPlayableCachedSongs(serverId, preferredQuality)
         val mediaItems = songs.map { song ->
             song.toPreferredMediaItem(
@@ -477,7 +492,7 @@ class DefaultPlaybackManager @Inject constructor(
     ) {
         cancelDeferredQueueLoad(clearPendingShuffleState = true)
         clearShuffleIfActive()
-        val preferredQuality = effectiveQuality()
+        val preferredQuality = playbackQuality(serverId)
         val cachedSong = cachedSongRepository.getPlayableCachedSong(serverId, song.id, preferredQuality)
         val mediaItem = song.toPreferredMediaItem(
             serverId = serverId,
@@ -728,7 +743,7 @@ class DefaultPlaybackManager @Inject constructor(
         val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
         val cachedQualityKey = if (currentRequest != null && !currentRequest.isCached && cacheReady) {
             streamCacheRepository.findCachedQualityKey(
-                currentRequest.serverId, currentRequest.songId, effectiveQuality(),
+                currentRequest.serverId, currentRequest.songId, playbackQuality(currentRequest.serverId),
             )
         } else null
         val streamCached = cachedQualityKey != null
@@ -742,7 +757,7 @@ class DefaultPlaybackManager @Inject constructor(
                     val quality = if (streamCached) {
                         org.hdhmc.saki.domain.model.StreamQuality.fromStorageKey(cachedQualityKey!!)
                     } else {
-                        effectiveQuality()
+                        currentRequest?.let { request -> playbackQuality(request.serverId) } ?: effectiveQuality()
                     }
                     item.copy(
                         qualityLabel = quality.label,

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -735,12 +735,19 @@ class DefaultPlaybackManager @Inject constructor(
         val displayOrder = shuffleDisplayOrder
         val (displayQueue, displayIndex) = if (displayOrder != null && queue.isNotEmpty()) {
             val shuffled = displayOrder.mapNotNull { queue.getOrNull(it) }
-            shuffled to playerToDisplay(playerIndex)
+            val mappedIndex = playerToDisplay(playerIndex)
+            val currentPlayerItem = player.currentMediaItem?.toQueueItemOrNull()
+            val reconciledIndex = currentPlayerItem?.let { current ->
+                shuffled.indexOfFirst { item -> item.songId == current.songId }
+                    .takeIf { index -> index >= 0 }
+            } ?: mappedIndex
+            shuffled to reconciledIndex
         } else {
             queue to playerIndex
         }
 
         val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
+        val currentPlayerItem = player.currentMediaItem?.toQueueItemOrNull()
         val cachedQualityKey = if (currentRequest != null && !currentRequest.isCached && cacheReady) {
             streamCacheRepository.findCachedQualityKey(
                 currentRequest.serverId, currentRequest.songId, playbackQuality(currentRequest.serverId),
@@ -751,7 +758,7 @@ class DefaultPlaybackManager @Inject constructor(
         mutablePlaybackProgress.value = progress
 
         mutablePlaybackState.update { state ->
-            val currentDisplayItem = displayQueue.getOrNull(displayIndex)?.let { item ->
+            val currentDisplayItem = (currentPlayerItem ?: displayQueue.getOrNull(displayIndex))?.let { item ->
                 if (item.isCached) return@let item
                 if (state.preferences.adaptiveQualityEnabled) {
                     val quality = if (streamCached) {

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -734,13 +734,14 @@ class DefaultPlaybackManager @Inject constructor(
         // Expose queue in shuffled order if shuffle is active
         val displayOrder = shuffleDisplayOrder
         val (displayQueue, displayIndex) = if (displayOrder != null && queue.isNotEmpty()) {
-            val shuffled = displayOrder.mapNotNull { queue.getOrNull(it) }
-            val mappedIndex = playerToDisplay(playerIndex)
-            val currentPlayerItem = player.currentMediaItem?.toQueueItemOrNull()
-            val reconciledIndex = currentPlayerItem?.let { current ->
-                shuffled.indexOfFirst { item -> item.songId == current.songId }
-                    .takeIf { index -> index >= 0 }
-            } ?: mappedIndex
+            val shuffledEntries = displayOrder.mapNotNull { index ->
+                queue.getOrNull(index)?.let { item -> index to item }
+            }
+            val shuffled = shuffledEntries.map { (_, item) -> item }
+            val reconciledIndex = shuffledEntries
+                .indexOfFirst { (index, _) -> index == playerIndex }
+                .takeIf { index -> index >= 0 }
+                ?: playerToDisplay(playerIndex)
             shuffled to reconciledIndex
         } else {
             queue to playerIndex

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -31,7 +31,10 @@ import org.hdhmc.saki.MainActivity
 import org.hdhmc.saki.R
 import org.hdhmc.saki.data.remote.HTTP_USER_AGENT
 import org.hdhmc.saki.domain.model.LyricLine
+import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshot
+import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.domain.model.SoundBalancingMode
+import org.hdhmc.saki.domain.repository.LocalPlayQueueRepository
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
 import org.hdhmc.saki.domain.repository.SubsonicRepository
 import com.google.common.util.concurrent.ListenableFuture
@@ -77,6 +80,9 @@ class SakiPlaybackService : MediaSessionService() {
 
     @Inject
     lateinit var playbackPreferencesRepository: PlaybackPreferencesRepository
+
+    @Inject
+    lateinit var localPlayQueueRepository: LocalPlayQueueRepository
 
     @Inject
     lateinit var streamCache: SimpleCache
@@ -448,16 +454,27 @@ class SakiPlaybackService : MediaSessionService() {
         val itemCount = activePlayer.mediaItemCount
         if (itemCount == 0) return
         val request = activePlayer.currentMediaItem?.toPlaybackRequestOrNull() ?: return
-        val songIds = (0 until itemCount).mapNotNull { i ->
-            activePlayer.getMediaItemAt(i).toPlaybackRequestOrNull()?.songId
-        }
+        val queueRequests = (0 until itemCount)
+            .mapNotNull { i -> activePlayer.getMediaItemAt(i).toPlaybackRequestOrNull() }
+            .filter { itemRequest -> itemRequest.serverId == request.serverId }
+        val songIds = queueRequests.map(PlaybackRequest::songId)
         if (songIds.isEmpty()) return
         val positionMs = activePlayer.currentPosition
         val serverId = request.serverId
         val currentSongId = request.songId
+        val snapshot = LocalPlayQueueSnapshot(
+            serverId = serverId,
+            songs = queueRequests.map(PlaybackRequest::toSong),
+            currentSongId = currentSongId,
+            positionMs = positionMs,
+            updatedAt = System.currentTimeMillis(),
+        )
         savePlayQueueJob?.cancel()
         savePlayQueueJob = serviceScope.launch {
             if (!immediate) kotlinx.coroutines.delay(500)
+            runCatching {
+                localPlayQueueRepository.save(snapshot)
+            }
             runCatching {
                 subsonicRepository.savePlayQueue(
                     serverId = serverId,
@@ -745,6 +762,31 @@ class SakiPlaybackService : MediaSessionService() {
             }
         }.getOrNull()
     }
+}
+
+private fun PlaybackRequest.toSong(): Song {
+    return Song(
+        id = songId,
+        parentId = null,
+        title = title,
+        album = album,
+        albumId = albumId,
+        artist = artist,
+        artistId = artistId,
+        coverArtId = coverArtId,
+        durationSeconds = durationMs?.div(1_000L)?.toInt(),
+        track = track,
+        discNumber = discNumber,
+        year = null,
+        genre = null,
+        bitRate = sourceBitRate ?: bitRate,
+        sampleRate = sampleRate,
+        suffix = suffix,
+        contentType = mimeType,
+        sizeBytes = null,
+        path = null,
+        created = null,
+    )
 }
 
 private fun PlaybackException.shouldRetryNextEndpoint(): Boolean {

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -388,6 +388,7 @@ class SakiPlaybackService : MediaSessionService() {
         val cachedKey = streamCacheRepository.findCachedQualityKey(serverId, songId, cacheLookupQuality)
         if (preferLocalCache && cachedKey != null) {
             return dataSpec.buildUpon()
+                .setUri(cachedStreamUri(cachedKey))
                 .setKey(cachedKey)
                 .build()
         }
@@ -427,6 +428,14 @@ class SakiPlaybackService : MediaSessionService() {
     private fun shouldPreferLocalStreamCache(serverId: Long): Boolean {
         val probeResults = endpointSelector.getLastProbeResults(serverId)
         return probeResults.isNotEmpty() && probeResults.none { result -> result.reachable }
+    }
+
+    private fun cachedStreamUri(cacheKey: String): Uri {
+        return Uri.Builder()
+            .scheme("saki-cache")
+            .authority("stream")
+            .appendQueryParameter("key", cacheKey)
+            .build()
     }
 
     override fun onGetSession(

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -470,19 +470,52 @@ class SakiPlaybackService : MediaSessionService() {
             updatedAt = System.currentTimeMillis(),
         )
         savePlayQueueJob?.cancel()
-        savePlayQueueJob = serviceScope.launch {
-            if (!immediate) kotlinx.coroutines.delay(500)
-            runCatching {
-                localPlayQueueRepository.save(snapshot)
+        if (immediate) {
+            runBlocking {
+                saveLocalPlayQueueSnapshot(snapshot)
             }
-            runCatching {
-                subsonicRepository.savePlayQueue(
+            savePlayQueueJob = serviceScope.launch {
+                saveRemotePlayQueue(
                     serverId = serverId,
                     songIds = songIds,
                     currentSongId = currentSongId,
                     positionMs = positionMs,
                 )
             }
+            return
+        }
+
+        savePlayQueueJob = serviceScope.launch {
+            delay(500)
+            saveLocalPlayQueueSnapshot(snapshot)
+            saveRemotePlayQueue(
+                serverId = serverId,
+                songIds = songIds,
+                currentSongId = currentSongId,
+                positionMs = positionMs,
+            )
+        }
+    }
+
+    private suspend fun saveLocalPlayQueueSnapshot(snapshot: LocalPlayQueueSnapshot) {
+        runCatching {
+            localPlayQueueRepository.save(snapshot)
+        }
+    }
+
+    private suspend fun saveRemotePlayQueue(
+        serverId: Long,
+        songIds: List<String>,
+        currentSongId: String,
+        positionMs: Long,
+    ) {
+        runCatching {
+            subsonicRepository.savePlayQueue(
+                serverId = serverId,
+                songIds = songIds,
+                currentSongId = currentSongId,
+                positionMs = positionMs,
+            )
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -47,6 +47,7 @@ import java.net.NoRouteToHostException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -521,8 +522,11 @@ class SakiPlaybackService : MediaSessionService() {
     }
 
     private suspend fun saveLocalPlayQueueSnapshot(snapshot: LocalPlayQueueSnapshot) {
-        runCatching {
+        try {
             localPlayQueueRepository.save(snapshot)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (_: Exception) {
         }
     }
 
@@ -532,13 +536,16 @@ class SakiPlaybackService : MediaSessionService() {
         currentSongId: String,
         positionMs: Long,
     ) {
-        runCatching {
+        try {
             subsonicRepository.savePlayQueue(
                 serverId = serverId,
                 songIds = songIds,
                 currentSongId = currentSongId,
                 positionMs = positionMs,
             )
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (_: Exception) {
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -385,17 +385,21 @@ class SakiPlaybackService : MediaSessionService() {
         }
         val preferLocalCache = shouldPreferLocalStreamCache(serverId)
         val cacheLookupQuality = if (preferLocalCache) StreamQuality.entries.last() else requestedQuality
-        val cachedKey = streamCacheRepository.findCachedQualityKey(serverId, songId, cacheLookupQuality)
-        if (preferLocalCache && cachedKey != null) {
+        val cachedQualityKey = streamCacheRepository.findCachedQualityKey(serverId, songId, cacheLookupQuality)
+        val cachedQuality = cachedQualityKey?.let { key -> StreamQuality.fromStorageKey(key) }
+        val cachedResourceKey = cachedQuality?.let { quality ->
+            streamCacheRepository.buildCacheKey(serverId, songId, quality)
+        }
+        if (preferLocalCache && cachedResourceKey != null) {
             return dataSpec.buildUpon()
-                .setUri(cachedStreamUri(cachedKey))
-                .setKey(cachedKey)
+                .setUri(cachedStreamUri(cachedResourceKey))
+                .setKey(cachedResourceKey)
                 .build()
         }
 
-        val quality = cachedKey?.let { key -> StreamQuality.fromStorageKey(key) } ?: requestedQuality
+        val quality = cachedQuality ?: requestedQuality
         val format = uri.getQueryParameter("format")
-        if (!prefs.adaptiveQualityEnabled && cachedKey == null && format != null && format != requestedQuality.format) {
+        if (!prefs.adaptiveQualityEnabled && cachedResourceKey == null && format != null && format != requestedQuality.format) {
             val streamRequest = runBlocking {
                 subsonicRepository.buildStreamRequest(serverId, songId, requestedQuality.maxBitRate, format)
             }
@@ -421,7 +425,7 @@ class SakiPlaybackService : MediaSessionService() {
 
         return dataSpec.buildUpon()
             .setUri(realUrl)
-            .setKey(cachedKey ?: cacheKey)
+            .setKey(cachedResourceKey ?: cacheKey)
             .build()
     }
 

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -34,6 +34,7 @@ import org.hdhmc.saki.domain.model.LyricLine
 import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshot
 import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.domain.model.SoundBalancingMode
+import org.hdhmc.saki.domain.model.StreamQuality
 import org.hdhmc.saki.domain.repository.LocalPlayQueueRepository
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
 import org.hdhmc.saki.domain.repository.SubsonicRepository
@@ -373,34 +374,38 @@ class SakiPlaybackService : MediaSessionService() {
 
         // Use cached prefs to avoid blocking; fall back to blocking read if not yet available
         val prefs = cachedPlaybackPrefs ?: runBlocking { playbackPreferencesRepository.getPreferences() }
-        val quality = if (prefs.adaptiveQualityEnabled) {
-            val preferred = when (networkTypeProvider.networkType.value) {
+        val requestedQuality = if (prefs.adaptiveQualityEnabled) {
+            when (networkTypeProvider.networkType.value) {
                 org.hdhmc.saki.data.remote.NetworkType.WIFI -> prefs.wifiStreamQuality
                 org.hdhmc.saki.data.remote.NetworkType.MOBILE -> prefs.mobileStreamQuality
             }
-            val cachedKey = streamCacheRepository.findCachedQualityKey(serverId, songId, preferred)
-            if (cachedKey != null) org.hdhmc.saki.domain.model.StreamQuality.fromStorageKey(cachedKey) else preferred
         } else {
             val maxBitRate = uri.getQueryParameter("maxBitRate")?.toIntOrNull()
-            val format = uri.getQueryParameter("format")
-            val matched = org.hdhmc.saki.domain.model.StreamQuality.entries.find { it.maxBitRate == maxBitRate }
-                ?: org.hdhmc.saki.domain.model.StreamQuality.ORIGINAL
-            // If the placeholder has a specific format, pass it through to buildStreamRequest
-            if (format != null && format != matched.format) {
-                // Use maxBitRate/format directly instead of going through StreamQuality enum
-                val streamRequest = runBlocking {
-                    subsonicRepository.buildStreamRequest(serverId, songId, maxBitRate, format)
-                }
-                if (streamRequest.candidates.isEmpty()) {
-                    throw IOException("No stream candidates for song $songId on server $serverId")
-                }
-                val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, matched)
-                return dataSpec.buildUpon()
-                    .setUri(streamRequest.candidates.first().url)
-                    .setKey(cacheKey)
-                    .build()
+            StreamQuality.entries.find { it.maxBitRate == maxBitRate } ?: StreamQuality.ORIGINAL
+        }
+        val preferLocalCache = shouldPreferLocalStreamCache(serverId)
+        val cacheLookupQuality = if (preferLocalCache) StreamQuality.entries.last() else requestedQuality
+        val cachedKey = streamCacheRepository.findCachedQualityKey(serverId, songId, cacheLookupQuality)
+        if (preferLocalCache && cachedKey != null) {
+            return dataSpec.buildUpon()
+                .setKey(cachedKey)
+                .build()
+        }
+
+        val quality = cachedKey?.let { key -> StreamQuality.fromStorageKey(key) } ?: requestedQuality
+        val format = uri.getQueryParameter("format")
+        if (!prefs.adaptiveQualityEnabled && cachedKey == null && format != null && format != requestedQuality.format) {
+            val streamRequest = runBlocking {
+                subsonicRepository.buildStreamRequest(serverId, songId, requestedQuality.maxBitRate, format)
             }
-            matched
+            if (streamRequest.candidates.isEmpty()) {
+                throw IOException("No stream candidates for song $songId on server $serverId")
+            }
+            val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, requestedQuality)
+            return dataSpec.buildUpon()
+                .setUri(streamRequest.candidates.first().url)
+                .setKey(cacheKey)
+                .build()
         }
 
         val streamRequest = runBlocking {
@@ -415,8 +420,13 @@ class SakiPlaybackService : MediaSessionService() {
 
         return dataSpec.buildUpon()
             .setUri(realUrl)
-            .setKey(cacheKey)
+            .setKey(cachedKey ?: cacheKey)
             .build()
+    }
+
+    private fun shouldPreferLocalStreamCache(serverId: Long): Boolean {
+        val probeResults = endpointSelector.getLastProbeResults(serverId)
+        return probeResults.isNotEmpty() && probeResults.none { result -> result.reachable }
     }
 
     override fun onGetSession(

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -5,8 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.hdhmc.saki.R
 import org.hdhmc.saki.data.remote.EndpointSelector
-import org.hdhmc.saki.data.remote.NetworkType
-import org.hdhmc.saki.data.remote.NetworkTypeProvider
 import org.hdhmc.saki.data.repository.ConfigBackupManager
 import org.hdhmc.saki.data.repository.ImportResult
 import org.hdhmc.saki.domain.model.Album
@@ -81,7 +79,6 @@ class SakiAppViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val lyricsHolder: LyricsHolder,
     private val endpointSelector: EndpointSelector,
-    private val networkTypeProvider: NetworkTypeProvider,
     private val configBackupManager: ConfigBackupManager,
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(SakiAppUiState())
@@ -1075,10 +1072,6 @@ class SakiAppViewModel @Inject constructor(
     private suspend fun refreshCacheStorageSummary(serverId: Long?) {
         val downloadSummary = cachedSongRepository.getCacheStorageSummary(serverId)
         val fullStreamSummary = streamCacheRepository.getStreamCacheSummary(serverId)
-        val playableStreamSummary = streamCacheRepository.getStreamCacheSummary(
-            serverId = serverId,
-            quality = effectiveStreamQuality(),
-        )
         val imageCacheDir = appContext.cacheDir.resolve("image_cache")
         val imageCacheBytes = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
             imageCacheDir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
@@ -1092,7 +1085,7 @@ class SakiAppViewModel @Inject constructor(
                         hasStreamingCache = true,
                         imageCacheBytes = imageCacheBytes,
                     ),
-                    streamCachedSongIds = playableStreamSummary.cachedSongIds,
+                    streamCachedSongIds = fullStreamSummary.cachedSongIds,
                 )
             } else {
                 state
@@ -1168,11 +1161,11 @@ class SakiAppViewModel @Inject constructor(
     private suspend fun LocalPlayQueueSnapshot.offlinePlayableRestorePlan(
         serverId: Long,
     ): LocalPlayQueueRestorePlan? {
-        val preferredQuality = effectiveStreamQuality()
-        val downloadedSongIds = cachedSongRepository.getPlayableCachedSongs(serverId, preferredQuality).keys
+        val localCacheQuality = StreamQuality.entries.last()
+        val downloadedSongIds = cachedSongRepository.getPlayableCachedSongs(serverId, localCacheQuality).keys
         val streamCachedSongIds = songs.asSequence()
             .map(Song::id)
-            .filter { songId -> streamCacheRepository.findCachedQualityKey(serverId, songId, preferredQuality) != null }
+            .filter { songId -> streamCacheRepository.findCachedQualityKey(serverId, songId, localCacheQuality) != null }
             .toSet()
         val playableSongIds = downloadedSongIds + streamCachedSongIds
         val originalStartIndex = songs.indexOfFirst { song -> song.id == currentSongId }
@@ -1189,15 +1182,6 @@ class SakiAppViewModel @Inject constructor(
             startIndex = startIndex.coerceAtLeast(0),
             positionMs = if (startItem.value.id == currentSongId) positionMs else 0L,
         )
-    }
-
-    private fun effectiveStreamQuality(): StreamQuality {
-        val preferences = uiState.value.playbackState.preferences
-        if (!preferences.adaptiveQualityEnabled) return preferences.streamQuality
-        return when (networkTypeProvider.networkType.value) {
-            NetworkType.WIFI -> preferences.wifiStreamQuality
-            NetworkType.MOBILE -> preferences.mobileStreamQuality
-        }
     }
 
     private fun loadCachedContent(serverId: Long) {

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.hdhmc.saki.R
 import org.hdhmc.saki.data.remote.EndpointSelector
+import org.hdhmc.saki.data.remote.NetworkType
+import org.hdhmc.saki.data.remote.NetworkTypeProvider
 import org.hdhmc.saki.data.repository.ConfigBackupManager
 import org.hdhmc.saki.data.repository.ImportResult
 import org.hdhmc.saki.domain.model.Album
@@ -79,6 +81,7 @@ class SakiAppViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val lyricsHolder: LyricsHolder,
     private val endpointSelector: EndpointSelector,
+    private val networkTypeProvider: NetworkTypeProvider,
     private val configBackupManager: ConfigBackupManager,
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(SakiAppUiState())
@@ -1074,7 +1077,7 @@ class SakiAppViewModel @Inject constructor(
         val fullStreamSummary = streamCacheRepository.getStreamCacheSummary(serverId)
         val playableStreamSummary = streamCacheRepository.getStreamCacheSummary(
             serverId = serverId,
-            quality = uiState.value.playbackState.preferences.streamQuality,
+            quality = effectiveStreamQuality(),
         )
         val imageCacheDir = appContext.cacheDir.resolve("image_cache")
         val imageCacheBytes = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
@@ -1147,12 +1150,11 @@ class SakiAppViewModel @Inject constructor(
         val restored = if (offlineOnly) {
             snapshot.offlinePlayableRestorePlan(serverId) ?: return
         } else {
-            val startIndex = snapshot.songs.indexOfFirst { song -> song.id == snapshot.currentSongId }
-                .coerceAtLeast(0)
+            val rawStartIndex = snapshot.songs.indexOfFirst { song -> song.id == snapshot.currentSongId }
             LocalPlayQueueRestorePlan(
                 songs = snapshot.songs,
-                startIndex = startIndex,
-                positionMs = snapshot.positionMs,
+                startIndex = rawStartIndex.coerceAtLeast(0),
+                positionMs = if (rawStartIndex >= 0) snapshot.positionMs else 0L,
             )
         }
         playbackManager.restoreQueue(
@@ -1166,12 +1168,12 @@ class SakiAppViewModel @Inject constructor(
     private suspend fun LocalPlayQueueSnapshot.offlinePlayableRestorePlan(
         serverId: Long,
     ): LocalPlayQueueRestorePlan? {
-        val preferredQuality = uiState.value.playbackState.preferences.streamQuality
+        val preferredQuality = effectiveStreamQuality()
         val downloadedSongIds = cachedSongRepository.getPlayableCachedSongs(serverId, preferredQuality).keys
-        val streamCachedSongIds = streamCacheRepository.getStreamCacheSummary(
-            serverId = serverId,
-            quality = preferredQuality,
-        ).cachedSongIds
+        val streamCachedSongIds = songs.asSequence()
+            .map(Song::id)
+            .filter { songId -> streamCacheRepository.findCachedQualityKey(serverId, songId, preferredQuality) != null }
+            .toSet()
         val playableSongIds = downloadedSongIds + streamCachedSongIds
         val originalStartIndex = songs.indexOfFirst { song -> song.id == currentSongId }
             .coerceAtLeast(0)
@@ -1187,6 +1189,15 @@ class SakiAppViewModel @Inject constructor(
             startIndex = startIndex.coerceAtLeast(0),
             positionMs = if (startItem.value.id == currentSongId) positionMs else 0L,
         )
+    }
+
+    private fun effectiveStreamQuality(): StreamQuality {
+        val preferences = uiState.value.playbackState.preferences
+        if (!preferences.adaptiveQualityEnabled) return preferences.streamQuality
+        return when (networkTypeProvider.networkType.value) {
+            NetworkType.WIFI -> preferences.wifiStreamQuality
+            NetworkType.MOBILE -> preferences.mobileStreamQuality
+        }
     }
 
     private fun loadCachedContent(serverId: Long) {

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -19,6 +19,7 @@ import org.hdhmc.saki.domain.model.CacheStorageSummary
 import org.hdhmc.saki.domain.model.CachedSong
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
 import org.hdhmc.saki.domain.model.LibraryIndexes
+import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshot
 import org.hdhmc.saki.domain.model.regroupByLocale
 import org.hdhmc.saki.domain.model.PlaybackProgressState
 import org.hdhmc.saki.domain.model.PlaybackSessionState
@@ -34,6 +35,7 @@ import org.hdhmc.saki.domain.model.TextScale
 import org.hdhmc.saki.domain.repository.AppPreferencesRepository
 import org.hdhmc.saki.domain.repository.CachedSongRepository
 import org.hdhmc.saki.domain.repository.LibraryCacheRepository
+import org.hdhmc.saki.domain.repository.LocalPlayQueueRepository
 import org.hdhmc.saki.domain.repository.PlaybackManager
 import org.hdhmc.saki.playback.LyricsHolder
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
@@ -73,6 +75,7 @@ class SakiAppViewModel @Inject constructor(
     private val streamCacheRepository: StreamCacheRepository,
     private val playbackPreferencesRepository: PlaybackPreferencesRepository,
     private val libraryCacheRepository: LibraryCacheRepository,
+    private val localPlayQueueRepository: LocalPlayQueueRepository,
     private val playbackManager: PlaybackManager,
     private val lyricsHolder: LyricsHolder,
     private val endpointSelector: EndpointSelector,
@@ -1042,10 +1045,16 @@ class SakiAppViewModel @Inject constructor(
                     endpointSelector.probe(selectedServerId, server)
                     refreshEndpointStatus()
                 }
-                if (endpointSelector.getActiveEndpointId(selectedServerId) != null) {
-                    if (uiState.value.playbackState.currentItem == null) {
+                val hasReachableEndpoint = endpointSelector.getActiveEndpointId(selectedServerId) != null &&
+                    !endpointStatus.value.isOfflineDegraded
+                if (uiState.value.playbackState.currentItem == null) {
+                    if (hasReachableEndpoint) {
                         restorePlayQueue(selectedServerId)
+                    } else {
+                        restoreLocalPlayQueue(selectedServerId, offlineOnly = true)
                     }
+                }
+                if (hasReachableEndpoint) {
                     refreshServerContent(selectedServerId, forceRefresh = serverChanged)
                 }
             }
@@ -1108,8 +1117,76 @@ class SakiAppViewModel @Inject constructor(
                 )
             }.onFailure { e ->
                 if (e is CancellationException) throw e
+                restoreLocalPlayQueueSnapshot(
+                    serverId = serverId,
+                    offlineOnly = endpointStatus.value.isOfflineDegraded,
+                )
             }
         }
+    }
+
+    private fun restoreLocalPlayQueue(
+        serverId: Long,
+        offlineOnly: Boolean,
+    ) {
+        viewModelScope.launch {
+            restoreLocalPlayQueueSnapshot(serverId, offlineOnly)
+        }
+    }
+
+    private suspend fun restoreLocalPlayQueueSnapshot(
+        serverId: Long,
+        offlineOnly: Boolean,
+    ) {
+        if (uiState.value.playbackState.currentItem != null || uiState.value.playbackState.queue.isNotEmpty()) {
+            return
+        }
+        val snapshot = localPlayQueueRepository.get(serverId) ?: return
+        if (snapshot.songs.isEmpty()) return
+
+        val restored = if (offlineOnly) {
+            snapshot.offlinePlayableRestorePlan(serverId) ?: return
+        } else {
+            val startIndex = snapshot.songs.indexOfFirst { song -> song.id == snapshot.currentSongId }
+                .coerceAtLeast(0)
+            LocalPlayQueueRestorePlan(
+                songs = snapshot.songs,
+                startIndex = startIndex,
+                positionMs = snapshot.positionMs,
+            )
+        }
+        playbackManager.restoreQueue(
+            serverId = serverId,
+            songs = restored.songs,
+            startIndex = restored.startIndex,
+            positionMs = restored.positionMs,
+        )
+    }
+
+    private suspend fun LocalPlayQueueSnapshot.offlinePlayableRestorePlan(
+        serverId: Long,
+    ): LocalPlayQueueRestorePlan? {
+        val preferredQuality = uiState.value.playbackState.preferences.streamQuality
+        val downloadedSongIds = cachedSongRepository.getPlayableCachedSongs(serverId, preferredQuality).keys
+        val streamCachedSongIds = streamCacheRepository.getStreamCacheSummary(
+            serverId = serverId,
+            quality = preferredQuality,
+        ).cachedSongIds
+        val playableSongIds = downloadedSongIds + streamCachedSongIds
+        val originalStartIndex = songs.indexOfFirst { song -> song.id == currentSongId }
+            .coerceAtLeast(0)
+        val playableSongs = songs.withIndex()
+            .filter { (_, song) -> song.id in playableSongIds }
+        if (playableSongs.isEmpty()) return null
+
+        val startItem = playableSongs.firstOrNull { (index, _) -> index >= originalStartIndex }
+            ?: playableSongs.first()
+        val startIndex = playableSongs.indexOfFirst { (index, _) -> index == startItem.index }
+        return LocalPlayQueueRestorePlan(
+            songs = playableSongs.map { (_, song) -> song },
+            startIndex = startIndex.coerceAtLeast(0),
+            positionMs = if (startItem.value.id == currentSongId) positionMs else 0L,
+        )
     }
 
     private fun loadCachedContent(serverId: Long) {
@@ -1601,6 +1678,12 @@ data class EndpointProbeInfo(
     val baseUrl: String,
     val latencyMs: Long?,
     val reachable: Boolean,
+)
+
+private data class LocalPlayQueueRestorePlan(
+    val songs: List<Song>,
+    val startIndex: Int,
+    val positionMs: Long,
 )
 
 enum class BrowseSection {

--- a/app/src/test/java/org/hdhmc/saki/data/repository/FileLocalPlayQueueRepositoryTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/data/repository/FileLocalPlayQueueRepositoryTest.kt
@@ -1,0 +1,132 @@
+package org.hdhmc.saki.data.repository
+
+import com.squareup.moshi.Moshi
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshot
+import org.hdhmc.saki.domain.model.Song
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class FileLocalPlayQueueRepositoryTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `save get and clear round trip snapshot`() = runTest {
+        val repository = createRepository()
+        val snapshot = snapshot(
+            serverId = 1L,
+            songs = listOf(song("song-1"), song("song-2")),
+            currentSongId = "song-2",
+            positionMs = 42_000L,
+        )
+
+        repository.save(snapshot)
+
+        assertEquals(snapshot, repository.get(1L))
+
+        repository.clear(1L)
+
+        assertNull(repository.get(1L))
+    }
+
+    @Test
+    fun `get returns null for corrupted json`() = runTest {
+        val directory = temporaryFolder.newFolder()
+        val repository = createRepository(directory)
+        File(directory, "server_1.json").writeText("{not json")
+
+        assertNull(repository.get(1L))
+    }
+
+    @Test
+    fun `save overwrites previous snapshot`() = runTest {
+        val repository = createRepository()
+        val first = snapshot(
+            serverId = 1L,
+            songs = listOf(song("song-1")),
+            currentSongId = "song-1",
+            positionMs = 1_000L,
+        )
+        val second = snapshot(
+            serverId = 1L,
+            songs = listOf(song("song-2"), song("song-3")),
+            currentSongId = "song-3",
+            positionMs = 3_000L,
+        )
+
+        repository.save(first)
+        repository.save(second)
+
+        assertEquals(second, repository.get(1L))
+    }
+
+    @Test
+    fun `get can recover backup when target is missing`() = runTest {
+        val directory = temporaryFolder.newFolder()
+        val repository = createRepository(directory)
+        val snapshot = snapshot(
+            serverId = 1L,
+            songs = listOf(song("song-1")),
+            currentSongId = "song-1",
+            positionMs = 1_000L,
+        )
+
+        repository.save(snapshot)
+        val target = File(directory, "server_1.json")
+        val backup = File(directory, "server_1.json.bak")
+        assertTrue(target.renameTo(backup))
+
+        assertEquals(snapshot, repository.get(1L))
+    }
+
+    private fun createRepository(
+        directory: File = temporaryFolder.newFolder(),
+    ): FileLocalPlayQueueRepository = FileLocalPlayQueueRepository(
+        directory = directory,
+        moshi = Moshi.Builder().build(),
+        ioDispatcher = Dispatchers.Unconfined,
+    )
+
+    private fun snapshot(
+        serverId: Long,
+        songs: List<Song>,
+        currentSongId: String?,
+        positionMs: Long,
+    ) = LocalPlayQueueSnapshot(
+        serverId = serverId,
+        songs = songs,
+        currentSongId = currentSongId,
+        positionMs = positionMs,
+        updatedAt = 123_456L,
+    )
+
+    private fun song(id: String) = Song(
+        id = id,
+        parentId = null,
+        title = "Title $id",
+        album = "Album",
+        albumId = "album-1",
+        artist = "Artist",
+        artistId = "artist-1",
+        coverArtId = "cover-1",
+        durationSeconds = 180,
+        track = 1,
+        discNumber = 1,
+        year = 2026,
+        genre = "Genre",
+        bitRate = 320,
+        sampleRate = 44_100,
+        suffix = "mp3",
+        contentType = "audio/mpeg",
+        sizeBytes = 1_024L,
+        path = "path/$id.mp3",
+        created = "2026-04-29T00:00:00Z",
+    )
+}


### PR DESCRIPTION
## Summary

Adds a local, per-server playback queue snapshot so Now Playing can be restored even when the server play queue cannot be fetched, including offline-degraded startup.

## Changes

- Persist the active playback queue locally from `SakiPlaybackService`, including queue songs, current song id, playback position, and update time.
- Restore Now Playing from the local snapshot when remote play queue restore fails or when the app starts in offline-degraded mode.
- In online mode, keep the playback quality behavior aligned with the playback layer's effective stream quality, including adaptive Wi-Fi/mobile quality.
- In offline-degraded mode, treat any fully local cached quality as playable. This keeps previously cached/downloaded items playable even when their cached quality is lower than the current online preferred quality.
- Preserve playback position only when the restored current song is the same song; otherwise start the restored item from `0L` to avoid seeking into the wrong track.
- Harden snapshot file replacement with temp + backup swap so a failed write does not delete the last known-good queue.
- Make the immediate service shutdown path wait for the local snapshot save before `serviceScope` cancellation can interrupt it.
- Keep offline stream-cache playback identity stable by using the full per-song stream cache resource key for cache-only reads, and make Now Playing's current item follow the player's current media item if display-order mapping is briefly out of sync.
- Add repository tests for save/get/clear, corrupted JSON handling, overwrite behavior, and backup recovery.

## Behavior

Online mode still prefers the server play queue. The local snapshot is only a fallback when the remote queue cannot be restored and the current playback state is empty.

Offline-degraded mode restores only locally playable items. Downloaded files and fully cached stream entries are considered playable regardless of their cached quality. If the original current song is not available locally, restore starts from the next playable item in the saved queue, or wraps to the first playable item.

For stream cache playback while offline-degraded, the resolver uses the full per-song cache resource key directly when a fully cached entry exists, so playback does not require resolving a remote stream URL first and adjacent cached songs cannot share a quality-only cache key.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Local build/test not run; CI should validate the Android build and test suite.
