### PR TITLE
feat: add offline library detail cache

### DIFF
--- a/app/schemas/org.hdhmc.saki.data.local.database.SakiDatabase/12.json
+++ b/app/schemas/org.hdhmc.saki.data.local.database.SakiDatabase/12.json
@@ -1,0 +1,1334 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "d7558a504c0829761db01f3d9849dcc0",
+    "entities": [
+      {
+        "tableName": "app_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `onboardingCompleted` INTEGER NOT NULL, `textScaleKey` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "onboardingCompleted",
+            "columnName": "onboardingCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textScaleKey",
+            "columnName": "textScaleKey",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `albumId` TEXT NOT NULL, `listType` TEXT NOT NULL, `name` TEXT NOT NULL, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `songCount` INTEGER, `durationSeconds` INTEGER, `year` INTEGER, `genre` TEXT, `created` TEXT, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `albumId`, `listType`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listType",
+            "columnName": "listType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "albumId",
+            "listType"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_album_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `albumId` TEXT NOT NULL, `name` TEXT NOT NULL, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `songCount` INTEGER, `durationSeconds` INTEGER, `year` INTEGER, `genre` TEXT, `created` TEXT, `cachedAt` INTEGER NOT NULL, `isComplete` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `albumId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isComplete",
+            "columnName": "isComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "albumId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_album_detail_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `albumId` TEXT NOT NULL, `songId` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `albumId`, `sortOrder`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "albumId",
+            "sortOrder"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_album_detail_songs_serverId_albumId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_album_detail_songs_serverId_albumId` ON `${TABLE_NAME}` (`serverId`, `albumId`)"
+          },
+          {
+            "name": "index_cached_album_detail_songs_serverId_songId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_album_detail_songs_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_artist_detail_albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `albumId` TEXT NOT NULL, `name` TEXT NOT NULL, `artist` TEXT, `albumArtistId` TEXT, `coverArtId` TEXT, `songCount` INTEGER, `durationSeconds` INTEGER, `year` INTEGER, `genre` TEXT, `created` TEXT, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `artistId`, `albumId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtistId",
+            "columnName": "albumArtistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId",
+            "albumId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_artist_detail_albums_serverId_artistId_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "artistId",
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_artist_detail_albums_serverId_artistId_sortOrder` ON `${TABLE_NAME}` (`serverId`, `artistId`, `sortOrder`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_artist_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverArtId` TEXT, `artistImageUrl` TEXT, `albumCount` INTEGER, `cachedAt` INTEGER NOT NULL, `isComplete` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `artistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistImageUrl",
+            "columnName": "artistImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumCount",
+            "columnName": "albumCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isComplete",
+            "columnName": "isComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_artist_detail_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `artistId`, `sortOrder`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId",
+            "sortOrder"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_artist_detail_songs_serverId_artistId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_artist_detail_songs_serverId_artistId` ON `${TABLE_NAME}` (`serverId`, `artistId`)"
+          },
+          {
+            "name": "index_cached_artist_detail_songs_serverId_songId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_artist_detail_songs_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `name` TEXT NOT NULL, `sectionName` TEXT NOT NULL, `albumCount` INTEGER, `coverArtId` TEXT, `artistImageUrl` TEXT, PRIMARY KEY(`serverId`, `artistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sectionName",
+            "columnName": "sectionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumCount",
+            "columnName": "albumCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistImageUrl",
+            "columnName": "artistImageUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_library_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `parentId` TEXT, `title` TEXT NOT NULL COLLATE NOCASE, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `year` INTEGER, `genre` TEXT, `bitRate` INTEGER, `sampleRate` INTEGER, `suffix` TEXT, `contentType` TEXT, `sizeBytes` INTEGER, `path` TEXT, `created` TEXT, PRIMARY KEY(`serverId`, `songId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "track",
+            "columnName": "track",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "songId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_library_songs_serverId_title",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_library_songs_serverId_title` ON `${TABLE_NAME}` (`serverId`, `title`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_playlist_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `playlistId` TEXT NOT NULL, `name` TEXT NOT NULL, `owner` TEXT, `isPublic` INTEGER, `songCount` INTEGER, `durationSeconds` INTEGER, `coverArtId` TEXT, `created` TEXT, `changed` TEXT, `cachedAt` INTEGER NOT NULL, `isComplete` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `playlistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPublic",
+            "columnName": "isPublic",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "changed",
+            "columnName": "changed",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isComplete",
+            "columnName": "isComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "playlistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_playlist_detail_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `playlistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `playlistId`, `sortOrder`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "playlistId",
+            "sortOrder"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_playlist_detail_songs_serverId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_playlist_detail_songs_serverId_playlistId` ON `${TABLE_NAME}` (`serverId`, `playlistId`)"
+          },
+          {
+            "name": "index_cached_playlist_detail_songs_serverId_songId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_playlist_detail_songs_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `playlistId` TEXT NOT NULL, `name` TEXT NOT NULL, `owner` TEXT, `isPublic` INTEGER, `songCount` INTEGER, `durationSeconds` INTEGER, `coverArtId` TEXT, `created` TEXT, `changed` TEXT, PRIMARY KEY(`serverId`, `playlistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPublic",
+            "columnName": "isPublic",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "changed",
+            "columnName": "changed",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "playlistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheId` TEXT NOT NULL, `serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `title` TEXT NOT NULL, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `coverArtPath` TEXT, `localPath` TEXT NOT NULL, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `suffix` TEXT, `contentType` TEXT, `bitRate` INTEGER, `sampleRate` INTEGER, `qualityKey` TEXT NOT NULL, `fileSizeBytes` INTEGER NOT NULL, `downloadedAt` INTEGER NOT NULL, PRIMARY KEY(`cacheId`))",
+        "fields": [
+          {
+            "fieldPath": "cacheId",
+            "columnName": "cacheId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtPath",
+            "columnName": "coverArtPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "track",
+            "columnName": "track",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "qualityKey",
+            "columnName": "qualityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "fileSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_songs_serverId_songId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cached_songs_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_song_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `parentId` TEXT, `title` TEXT NOT NULL COLLATE NOCASE, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `year` INTEGER, `genre` TEXT, `bitRate` INTEGER, `sampleRate` INTEGER, `suffix` TEXT, `contentType` TEXT, `sizeBytes` INTEGER, `path` TEXT, `created` TEXT, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `songId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "track",
+            "columnName": "track",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "songId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_song_metadata_serverId_albumId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_song_metadata_serverId_albumId` ON `${TABLE_NAME}` (`serverId`, `albumId`)"
+          },
+          {
+            "name": "index_cached_song_metadata_serverId_artistId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_song_metadata_serverId_artistId` ON `${TABLE_NAME}` (`serverId`, `artistId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `streamQualityKey` TEXT NOT NULL, `soundBalancingEnabled` INTEGER NOT NULL, `soundBalancingModeKey` TEXT NOT NULL, `streamCacheSizeMb` INTEGER NOT NULL, `bluetoothLyricsEnabled` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamQualityKey",
+            "columnName": "streamQualityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "soundBalancingEnabled",
+            "columnName": "soundBalancingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "soundBalancingModeKey",
+            "columnName": "soundBalancingModeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamCacheSizeMb",
+            "columnName": "streamCacheSizeMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bluetoothLyricsEnabled",
+            "columnName": "bluetoothLyricsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `clientName` TEXT NOT NULL, `apiVersion` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientName",
+            "columnName": "clientName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiVersion",
+            "columnName": "apiVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "server_endpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serverId` INTEGER NOT NULL, `label` TEXT NOT NULL, `baseUrl` TEXT NOT NULL, `displayOrder` INTEGER NOT NULL, FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_server_endpoints_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_server_endpoints_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd7558a504c0829761db01f3d9849dcc0')"
+    ]
+  }
+}

--- a/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
@@ -42,7 +42,33 @@ interface LibraryCacheDao {
     @Query("SELECT * FROM cached_albums WHERE serverId = :serverId AND listType = :listType ORDER BY sortOrder")
     suspend fun getAlbums(serverId: Long, listType: String): List<CachedAlbumEntity>
 
-    @Query("SELECT * FROM cached_albums WHERE serverId = :serverId AND albumId = :albumId ORDER BY sortOrder LIMIT 1")
+    @Query(
+        """
+        SELECT * FROM cached_albums
+        WHERE serverId = :serverId AND albumId = :albumId
+        ORDER BY
+            CASE WHEN artist IS NOT NULL THEN 1 ELSE 0 END
+                + CASE WHEN artistId IS NOT NULL THEN 1 ELSE 0 END
+                + CASE WHEN coverArtId IS NOT NULL THEN 1 ELSE 0 END
+                + CASE WHEN songCount IS NOT NULL THEN 1 ELSE 0 END
+                + CASE WHEN durationSeconds IS NOT NULL THEN 1 ELSE 0 END
+                + CASE WHEN year IS NOT NULL THEN 1 ELSE 0 END
+                + CASE WHEN genre IS NOT NULL THEN 1 ELSE 0 END DESC,
+            CASE listType
+                WHEN 'newest' THEN 0
+                WHEN 'recent' THEN 1
+                WHEN 'highest' THEN 2
+                WHEN 'frequent' THEN 3
+                WHEN 'alphabeticalByName' THEN 4
+                WHEN 'alphabeticalByArtist' THEN 5
+                WHEN 'starred' THEN 6
+                WHEN 'random' THEN 7
+                ELSE 99
+            END,
+            sortOrder
+        LIMIT 1
+        """,
+    )
     suspend fun getAlbumSummary(serverId: Long, albumId: String): CachedAlbumEntity?
 
     @Query("SELECT * FROM cached_albums WHERE serverId = :serverId AND artistId = :artistId ORDER BY year DESC, name COLLATE NOCASE")
@@ -206,6 +232,34 @@ interface LibraryCacheDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertSongMetadata(songs: List<CachedSongMetadataEntity>)
+
+    @Query(
+        """
+        DELETE FROM cached_song_metadata
+        WHERE serverId = :serverId
+            AND NOT EXISTS (
+                SELECT 1 FROM cached_library_songs
+                WHERE cached_library_songs.serverId = cached_song_metadata.serverId
+                    AND cached_library_songs.songId = cached_song_metadata.songId
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM cached_artist_detail_songs
+                WHERE cached_artist_detail_songs.serverId = cached_song_metadata.serverId
+                    AND cached_artist_detail_songs.songId = cached_song_metadata.songId
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM cached_album_detail_songs
+                WHERE cached_album_detail_songs.serverId = cached_song_metadata.serverId
+                    AND cached_album_detail_songs.songId = cached_song_metadata.songId
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM cached_playlist_detail_songs
+                WHERE cached_playlist_detail_songs.serverId = cached_song_metadata.serverId
+                    AND cached_playlist_detail_songs.songId = cached_song_metadata.songId
+            )
+        """,
+    )
+    suspend fun pruneUnreferencedSongMetadata(serverId: Long)
 
     @Query("SELECT * FROM cached_song_metadata WHERE serverId = :serverId AND songId IN (:songIds)")
     suspend fun getSongMetadata(serverId: Long, songIds: List<String>): List<CachedSongMetadataEntity>

--- a/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
@@ -6,9 +6,17 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import org.hdhmc.saki.data.local.entity.CachedAlbumEntity
+import org.hdhmc.saki.data.local.entity.CachedAlbumDetailEntity
+import org.hdhmc.saki.data.local.entity.CachedAlbumDetailSongEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistDetailAlbumEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistDetailEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistEntity
 import org.hdhmc.saki.data.local.entity.CachedLibrarySongEntity
+import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailEntity
+import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistEntity
+import org.hdhmc.saki.data.local.entity.CachedSongMetadataEntity
 
 @Dao
 interface LibraryCacheDao {
@@ -72,4 +80,115 @@ interface LibraryCacheDao {
         clearSongs(serverId)
         insertSongs(songs)
     }
+
+    @Query("SELECT * FROM cached_artist_details WHERE serverId = :serverId AND artistId = :artistId LIMIT 1")
+    suspend fun getArtistDetail(serverId: Long, artistId: String): CachedArtistDetailEntity?
+
+    @Query("SELECT * FROM cached_artist_detail_albums WHERE serverId = :serverId AND artistId = :artistId ORDER BY sortOrder")
+    suspend fun getArtistDetailAlbums(serverId: Long, artistId: String): List<CachedArtistDetailAlbumEntity>
+
+    @Query("SELECT * FROM cached_artist_detail_songs WHERE serverId = :serverId AND artistId = :artistId ORDER BY sortOrder")
+    suspend fun getArtistDetailSongs(serverId: Long, artistId: String): List<CachedArtistDetailSongEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertArtistDetail(detail: CachedArtistDetailEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertArtistDetailAlbums(albums: List<CachedArtistDetailAlbumEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertArtistDetailSongs(songs: List<CachedArtistDetailSongEntity>)
+
+    @Query("DELETE FROM cached_artist_details WHERE serverId = :serverId AND artistId = :artistId")
+    suspend fun clearArtistDetail(serverId: Long, artistId: String)
+
+    @Query("DELETE FROM cached_artist_detail_albums WHERE serverId = :serverId AND artistId = :artistId")
+    suspend fun clearArtistDetailAlbums(serverId: Long, artistId: String)
+
+    @Query("DELETE FROM cached_artist_detail_songs WHERE serverId = :serverId AND artistId = :artistId")
+    suspend fun clearArtistDetailSongs(serverId: Long, artistId: String)
+
+    @Transaction
+    suspend fun replaceArtistDetail(
+        detail: CachedArtistDetailEntity,
+        albums: List<CachedArtistDetailAlbumEntity>,
+        topSongs: List<CachedArtistDetailSongEntity>,
+        songMetadata: List<CachedSongMetadataEntity>,
+    ) {
+        clearArtistDetail(detail.serverId, detail.artistId)
+        clearArtistDetailAlbums(detail.serverId, detail.artistId)
+        clearArtistDetailSongs(detail.serverId, detail.artistId)
+        insertArtistDetail(detail)
+        if (albums.isNotEmpty()) insertArtistDetailAlbums(albums)
+        if (songMetadata.isNotEmpty()) insertSongMetadata(songMetadata)
+        if (topSongs.isNotEmpty()) insertArtistDetailSongs(topSongs)
+    }
+
+    @Query("SELECT * FROM cached_album_details WHERE serverId = :serverId AND albumId = :albumId LIMIT 1")
+    suspend fun getAlbumDetail(serverId: Long, albumId: String): CachedAlbumDetailEntity?
+
+    @Query("SELECT * FROM cached_album_detail_songs WHERE serverId = :serverId AND albumId = :albumId ORDER BY sortOrder")
+    suspend fun getAlbumDetailSongs(serverId: Long, albumId: String): List<CachedAlbumDetailSongEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAlbumDetail(detail: CachedAlbumDetailEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAlbumDetailSongs(songs: List<CachedAlbumDetailSongEntity>)
+
+    @Query("DELETE FROM cached_album_details WHERE serverId = :serverId AND albumId = :albumId")
+    suspend fun clearAlbumDetail(serverId: Long, albumId: String)
+
+    @Query("DELETE FROM cached_album_detail_songs WHERE serverId = :serverId AND albumId = :albumId")
+    suspend fun clearAlbumDetailSongs(serverId: Long, albumId: String)
+
+    @Transaction
+    suspend fun replaceAlbumDetail(
+        detail: CachedAlbumDetailEntity,
+        songs: List<CachedAlbumDetailSongEntity>,
+        songMetadata: List<CachedSongMetadataEntity>,
+    ) {
+        clearAlbumDetail(detail.serverId, detail.albumId)
+        clearAlbumDetailSongs(detail.serverId, detail.albumId)
+        insertAlbumDetail(detail)
+        if (songMetadata.isNotEmpty()) insertSongMetadata(songMetadata)
+        if (songs.isNotEmpty()) insertAlbumDetailSongs(songs)
+    }
+
+    @Query("SELECT * FROM cached_playlist_details WHERE serverId = :serverId AND playlistId = :playlistId LIMIT 1")
+    suspend fun getPlaylistDetail(serverId: Long, playlistId: String): CachedPlaylistDetailEntity?
+
+    @Query("SELECT * FROM cached_playlist_detail_songs WHERE serverId = :serverId AND playlistId = :playlistId ORDER BY sortOrder")
+    suspend fun getPlaylistDetailSongs(serverId: Long, playlistId: String): List<CachedPlaylistDetailSongEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPlaylistDetail(detail: CachedPlaylistDetailEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPlaylistDetailSongs(songs: List<CachedPlaylistDetailSongEntity>)
+
+    @Query("DELETE FROM cached_playlist_details WHERE serverId = :serverId AND playlistId = :playlistId")
+    suspend fun clearPlaylistDetail(serverId: Long, playlistId: String)
+
+    @Query("DELETE FROM cached_playlist_detail_songs WHERE serverId = :serverId AND playlistId = :playlistId")
+    suspend fun clearPlaylistDetailSongs(serverId: Long, playlistId: String)
+
+    @Transaction
+    suspend fun replacePlaylistDetail(
+        detail: CachedPlaylistDetailEntity,
+        songs: List<CachedPlaylistDetailSongEntity>,
+        songMetadata: List<CachedSongMetadataEntity>,
+    ) {
+        clearPlaylistDetail(detail.serverId, detail.playlistId)
+        clearPlaylistDetailSongs(detail.serverId, detail.playlistId)
+        insertPlaylistDetail(detail)
+        if (songMetadata.isNotEmpty()) insertSongMetadata(songMetadata)
+        if (songs.isNotEmpty()) insertPlaylistDetailSongs(songs)
+    }
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSongMetadata(songs: List<CachedSongMetadataEntity>)
+
+    @Query("SELECT * FROM cached_song_metadata WHERE serverId = :serverId AND songId IN (:songIds)")
+    suspend fun getSongMetadata(serverId: Long, songIds: List<String>): List<CachedSongMetadataEntity>
 }

--- a/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
@@ -24,6 +24,9 @@ interface LibraryCacheDao {
     @Query("SELECT * FROM cached_artists WHERE serverId = :serverId ORDER BY sectionName, name")
     suspend fun getArtists(serverId: Long): List<CachedArtistEntity>
 
+    @Query("SELECT * FROM cached_artists WHERE serverId = :serverId AND artistId = :artistId LIMIT 1")
+    suspend fun getArtistSummary(serverId: Long, artistId: String): CachedArtistEntity?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertArtists(artists: List<CachedArtistEntity>)
 
@@ -38,6 +41,12 @@ interface LibraryCacheDao {
 
     @Query("SELECT * FROM cached_albums WHERE serverId = :serverId AND listType = :listType ORDER BY sortOrder")
     suspend fun getAlbums(serverId: Long, listType: String): List<CachedAlbumEntity>
+
+    @Query("SELECT * FROM cached_albums WHERE serverId = :serverId AND albumId = :albumId ORDER BY sortOrder LIMIT 1")
+    suspend fun getAlbumSummary(serverId: Long, albumId: String): CachedAlbumEntity?
+
+    @Query("SELECT * FROM cached_albums WHERE serverId = :serverId AND artistId = :artistId ORDER BY year DESC, name COLLATE NOCASE")
+    suspend fun getAlbumSummariesByArtistId(serverId: Long, artistId: String): List<CachedAlbumEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAlbums(albums: List<CachedAlbumEntity>)
@@ -69,6 +78,15 @@ interface LibraryCacheDao {
     @Query("SELECT * FROM cached_library_songs WHERE serverId = :serverId ORDER BY title COLLATE NOCASE")
     suspend fun getSongs(serverId: Long): List<CachedLibrarySongEntity>
 
+    @Query("SELECT * FROM cached_library_songs WHERE serverId = :serverId AND songId IN (:songIds)")
+    suspend fun getLibrarySongs(serverId: Long, songIds: List<String>): List<CachedLibrarySongEntity>
+
+    @Query("SELECT * FROM cached_library_songs WHERE serverId = :serverId AND albumId = :albumId ORDER BY CASE WHEN discNumber IS NULL THEN 1 ELSE 0 END, discNumber, CASE WHEN track IS NULL THEN 1 ELSE 0 END, track, title COLLATE NOCASE")
+    suspend fun getLibrarySongsByAlbumId(serverId: Long, albumId: String): List<CachedLibrarySongEntity>
+
+    @Query("SELECT * FROM cached_library_songs WHERE serverId = :serverId AND artistId = :artistId ORDER BY album COLLATE NOCASE, CASE WHEN discNumber IS NULL THEN 1 ELSE 0 END, discNumber, CASE WHEN track IS NULL THEN 1 ELSE 0 END, track, title COLLATE NOCASE")
+    suspend fun getLibrarySongsByArtistId(serverId: Long, artistId: String): List<CachedLibrarySongEntity>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertSongs(songs: List<CachedLibrarySongEntity>)
 
@@ -78,7 +96,7 @@ interface LibraryCacheDao {
     @Transaction
     suspend fun replaceSongs(serverId: Long, songs: List<CachedLibrarySongEntity>) {
         clearSongs(serverId)
-        insertSongs(songs)
+        if (songs.isNotEmpty()) insertSongs(songs)
     }
 
     @Query("SELECT * FROM cached_artist_details WHERE serverId = :serverId AND artistId = :artistId LIMIT 1")
@@ -191,4 +209,10 @@ interface LibraryCacheDao {
 
     @Query("SELECT * FROM cached_song_metadata WHERE serverId = :serverId AND songId IN (:songIds)")
     suspend fun getSongMetadata(serverId: Long, songIds: List<String>): List<CachedSongMetadataEntity>
+
+    @Query("SELECT * FROM cached_song_metadata WHERE serverId = :serverId AND albumId = :albumId ORDER BY CASE WHEN discNumber IS NULL THEN 1 ELSE 0 END, discNumber, CASE WHEN track IS NULL THEN 1 ELSE 0 END, track, title COLLATE NOCASE")
+    suspend fun getSongMetadataByAlbumId(serverId: Long, albumId: String): List<CachedSongMetadataEntity>
+
+    @Query("SELECT * FROM cached_song_metadata WHERE serverId = :serverId AND artistId = :artistId ORDER BY album COLLATE NOCASE, CASE WHEN discNumber IS NULL THEN 1 ELSE 0 END, discNumber, CASE WHEN track IS NULL THEN 1 ELSE 0 END, track, title COLLATE NOCASE")
+    suspend fun getSongMetadataByArtistId(serverId: Long, artistId: String): List<CachedSongMetadataEntity>
 }

--- a/app/src/main/java/org/hdhmc/saki/data/local/database/SakiDatabase.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/database/SakiDatabase.kt
@@ -9,10 +9,18 @@ import org.hdhmc.saki.data.local.dao.AppPreferencesDao
 import org.hdhmc.saki.data.local.dao.ServerConfigDao
 import org.hdhmc.saki.data.local.entity.AppPreferencesEntity
 import org.hdhmc.saki.data.local.entity.CachedAlbumEntity
+import org.hdhmc.saki.data.local.entity.CachedAlbumDetailEntity
+import org.hdhmc.saki.data.local.entity.CachedAlbumDetailSongEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistDetailAlbumEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistDetailEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistEntity
 import org.hdhmc.saki.data.local.entity.CachedLibrarySongEntity
+import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailEntity
+import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistEntity
 import org.hdhmc.saki.data.local.entity.CachedSongEntity
+import org.hdhmc.saki.data.local.entity.CachedSongMetadataEntity
 import org.hdhmc.saki.data.local.entity.PlaybackPreferencesEntity
 import org.hdhmc.saki.data.local.entity.ServerEndpointEntity
 import org.hdhmc.saki.data.local.entity.ServerEntity
@@ -21,15 +29,23 @@ import org.hdhmc.saki.data.local.entity.ServerEntity
     entities = [
         AppPreferencesEntity::class,
         CachedAlbumEntity::class,
+        CachedAlbumDetailEntity::class,
+        CachedAlbumDetailSongEntity::class,
+        CachedArtistDetailAlbumEntity::class,
+        CachedArtistDetailEntity::class,
+        CachedArtistDetailSongEntity::class,
         CachedArtistEntity::class,
         CachedLibrarySongEntity::class,
+        CachedPlaylistDetailEntity::class,
+        CachedPlaylistDetailSongEntity::class,
         CachedPlaylistEntity::class,
         CachedSongEntity::class,
+        CachedSongMetadataEntity::class,
         PlaybackPreferencesEntity::class,
         ServerEntity::class,
         ServerEndpointEntity::class,
     ],
-    version = 11,
+    version = 12,
     exportSchema = true,
 )
 abstract class SakiDatabase : RoomDatabase() {

--- a/app/src/main/java/org/hdhmc/saki/data/local/entity/CachedLibraryDetailEntities.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/entity/CachedLibraryDetailEntities.kt
@@ -1,0 +1,150 @@
+package org.hdhmc.saki.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "cached_song_metadata",
+    primaryKeys = ["serverId", "songId"],
+    indices = [
+        Index(value = ["serverId", "albumId"]),
+        Index(value = ["serverId", "artistId"]),
+    ],
+)
+data class CachedSongMetadataEntity(
+    val serverId: Long,
+    val songId: String,
+    val parentId: String?,
+    @ColumnInfo(collate = ColumnInfo.NOCASE)
+    val title: String,
+    val album: String?,
+    val albumId: String?,
+    val artist: String?,
+    val artistId: String?,
+    val coverArtId: String?,
+    val durationSeconds: Int?,
+    val track: Int?,
+    val discNumber: Int?,
+    val year: Int?,
+    val genre: String?,
+    val bitRate: Int?,
+    val sampleRate: Int?,
+    val suffix: String?,
+    val contentType: String?,
+    val sizeBytes: Long?,
+    val path: String?,
+    val created: String?,
+    val cachedAt: Long,
+)
+
+@Entity(tableName = "cached_artist_details", primaryKeys = ["serverId", "artistId"])
+data class CachedArtistDetailEntity(
+    val serverId: Long,
+    val artistId: String,
+    val name: String,
+    val coverArtId: String?,
+    val artistImageUrl: String?,
+    val albumCount: Int?,
+    val cachedAt: Long,
+    val isComplete: Boolean,
+)
+
+@Entity(
+    tableName = "cached_artist_detail_albums",
+    primaryKeys = ["serverId", "artistId", "albumId"],
+    indices = [Index(value = ["serverId", "artistId", "sortOrder"])],
+)
+data class CachedArtistDetailAlbumEntity(
+    val serverId: Long,
+    val artistId: String,
+    val albumId: String,
+    val name: String,
+    val artist: String?,
+    val albumArtistId: String?,
+    val coverArtId: String?,
+    val songCount: Int?,
+    val durationSeconds: Int?,
+    val year: Int?,
+    val genre: String?,
+    val created: String?,
+    val sortOrder: Int,
+)
+
+@Entity(
+    tableName = "cached_artist_detail_songs",
+    primaryKeys = ["serverId", "artistId", "sortOrder"],
+    indices = [
+        Index(value = ["serverId", "artistId"]),
+        Index(value = ["serverId", "songId"]),
+    ],
+)
+data class CachedArtistDetailSongEntity(
+    val serverId: Long,
+    val artistId: String,
+    val songId: String,
+    val sortOrder: Int,
+)
+
+@Entity(tableName = "cached_album_details", primaryKeys = ["serverId", "albumId"])
+data class CachedAlbumDetailEntity(
+    val serverId: Long,
+    val albumId: String,
+    val name: String,
+    val artist: String?,
+    val artistId: String?,
+    val coverArtId: String?,
+    val songCount: Int?,
+    val durationSeconds: Int?,
+    val year: Int?,
+    val genre: String?,
+    val created: String?,
+    val cachedAt: Long,
+    val isComplete: Boolean,
+)
+
+@Entity(
+    tableName = "cached_album_detail_songs",
+    primaryKeys = ["serverId", "albumId", "sortOrder"],
+    indices = [
+        Index(value = ["serverId", "albumId"]),
+        Index(value = ["serverId", "songId"]),
+    ],
+)
+data class CachedAlbumDetailSongEntity(
+    val serverId: Long,
+    val albumId: String,
+    val songId: String,
+    val sortOrder: Int,
+)
+
+@Entity(tableName = "cached_playlist_details", primaryKeys = ["serverId", "playlistId"])
+data class CachedPlaylistDetailEntity(
+    val serverId: Long,
+    val playlistId: String,
+    val name: String,
+    val owner: String?,
+    val isPublic: Boolean?,
+    val songCount: Int?,
+    val durationSeconds: Int?,
+    val coverArtId: String?,
+    val created: String?,
+    val changed: String?,
+    val cachedAt: Long,
+    val isComplete: Boolean,
+)
+
+@Entity(
+    tableName = "cached_playlist_detail_songs",
+    primaryKeys = ["serverId", "playlistId", "sortOrder"],
+    indices = [
+        Index(value = ["serverId", "playlistId"]),
+        Index(value = ["serverId", "songId"]),
+    ],
+)
+data class CachedPlaylistDetailSongEntity(
+    val serverId: Long,
+    val playlistId: String,
+    val songId: String,
+    val sortOrder: Int,
+)

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -124,6 +124,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
     }
 
     override suspend fun saveSongs(serverId: Long, songs: List<Song>) = withContext(ioDispatcher) {
+        val cachedAt = System.currentTimeMillis()
         val entities = songs.map { song ->
             CachedLibrarySongEntity(
                 serverId = serverId,
@@ -150,19 +151,27 @@ class DefaultLibraryCacheRepository @Inject constructor(
             )
         }
         dao.replaceSongs(serverId, entities)
+        songs.asSequence()
+            .map { song -> song.toMetadataEntity(serverId, cachedAt) }
+            .chunked(SONG_METADATA_WRITE_CHUNK_SIZE)
+            .forEach { chunk -> dao.insertSongMetadata(chunk) }
     }
 
     override suspend fun getArtistDetail(
         serverId: Long,
         artistId: String,
     ): CachedArtistDetail? = withContext(ioDispatcher) {
-        val detail = dao.getArtistDetail(serverId, artistId) ?: return@withContext null
-        val albums = dao.getArtistDetailAlbums(serverId, artistId).map { it.toDomain() }
-        val topSongRefs = dao.getArtistDetailSongs(serverId, artistId)
-        CachedArtistDetail(
-            artist = detail.toDomain(albums),
-            topSongs = resolveSongs(serverId, topSongRefs.map { it.songId }),
-        )
+        val detail = dao.getArtistDetail(serverId, artistId)
+        if (detail != null) {
+            val albums = dao.getArtistDetailAlbums(serverId, artistId).map { it.toDomain() }
+            val topSongRefs = dao.getArtistDetailSongs(serverId, artistId)
+            return@withContext CachedArtistDetail(
+                artist = detail.toDomain(albums),
+                songs = resolveSongs(serverId, topSongRefs.map { it.songId }),
+                songsAreTopSongs = true,
+            )
+        }
+        getInferredArtistDetail(serverId, artistId)
     }
 
     override suspend fun saveArtistDetail(
@@ -175,7 +184,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
             albums = detail.artist.albums.mapIndexed { index, album ->
                 album.toArtistDetailAlbumEntity(serverId, detail.artist.id, index)
             },
-            topSongs = detail.topSongs.mapIndexed { index, song ->
+            topSongs = detail.songs.mapIndexed { index, song ->
                 CachedArtistDetailSongEntity(
                     serverId = serverId,
                     artistId = detail.artist.id,
@@ -183,7 +192,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
                     sortOrder = index,
                 )
             },
-            songMetadata = detail.topSongs.map { song -> song.toMetadataEntity(serverId, cachedAt) },
+            songMetadata = detail.songs.map { song -> song.toMetadataEntity(serverId, cachedAt) },
         )
     }
 
@@ -191,9 +200,12 @@ class DefaultLibraryCacheRepository @Inject constructor(
         serverId: Long,
         albumId: String,
     ): Album? = withContext(ioDispatcher) {
-        val detail = dao.getAlbumDetail(serverId, albumId) ?: return@withContext null
-        val songRefs = dao.getAlbumDetailSongs(serverId, albumId)
-        detail.toDomain(resolveSongs(serverId, songRefs.map { it.songId }))
+        val detail = dao.getAlbumDetail(serverId, albumId)
+        if (detail != null) {
+            val songRefs = dao.getAlbumDetailSongs(serverId, albumId)
+            return@withContext detail.toDomain(resolveSongs(serverId, songRefs.map { it.songId }))
+        }
+        getInferredAlbumDetail(serverId, albumId)
     }
 
     override suspend fun saveAlbumDetail(
@@ -301,14 +313,135 @@ class DefaultLibraryCacheRepository @Inject constructor(
 
     private suspend fun resolveSongs(serverId: Long, songIds: List<String>): List<Song> {
         if (songIds.isEmpty()) return emptyList()
-        val songsById = songIds.distinct()
+        val distinctSongIds = songIds.distinct()
+        val metadataSongs = distinctSongIds
             .chunked(SONG_METADATA_QUERY_CHUNK_SIZE)
-            .flatMap { chunk -> dao.getSongMetadata(serverId, chunk) }
-            .associateBy(CachedSongMetadataEntity::songId)
-        return songIds.mapNotNull { songId -> songsById[songId]?.toDomain() }
+            .flatMap { chunk -> dao.getSongMetadata(serverId, chunk).map { it.toDomain() } }
+        val librarySongs = distinctSongIds
+            .chunked(SONG_METADATA_QUERY_CHUNK_SIZE)
+            .flatMap { chunk -> dao.getLibrarySongs(serverId, chunk).map { it.toDomain() } }
+        val songsById = (librarySongs + metadataSongs).associateBy(Song::id)
+        return songIds.mapNotNull { songId -> songsById[songId] }
+    }
+
+    private suspend fun getInferredArtistDetail(
+        serverId: Long,
+        artistId: String,
+    ): CachedArtistDetail? {
+        val songs = resolveSongsByArtistId(serverId, artistId)
+        val cachedAlbums = dao.getAlbumSummariesByArtistId(serverId, artistId)
+            .map { it.toDomain() }
+            .distinctBy(AlbumSummary::id)
+        val albums = (cachedAlbums + inferAlbumSummariesFromSongs(songs)).distinctBy(AlbumSummary::id)
+        if (albums.isEmpty() && songs.isEmpty()) return null
+
+        val summary = dao.getArtistSummary(serverId, artistId)
+        val artist = summary?.toDomain(albums) ?: Artist(
+            id = artistId,
+            name = songs.firstOrNull()?.artist ?: albums.firstOrNull()?.artist ?: artistId,
+            coverArtId = songs.asSequence().mapNotNull(Song::coverArtId).firstOrNull()
+                ?: albums.asSequence().mapNotNull(AlbumSummary::coverArtId).firstOrNull(),
+            artistImageUrl = null,
+            albumCount = albums.size.takeIf { it > 0 },
+            albums = albums,
+        )
+        return CachedArtistDetail(
+            artist = artist,
+            songs = songs,
+            songsAreTopSongs = false,
+        )
+    }
+
+    private suspend fun getInferredAlbumDetail(
+        serverId: Long,
+        albumId: String,
+    ): Album? {
+        val songs = resolveSongsByAlbumId(serverId, albumId)
+        if (songs.isEmpty()) return null
+        val summary = dao.getAlbumSummary(serverId, albumId)?.toDomain()
+        return summary?.toDomain(songs) ?: songs.first().toInferredAlbum(albumId, songs)
+    }
+
+    private suspend fun resolveSongsByAlbumId(serverId: Long, albumId: String): List<Song> {
+        val librarySongs = dao.getLibrarySongsByAlbumId(serverId, albumId).map { it.toDomain() }
+        val metadataSongs = dao.getSongMetadataByAlbumId(serverId, albumId).map { it.toDomain() }
+        return mergeSongs(librarySongs, metadataSongs)
+    }
+
+    private suspend fun resolveSongsByArtistId(serverId: Long, artistId: String): List<Song> {
+        val librarySongs = dao.getLibrarySongsByArtistId(serverId, artistId).map { it.toDomain() }
+        val metadataSongs = dao.getSongMetadataByArtistId(serverId, artistId).map { it.toDomain() }
+        return mergeSongs(librarySongs, metadataSongs)
+    }
+
+    private fun mergeSongs(primary: List<Song>, secondary: List<Song>): List<Song> {
+        return (primary + secondary).distinctBy(Song::id)
+    }
+
+    private fun inferAlbumSummariesFromSongs(songs: List<Song>): List<AlbumSummary> {
+        return songs.asSequence()
+            .filter { song -> song.albumId != null }
+            .groupBy { song -> song.albumId.orEmpty() }
+            .map { (albumId, albumSongs) -> albumSongs.first().toInferredAlbumSummary(albumId, albumSongs) }
+            .sortedWith(compareBy<AlbumSummary>({ it.year ?: Int.MAX_VALUE }, { it.name.lowercase() }))
+    }
+
+    private fun Song.toInferredAlbumSummary(albumId: String, songs: List<Song>) = AlbumSummary(
+        id = albumId,
+        name = album ?: albumId,
+        artist = artist,
+        artistId = artistId,
+        coverArtId = coverArtId,
+        songCount = songs.size,
+        durationSeconds = songs.totalDurationSeconds(),
+        year = year,
+        genre = genre,
+        created = null,
+    )
+
+    private fun AlbumSummary.toDomain(songs: List<Song>) = Album(
+        id = id,
+        name = name,
+        artist = artist,
+        artistId = artistId,
+        coverArtId = coverArtId,
+        songCount = songCount ?: songs.size,
+        durationSeconds = durationSeconds ?: songs.totalDurationSeconds(),
+        year = year,
+        genre = genre,
+        created = created,
+        songs = songs,
+    )
+
+    private fun Song.toInferredAlbum(albumId: String, songs: List<Song>) = Album(
+        id = albumId,
+        name = album ?: albumId,
+        artist = artist,
+        artistId = artistId,
+        coverArtId = coverArtId,
+        songCount = songs.size,
+        durationSeconds = songs.totalDurationSeconds(),
+        year = year,
+        genre = genre,
+        created = null,
+        songs = songs,
+    )
+
+    private fun List<Song>.totalDurationSeconds(): Int? {
+        val durations = mapNotNull(Song::durationSeconds)
+        return durations.takeIf { it.isNotEmpty() }?.sum()
     }
 
     private fun CachedArtistDetailEntity.toDomain(albums: List<AlbumSummary>) = Artist(
+        id = artistId,
+        name = name,
+        coverArtId = coverArtId,
+        artistImageUrl = artistImageUrl,
+        albumCount = albumCount,
+        albums = albums,
+    )
+
+    private fun CachedArtistEntity.toDomain(albums: List<AlbumSummary>) = Artist(
         id = artistId,
         name = name,
         coverArtId = coverArtId,
@@ -469,5 +602,6 @@ class DefaultLibraryCacheRepository @Inject constructor(
 
     private companion object {
         const val SONG_METADATA_QUERY_CHUNK_SIZE = 500
+        const val SONG_METADATA_WRITE_CHUNK_SIZE = 500
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -1,16 +1,28 @@
 package org.hdhmc.saki.data.repository
 
 import org.hdhmc.saki.data.local.dao.LibraryCacheDao
+import org.hdhmc.saki.data.local.entity.CachedAlbumDetailEntity
+import org.hdhmc.saki.data.local.entity.CachedAlbumDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedAlbumEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistDetailAlbumEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistDetailEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistEntity
 import org.hdhmc.saki.data.local.entity.CachedLibrarySongEntity
+import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailEntity
+import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistEntity
+import org.hdhmc.saki.data.local.entity.CachedSongMetadataEntity
 import org.hdhmc.saki.di.IoDispatcher
+import org.hdhmc.saki.domain.model.Album
 import org.hdhmc.saki.domain.model.AlbumListType
 import org.hdhmc.saki.domain.model.AlbumSummary
+import org.hdhmc.saki.domain.model.Artist
 import org.hdhmc.saki.domain.model.ArtistSection
 import org.hdhmc.saki.domain.model.ArtistSummary
+import org.hdhmc.saki.domain.model.CachedArtistDetail
 import org.hdhmc.saki.domain.model.LibraryIndexes
+import org.hdhmc.saki.domain.model.Playlist
 import org.hdhmc.saki.domain.model.PlaylistSummary
 import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.domain.repository.LibraryCacheRepository
@@ -140,6 +152,97 @@ class DefaultLibraryCacheRepository @Inject constructor(
         dao.replaceSongs(serverId, entities)
     }
 
+    override suspend fun getArtistDetail(
+        serverId: Long,
+        artistId: String,
+    ): CachedArtistDetail? = withContext(ioDispatcher) {
+        val detail = dao.getArtistDetail(serverId, artistId) ?: return@withContext null
+        val albums = dao.getArtistDetailAlbums(serverId, artistId).map { it.toDomain() }
+        val topSongRefs = dao.getArtistDetailSongs(serverId, artistId)
+        CachedArtistDetail(
+            artist = detail.toDomain(albums),
+            topSongs = resolveSongs(serverId, topSongRefs.map { it.songId }),
+        )
+    }
+
+    override suspend fun saveArtistDetail(
+        serverId: Long,
+        detail: CachedArtistDetail,
+    ): Unit = withContext(ioDispatcher) {
+        val cachedAt = System.currentTimeMillis()
+        dao.replaceArtistDetail(
+            detail = detail.artist.toEntity(serverId, cachedAt),
+            albums = detail.artist.albums.mapIndexed { index, album ->
+                album.toArtistDetailAlbumEntity(serverId, detail.artist.id, index)
+            },
+            topSongs = detail.topSongs.mapIndexed { index, song ->
+                CachedArtistDetailSongEntity(
+                    serverId = serverId,
+                    artistId = detail.artist.id,
+                    songId = song.id,
+                    sortOrder = index,
+                )
+            },
+            songMetadata = detail.topSongs.map { song -> song.toMetadataEntity(serverId, cachedAt) },
+        )
+    }
+
+    override suspend fun getAlbumDetail(
+        serverId: Long,
+        albumId: String,
+    ): Album? = withContext(ioDispatcher) {
+        val detail = dao.getAlbumDetail(serverId, albumId) ?: return@withContext null
+        val songRefs = dao.getAlbumDetailSongs(serverId, albumId)
+        detail.toDomain(resolveSongs(serverId, songRefs.map { it.songId }))
+    }
+
+    override suspend fun saveAlbumDetail(
+        serverId: Long,
+        album: Album,
+    ): Unit = withContext(ioDispatcher) {
+        val cachedAt = System.currentTimeMillis()
+        dao.replaceAlbumDetail(
+            detail = album.toEntity(serverId, cachedAt),
+            songs = album.songs.mapIndexed { index, song ->
+                CachedAlbumDetailSongEntity(
+                    serverId = serverId,
+                    albumId = album.id,
+                    songId = song.id,
+                    sortOrder = index,
+                )
+            },
+            songMetadata = album.songs.map { song -> song.toMetadataEntity(serverId, cachedAt) },
+        )
+    }
+
+    override suspend fun getPlaylistDetail(
+        serverId: Long,
+        playlistId: String,
+    ): Playlist? = withContext(ioDispatcher) {
+        val detail = dao.getPlaylistDetail(serverId, playlistId) ?: return@withContext null
+        val songRefs = dao.getPlaylistDetailSongs(serverId, playlistId)
+        detail.toDomain(resolveSongs(serverId, songRefs.map { it.songId }))
+    }
+
+    override suspend fun savePlaylistDetail(
+        serverId: Long,
+        playlist: Playlist,
+    ): Unit = withContext(ioDispatcher) {
+        val cachedAt = System.currentTimeMillis()
+        dao.replacePlaylistDetail(
+            detail = playlist.toEntity(serverId, cachedAt),
+            songs = playlist.songs.mapIndexed { index, song ->
+                CachedPlaylistDetailSongEntity(
+                    serverId = serverId,
+                    playlistId = playlist.id,
+                    songId = song.id,
+                    sortOrder = index,
+                )
+            },
+            songMetadata = playlist.songs.map { song -> song.toMetadataEntity(serverId, cachedAt) },
+        )
+    }
+
     private fun CachedArtistEntity.toDomain() = ArtistSummary(
         id = artistId,
         name = name,
@@ -195,4 +298,176 @@ class DefaultLibraryCacheRepository @Inject constructor(
         path = path,
         created = created,
     )
+
+    private suspend fun resolveSongs(serverId: Long, songIds: List<String>): List<Song> {
+        if (songIds.isEmpty()) return emptyList()
+        val songsById = songIds.distinct()
+            .chunked(SONG_METADATA_QUERY_CHUNK_SIZE)
+            .flatMap { chunk -> dao.getSongMetadata(serverId, chunk) }
+            .associateBy(CachedSongMetadataEntity::songId)
+        return songIds.mapNotNull { songId -> songsById[songId]?.toDomain() }
+    }
+
+    private fun CachedArtistDetailEntity.toDomain(albums: List<AlbumSummary>) = Artist(
+        id = artistId,
+        name = name,
+        coverArtId = coverArtId,
+        artistImageUrl = artistImageUrl,
+        albumCount = albumCount,
+        albums = albums,
+    )
+
+    private fun Artist.toEntity(serverId: Long, cachedAt: Long) = CachedArtistDetailEntity(
+        serverId = serverId,
+        artistId = id,
+        name = name,
+        coverArtId = coverArtId,
+        artistImageUrl = artistImageUrl,
+        albumCount = albumCount,
+        cachedAt = cachedAt,
+        isComplete = true,
+    )
+
+    private fun AlbumSummary.toArtistDetailAlbumEntity(
+        serverId: Long,
+        detailArtistId: String,
+        sortOrder: Int,
+    ) = CachedArtistDetailAlbumEntity(
+        serverId = serverId,
+        artistId = detailArtistId,
+        albumId = id,
+        name = name,
+        artist = artist,
+        albumArtistId = artistId,
+        coverArtId = coverArtId,
+        songCount = songCount,
+        durationSeconds = durationSeconds,
+        year = year,
+        genre = genre,
+        created = created,
+        sortOrder = sortOrder,
+    )
+
+    private fun CachedArtistDetailAlbumEntity.toDomain() = AlbumSummary(
+        id = albumId,
+        name = name,
+        artist = artist,
+        artistId = albumArtistId,
+        coverArtId = coverArtId,
+        songCount = songCount,
+        durationSeconds = durationSeconds,
+        year = year,
+        genre = genre,
+        created = created,
+    )
+
+    private fun Album.toEntity(serverId: Long, cachedAt: Long) = CachedAlbumDetailEntity(
+        serverId = serverId,
+        albumId = id,
+        name = name,
+        artist = artist,
+        artistId = artistId,
+        coverArtId = coverArtId,
+        songCount = songCount,
+        durationSeconds = durationSeconds,
+        year = year,
+        genre = genre,
+        created = created,
+        cachedAt = cachedAt,
+        isComplete = true,
+    )
+
+    private fun CachedAlbumDetailEntity.toDomain(songs: List<Song>) = Album(
+        id = albumId,
+        name = name,
+        artist = artist,
+        artistId = artistId,
+        coverArtId = coverArtId,
+        songCount = songCount,
+        durationSeconds = durationSeconds,
+        year = year,
+        genre = genre,
+        created = created,
+        songs = songs,
+    )
+
+    private fun Playlist.toEntity(serverId: Long, cachedAt: Long) = CachedPlaylistDetailEntity(
+        serverId = serverId,
+        playlistId = id,
+        name = name,
+        owner = owner,
+        isPublic = isPublic,
+        songCount = songCount,
+        durationSeconds = durationSeconds,
+        coverArtId = coverArtId,
+        created = created,
+        changed = changed,
+        cachedAt = cachedAt,
+        isComplete = true,
+    )
+
+    private fun CachedPlaylistDetailEntity.toDomain(songs: List<Song>) = Playlist(
+        id = playlistId,
+        name = name,
+        owner = owner,
+        isPublic = isPublic,
+        songCount = songCount,
+        durationSeconds = durationSeconds,
+        coverArtId = coverArtId,
+        created = created,
+        changed = changed,
+        songs = songs,
+    )
+
+    private fun Song.toMetadataEntity(serverId: Long, cachedAt: Long) = CachedSongMetadataEntity(
+        serverId = serverId,
+        songId = id,
+        parentId = parentId,
+        title = title,
+        album = album,
+        albumId = albumId,
+        artist = artist,
+        artistId = artistId,
+        coverArtId = coverArtId,
+        durationSeconds = durationSeconds,
+        track = track,
+        discNumber = discNumber,
+        year = year,
+        genre = genre,
+        bitRate = bitRate,
+        sampleRate = sampleRate,
+        suffix = suffix,
+        contentType = contentType,
+        sizeBytes = sizeBytes,
+        path = path,
+        created = created,
+        cachedAt = cachedAt,
+    )
+
+    private fun CachedSongMetadataEntity.toDomain() = Song(
+        id = songId,
+        parentId = parentId,
+        title = title,
+        album = album,
+        albumId = albumId,
+        artist = artist,
+        artistId = artistId,
+        coverArtId = coverArtId,
+        durationSeconds = durationSeconds,
+        track = track,
+        discNumber = discNumber,
+        year = year,
+        genre = genre,
+        bitRate = bitRate,
+        sampleRate = sampleRate,
+        suffix = suffix,
+        contentType = contentType,
+        sizeBytes = sizeBytes,
+        path = path,
+        created = created,
+    )
+
+    private companion object {
+        const val SONG_METADATA_QUERY_CHUNK_SIZE = 500
+    }
 }

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -151,6 +151,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
             )
         }
         dao.replaceSongs(serverId, entities)
+        dao.pruneUnreferencedSongMetadata(serverId)
         songs.asSequence()
             .map { song -> song.toMetadataEntity(serverId, cachedAt) }
             .chunked(SONG_METADATA_WRITE_CHUNK_SIZE)

--- a/app/src/main/java/org/hdhmc/saki/di/DatabaseModule.kt
+++ b/app/src/main/java/org/hdhmc/saki/di/DatabaseModule.kt
@@ -332,6 +332,20 @@ object DatabaseModule {
             db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_song_metadata_serverId_artistId` ON `cached_song_metadata` (`serverId`, `artistId`)")
             db.execSQL(
                 """
+                INSERT OR REPLACE INTO `cached_song_metadata` (
+                    `serverId`, `songId`, `parentId`, `title`, `album`, `albumId`, `artist`, `artistId`,
+                    `coverArtId`, `durationSeconds`, `track`, `discNumber`, `year`, `genre`, `bitRate`,
+                    `sampleRate`, `suffix`, `contentType`, `sizeBytes`, `path`, `created`, `cachedAt`
+                )
+                SELECT
+                    `serverId`, `songId`, `parentId`, `title`, `album`, `albumId`, `artist`, `artistId`,
+                    `coverArtId`, `durationSeconds`, `track`, `discNumber`, `year`, `genre`, `bitRate`,
+                    `sampleRate`, `suffix`, `contentType`, `sizeBytes`, `path`, `created`, 0
+                FROM `cached_library_songs`
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
                 CREATE TABLE IF NOT EXISTS `cached_artist_details` (
                     `serverId` INTEGER NOT NULL,
                     `artistId` TEXT NOT NULL,

--- a/app/src/main/java/org/hdhmc/saki/di/DatabaseModule.kt
+++ b/app/src/main/java/org/hdhmc/saki/di/DatabaseModule.kt
@@ -297,6 +297,156 @@ object DatabaseModule {
         }
     }
 
+    private val migration11To12 = object : Migration(11, 12) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_song_metadata` (
+                    `serverId` INTEGER NOT NULL,
+                    `songId` TEXT NOT NULL,
+                    `parentId` TEXT,
+                    `title` TEXT NOT NULL COLLATE NOCASE,
+                    `album` TEXT,
+                    `albumId` TEXT,
+                    `artist` TEXT,
+                    `artistId` TEXT,
+                    `coverArtId` TEXT,
+                    `durationSeconds` INTEGER,
+                    `track` INTEGER,
+                    `discNumber` INTEGER,
+                    `year` INTEGER,
+                    `genre` TEXT,
+                    `bitRate` INTEGER,
+                    `sampleRate` INTEGER,
+                    `suffix` TEXT,
+                    `contentType` TEXT,
+                    `sizeBytes` INTEGER,
+                    `path` TEXT,
+                    `created` TEXT,
+                    `cachedAt` INTEGER NOT NULL,
+                    PRIMARY KEY(`serverId`, `songId`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_song_metadata_serverId_albumId` ON `cached_song_metadata` (`serverId`, `albumId`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_song_metadata_serverId_artistId` ON `cached_song_metadata` (`serverId`, `artistId`)")
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_artist_details` (
+                    `serverId` INTEGER NOT NULL,
+                    `artistId` TEXT NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `coverArtId` TEXT,
+                    `artistImageUrl` TEXT,
+                    `albumCount` INTEGER,
+                    `cachedAt` INTEGER NOT NULL,
+                    `isComplete` INTEGER NOT NULL,
+                    PRIMARY KEY(`serverId`, `artistId`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_artist_detail_albums` (
+                    `serverId` INTEGER NOT NULL,
+                    `artistId` TEXT NOT NULL,
+                    `albumId` TEXT NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `artist` TEXT,
+                    `albumArtistId` TEXT,
+                    `coverArtId` TEXT,
+                    `songCount` INTEGER,
+                    `durationSeconds` INTEGER,
+                    `year` INTEGER,
+                    `genre` TEXT,
+                    `created` TEXT,
+                    `sortOrder` INTEGER NOT NULL,
+                    PRIMARY KEY(`serverId`, `artistId`, `albumId`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_artist_detail_albums_serverId_artistId_sortOrder` ON `cached_artist_detail_albums` (`serverId`, `artistId`, `sortOrder`)")
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_artist_detail_songs` (
+                    `serverId` INTEGER NOT NULL,
+                    `artistId` TEXT NOT NULL,
+                    `songId` TEXT NOT NULL,
+                    `sortOrder` INTEGER NOT NULL,
+                    PRIMARY KEY(`serverId`, `artistId`, `sortOrder`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_artist_detail_songs_serverId_artistId` ON `cached_artist_detail_songs` (`serverId`, `artistId`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_artist_detail_songs_serverId_songId` ON `cached_artist_detail_songs` (`serverId`, `songId`)")
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_album_details` (
+                    `serverId` INTEGER NOT NULL,
+                    `albumId` TEXT NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `artist` TEXT,
+                    `artistId` TEXT,
+                    `coverArtId` TEXT,
+                    `songCount` INTEGER,
+                    `durationSeconds` INTEGER,
+                    `year` INTEGER,
+                    `genre` TEXT,
+                    `created` TEXT,
+                    `cachedAt` INTEGER NOT NULL,
+                    `isComplete` INTEGER NOT NULL,
+                    PRIMARY KEY(`serverId`, `albumId`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_album_detail_songs` (
+                    `serverId` INTEGER NOT NULL,
+                    `albumId` TEXT NOT NULL,
+                    `songId` TEXT NOT NULL,
+                    `sortOrder` INTEGER NOT NULL,
+                    PRIMARY KEY(`serverId`, `albumId`, `sortOrder`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_album_detail_songs_serverId_albumId` ON `cached_album_detail_songs` (`serverId`, `albumId`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_album_detail_songs_serverId_songId` ON `cached_album_detail_songs` (`serverId`, `songId`)")
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_playlist_details` (
+                    `serverId` INTEGER NOT NULL,
+                    `playlistId` TEXT NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `owner` TEXT,
+                    `isPublic` INTEGER,
+                    `songCount` INTEGER,
+                    `durationSeconds` INTEGER,
+                    `coverArtId` TEXT,
+                    `created` TEXT,
+                    `changed` TEXT,
+                    `cachedAt` INTEGER NOT NULL,
+                    `isComplete` INTEGER NOT NULL,
+                    PRIMARY KEY(`serverId`, `playlistId`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_playlist_detail_songs` (
+                    `serverId` INTEGER NOT NULL,
+                    `playlistId` TEXT NOT NULL,
+                    `songId` TEXT NOT NULL,
+                    `sortOrder` INTEGER NOT NULL,
+                    PRIMARY KEY(`serverId`, `playlistId`, `sortOrder`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_playlist_detail_songs_serverId_playlistId` ON `cached_playlist_detail_songs` (`serverId`, `playlistId`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_cached_playlist_detail_songs_serverId_songId` ON `cached_playlist_detail_songs` (`serverId`, `songId`)")
+        }
+    }
+
     @Provides
     @Singleton
     fun provideSakiDatabase(
@@ -313,7 +463,7 @@ object DatabaseModule {
     fun allMigrations() = arrayOf(
         migration1To2, migration2To3, migration3To4, migration4To5,
         migration5To6, migration6To7, migration7To8, migration8To9,
-        migration9To10, migration10To11,
+        migration9To10, migration10To11, migration11To12,
     )
 
     @Provides

--- a/app/src/main/java/org/hdhmc/saki/domain/model/SubsonicModels.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/SubsonicModels.kt
@@ -46,6 +46,11 @@ data class Artist(
     val albums: List<AlbumSummary>,
 )
 
+data class CachedArtistDetail(
+    val artist: Artist,
+    val topSongs: List<Song>,
+)
+
 enum class AlbumListType(val apiValue: String) {
     RANDOM("random"),
     NEWEST("newest"),

--- a/app/src/main/java/org/hdhmc/saki/domain/model/SubsonicModels.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/SubsonicModels.kt
@@ -48,7 +48,8 @@ data class Artist(
 
 data class CachedArtistDetail(
     val artist: Artist,
-    val topSongs: List<Song>,
+    val songs: List<Song>,
+    val songsAreTopSongs: Boolean = true,
 )
 
 enum class AlbumListType(val apiValue: String) {

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/LibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/LibraryCacheRepository.kt
@@ -1,8 +1,11 @@
 package org.hdhmc.saki.domain.repository
 
 import org.hdhmc.saki.domain.model.AlbumListType
+import org.hdhmc.saki.domain.model.Album
 import org.hdhmc.saki.domain.model.AlbumSummary
+import org.hdhmc.saki.domain.model.CachedArtistDetail
 import org.hdhmc.saki.domain.model.LibraryIndexes
+import org.hdhmc.saki.domain.model.Playlist
 import org.hdhmc.saki.domain.model.PlaylistSummary
 import org.hdhmc.saki.domain.model.Song
 
@@ -15,4 +18,10 @@ interface LibraryCacheRepository {
     suspend fun savePlaylists(serverId: Long, playlists: List<PlaylistSummary>)
     suspend fun getSongs(serverId: Long): List<Song>
     suspend fun saveSongs(serverId: Long, songs: List<Song>)
+    suspend fun getArtistDetail(serverId: Long, artistId: String): CachedArtistDetail?
+    suspend fun saveArtistDetail(serverId: Long, detail: CachedArtistDetail)
+    suspend fun getAlbumDetail(serverId: Long, albumId: String): Album?
+    suspend fun saveAlbumDetail(serverId: Long, album: Album)
+    suspend fun getPlaylistDetail(serverId: Long, playlistId: String): Playlist?
+    suspend fun savePlaylistDetail(serverId: Long, playlist: Playlist)
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -389,7 +389,8 @@ class SakiAppViewModel @Inject constructor(
             state.copy(
                 selectedServerId = serverId,
                 selectedArtist = null,
-                selectedArtistTopSongs = emptyList(),
+                selectedArtistSongs = emptyList(),
+                selectedArtistSongsAreTopSongs = true,
                 albumFeeds = emptyAlbumFeedStates(),
                 selectedAlbum = null,
                 selectedPlaylist = null,
@@ -504,7 +505,8 @@ class SakiAppViewModel @Inject constructor(
         mutableUiState.update { state ->
             state.copy(
                 selectedArtist = fallbackArtist,
-                selectedArtistTopSongs = emptyList(),
+                selectedArtistSongs = emptyList(),
+                selectedArtistSongsAreTopSongs = true,
                 isArtistLoading = true,
                 artistError = null,
                 selectedAlbum = null,
@@ -517,7 +519,8 @@ class SakiAppViewModel @Inject constructor(
                 mutableUiState.update { state ->
                     state.copy(
                         selectedArtist = cached.artist,
-                        selectedArtistTopSongs = cached.topSongs,
+                        selectedArtistSongs = cached.songs,
+                        selectedArtistSongsAreTopSongs = cached.songsAreTopSongs,
                         isArtistLoading = !endpointStatus.value.isOfflineDegraded,
                         artistError = null,
                     )
@@ -542,7 +545,8 @@ class SakiAppViewModel @Inject constructor(
                     mutableUiState.update { state ->
                         state.copy(
                             selectedArtist = artist,
-                            selectedArtistTopSongs = topSongs,
+                            selectedArtistSongs = topSongs,
+                            selectedArtistSongsAreTopSongs = true,
                             isArtistLoading = false,
                             artistError = null,
                         )
@@ -551,7 +555,7 @@ class SakiAppViewModel @Inject constructor(
                 runCatching {
                     libraryCacheRepository.saveArtistDetail(
                         serverId = serverId,
-                        detail = CachedArtistDetail(artist = artist, topSongs = topSongs),
+                        detail = CachedArtistDetail(artist = artist, songs = topSongs, songsAreTopSongs = true),
                     )
                 }.onFailure { Log.w("SakiApp", "Failed to cache artist detail", it) }
             }.onFailure { throwable ->
@@ -575,7 +579,8 @@ class SakiAppViewModel @Inject constructor(
         mutableUiState.update { state ->
             state.copy(
                 selectedArtist = null,
-                selectedArtistTopSongs = emptyList(),
+                selectedArtistSongs = emptyList(),
+                selectedArtistSongsAreTopSongs = true,
                 selectedAlbum = null,
                 artistError = null,
                 albumError = null,
@@ -1125,7 +1130,8 @@ class SakiAppViewModel @Inject constructor(
                 servers = servers,
                 selectedServerId = selectedServerId,
                 selectedArtist = if (serverChanged) null else state.selectedArtist,
-                selectedArtistTopSongs = if (serverChanged) emptyList() else state.selectedArtistTopSongs,
+                selectedArtistSongs = if (serverChanged) emptyList() else state.selectedArtistSongs,
+                selectedArtistSongsAreTopSongs = if (serverChanged) true else state.selectedArtistSongsAreTopSongs,
                 albumFeeds = if (serverChanged) emptyAlbumFeedStates() else state.albumFeeds,
                 selectedAlbum = if (serverChanged) null else state.selectedAlbum,
                 selectedPlaylist = if (serverChanged) null else state.selectedPlaylist,
@@ -1816,7 +1822,8 @@ data class SakiAppUiState(
     val isArtistsLoading: Boolean = false,
     val artistsError: UiText? = null,
     val selectedArtist: Artist? = null,
-    val selectedArtistTopSongs: List<Song> = emptyList(),
+    val selectedArtistSongs: List<Song> = emptyList(),
+    val selectedArtistSongsAreTopSongs: Boolean = true,
     val isArtistLoading: Boolean = false,
     val artistError: UiText? = null,
     val albumFeeds: Map<AlbumListType, AlbumFeedState> = emptyAlbumFeedStates(),

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -15,7 +15,9 @@ import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.domain.model.AlbumSummary
 import org.hdhmc.saki.domain.model.Artist
+import org.hdhmc.saki.domain.model.ArtistSummary
 import org.hdhmc.saki.domain.model.CacheStorageSummary
+import org.hdhmc.saki.domain.model.CachedArtistDetail
 import org.hdhmc.saki.domain.model.CachedSong
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
 import org.hdhmc.saki.domain.model.LibraryIndexes
@@ -498,9 +500,10 @@ class SakiAppViewModel @Inject constructor(
 
     fun openArtist(artistId: String) {
         val serverId = uiState.value.selectedServerId ?: return
+        val fallbackArtist = uiState.value.findArtistSummary(artistId)?.toArtist()
         mutableUiState.update { state ->
             state.copy(
-                selectedArtist = null,
+                selectedArtist = fallbackArtist,
                 selectedArtistTopSongs = emptyList(),
                 isArtistLoading = true,
                 artistError = null,
@@ -509,6 +512,28 @@ class SakiAppViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
+            val cached = runCatching { libraryCacheRepository.getArtistDetail(serverId, artistId) }.getOrNull()
+            if (cached != null && uiState.value.selectedServerId == serverId) {
+                mutableUiState.update { state ->
+                    state.copy(
+                        selectedArtist = cached.artist,
+                        selectedArtistTopSongs = cached.topSongs,
+                        isArtistLoading = !endpointStatus.value.isOfflineDegraded,
+                        artistError = null,
+                    )
+                }
+            }
+            if (endpointStatus.value.isOfflineDegraded) {
+                if (cached == null && fallbackArtist == null) {
+                    snackbarMessages.emit(SnackbarMessage(UiText.resource(R.string.error_cached_detail_unavailable)))
+                } else if (cached == null) {
+                    mutableUiState.update { state ->
+                        state.copy(artistError = UiText.resource(R.string.error_cached_detail_unavailable))
+                    }
+                }
+                mutableUiState.update { state -> state.copy(isArtistLoading = false) }
+                return@launch
+            }
             runCatching {
                 val artist = subsonicRepository.getArtist(serverId, artistId).data
                 artist to buildArtistTopSongs(serverId, artist)
@@ -523,12 +548,24 @@ class SakiAppViewModel @Inject constructor(
                         )
                     }
                 }
-            }.onFailure { throwable ->
-                mutableUiState.update { state ->
-                    state.copy(
-                        isArtistLoading = false,
-                        artistError = throwable.localizedOr(R.string.error_load_artist_details),
+                runCatching {
+                    libraryCacheRepository.saveArtistDetail(
+                        serverId = serverId,
+                        detail = CachedArtistDetail(artist = artist, topSongs = topSongs),
                     )
+                }.onFailure { Log.w("SakiApp", "Failed to cache artist detail", it) }
+            }.onFailure { throwable ->
+                if (uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { state ->
+                        state.copy(
+                            isArtistLoading = false,
+                            artistError = if (cached == null && fallbackArtist == null) {
+                                throwable.localizedOr(R.string.error_load_artist_details)
+                            } else {
+                                null
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -548,14 +585,37 @@ class SakiAppViewModel @Inject constructor(
 
     fun openAlbum(albumId: String) {
         val serverId = uiState.value.selectedServerId ?: return
+        val fallbackAlbum = uiState.value.findAlbumSummary(albumId)?.toAlbum()
         mutableUiState.update { state ->
             state.copy(
+                selectedAlbum = fallbackAlbum,
                 isAlbumLoading = true,
                 albumError = null,
             )
         }
 
         viewModelScope.launch {
+            val cached = runCatching { libraryCacheRepository.getAlbumDetail(serverId, albumId) }.getOrNull()
+            if (cached != null && uiState.value.selectedServerId == serverId) {
+                mutableUiState.update { state ->
+                    state.copy(
+                        selectedAlbum = cached,
+                        isAlbumLoading = !endpointStatus.value.isOfflineDegraded,
+                        albumError = null,
+                    )
+                }
+            }
+            if (endpointStatus.value.isOfflineDegraded) {
+                if (cached == null && fallbackAlbum == null) {
+                    snackbarMessages.emit(SnackbarMessage(UiText.resource(R.string.error_cached_detail_unavailable)))
+                } else if (cached == null) {
+                    mutableUiState.update { state ->
+                        state.copy(albumError = UiText.resource(R.string.error_cached_detail_unavailable))
+                    }
+                }
+                mutableUiState.update { state -> state.copy(isAlbumLoading = false) }
+                return@launch
+            }
             runCatching {
                 subsonicRepository.getAlbum(serverId, albumId).data
             }.onSuccess { album ->
@@ -568,12 +628,20 @@ class SakiAppViewModel @Inject constructor(
                         )
                     }
                 }
+                runCatching { libraryCacheRepository.saveAlbumDetail(serverId, album) }
+                    .onFailure { Log.w("SakiApp", "Failed to cache album detail", it) }
             }.onFailure { throwable ->
-                mutableUiState.update { state ->
-                    state.copy(
-                        isAlbumLoading = false,
-                        albumError = throwable.localizedOr(R.string.error_load_album_details),
-                    )
+                if (uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { state ->
+                        state.copy(
+                            isAlbumLoading = false,
+                            albumError = if (cached == null && fallbackAlbum == null) {
+                                throwable.localizedOr(R.string.error_load_album_details)
+                            } else {
+                                null
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -590,14 +658,37 @@ class SakiAppViewModel @Inject constructor(
 
     fun openPlaylist(playlistId: String) {
         val serverId = uiState.value.selectedServerId ?: return
+        val fallbackPlaylist = uiState.value.findPlaylistSummary(playlistId)?.toPlaylist()
         mutableUiState.update { state ->
             state.copy(
+                selectedPlaylist = fallbackPlaylist,
                 isPlaylistLoading = true,
                 playlistError = null,
             )
         }
 
         viewModelScope.launch {
+            val cached = runCatching { libraryCacheRepository.getPlaylistDetail(serverId, playlistId) }.getOrNull()
+            if (cached != null && uiState.value.selectedServerId == serverId) {
+                mutableUiState.update { state ->
+                    state.copy(
+                        selectedPlaylist = cached,
+                        isPlaylistLoading = !endpointStatus.value.isOfflineDegraded,
+                        playlistError = null,
+                    )
+                }
+            }
+            if (endpointStatus.value.isOfflineDegraded) {
+                if (cached == null && fallbackPlaylist == null) {
+                    snackbarMessages.emit(SnackbarMessage(UiText.resource(R.string.error_cached_detail_unavailable)))
+                } else if (cached == null) {
+                    mutableUiState.update { state ->
+                        state.copy(playlistError = UiText.resource(R.string.error_cached_detail_unavailable))
+                    }
+                }
+                mutableUiState.update { state -> state.copy(isPlaylistLoading = false) }
+                return@launch
+            }
             runCatching {
                 subsonicRepository.getPlaylist(serverId, playlistId).data
             }.onSuccess { playlist ->
@@ -610,12 +701,20 @@ class SakiAppViewModel @Inject constructor(
                         )
                     }
                 }
+                runCatching { libraryCacheRepository.savePlaylistDetail(serverId, playlist) }
+                    .onFailure { Log.w("SakiApp", "Failed to cache playlist detail", it) }
             }.onFailure { throwable ->
-                mutableUiState.update { state ->
-                    state.copy(
-                        isPlaylistLoading = false,
-                        playlistError = throwable.localizedOr(R.string.error_load_playlist),
-                    )
+                if (uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { state ->
+                        state.copy(
+                            isPlaylistLoading = false,
+                            playlistError = if (cached == null && fallbackPlaylist == null) {
+                                throwable.localizedOr(R.string.error_load_playlist)
+                            } else {
+                                null
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -1762,6 +1861,61 @@ data class SakiAppUiState(
     val albumsError: UiText?
         get() = selectedAlbumFeedState.error
 }
+
+private fun SakiAppUiState.findArtistSummary(artistId: String): ArtistSummary? {
+    val indexes = libraryIndexes ?: return null
+    return indexes.shortcuts.firstOrNull { it.id == artistId }
+        ?: indexes.sections.asSequence()
+            .flatMap { section -> section.artists.asSequence() }
+            .firstOrNull { it.id == artistId }
+}
+
+private fun SakiAppUiState.findAlbumSummary(albumId: String): AlbumSummary? {
+    return albumFeeds.values.asSequence()
+        .flatMap { feed -> feed.albums.asSequence() }
+        .firstOrNull { it.id == albumId }
+        ?: selectedArtist?.albums?.firstOrNull { it.id == albumId }
+}
+
+private fun SakiAppUiState.findPlaylistSummary(playlistId: String): PlaylistSummary? {
+    return playlists.firstOrNull { it.id == playlistId }
+}
+
+private fun ArtistSummary.toArtist() = Artist(
+    id = id,
+    name = name,
+    coverArtId = coverArtId,
+    artistImageUrl = artistImageUrl,
+    albumCount = albumCount,
+    albums = emptyList(),
+)
+
+private fun AlbumSummary.toAlbum() = Album(
+    id = id,
+    name = name,
+    artist = artist,
+    artistId = artistId,
+    coverArtId = coverArtId,
+    songCount = songCount,
+    durationSeconds = durationSeconds,
+    year = year,
+    genre = genre,
+    created = created,
+    songs = emptyList(),
+)
+
+private fun PlaylistSummary.toPlaylist() = Playlist(
+    id = id,
+    name = name,
+    owner = owner,
+    isPublic = isPublic,
+    songCount = songCount,
+    durationSeconds = durationSeconds,
+    coverArtId = coverArtId,
+    created = created,
+    changed = changed,
+    songs = emptyList(),
+)
 
 private fun emptyAlbumFeedStates(): Map<AlbumListType, AlbumFeedState> {
     return AlbumListType.entries.associateWith { AlbumFeedState(hasMore = it.supportsPagination()) }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -69,7 +69,8 @@ import org.hdhmc.saki.domain.model.Song
 fun ArtistDetailScreen(
     server: ServerConfig,
     artist: Artist,
-    topSongs: List<Song>,
+    songs: List<Song>,
+    songsAreTopSongs: Boolean,
     cachedSongsBySongId: Map<String, CachedSong>,
     streamCachedSongIds: Set<String>,
     downloadingSongIds: Set<String>,
@@ -89,17 +90,25 @@ fun ArtistDetailScreen(
         bottomOverlayPadding = bottomOverlayPadding,
     ) {
         when {
-            isLoading && topSongs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_artist)) }
-            error != null && topSongs.isEmpty() -> item { ErrorStateCard(error) }
+            isLoading && songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_artist)) }
+            error != null && songs.isEmpty() -> item { ErrorStateCard(error) }
             else -> {
-                if (topSongs.isNotEmpty()) {
+                if (songs.isNotEmpty()) {
                     item {
                         SectionTitle(
-                            stringResource(R.string.library_popular_songs),
-                            stringResource(R.string.library_popular_songs_subtitle, artist.name),
+                            if (songsAreTopSongs) {
+                                stringResource(R.string.library_popular_songs)
+                            } else {
+                                stringResource(R.string.library_artist_songs)
+                            },
+                            if (songsAreTopSongs) {
+                                stringResource(R.string.library_popular_songs_subtitle, artist.name)
+                            } else {
+                                stringResource(R.string.library_artist_songs_subtitle, artist.name)
+                            },
                         )
                     }
-                    itemsIndexed(topSongs, key = { _, s -> s.id }) { index, song ->
+                    itemsIndexed(songs, key = { _, s -> s.id }) { index, song ->
                         val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
                         SongRow(
                             song = song,
@@ -109,7 +118,7 @@ fun ArtistDetailScreen(
                             isDownloading = song.id in downloadingSongIds,
                             isOfflineDegraded = isOfflineDegraded,
                             isOfflinePlayable = isOfflinePlayable,
-                            onClick = { onPlaySongs(topSongs, index) },
+                            onClick = { onPlaySongs(songs, index) },
                             onMore = { onShowActions(song) },
                         )
                     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -242,7 +242,8 @@ fun BrowseScreen(
                     target.hasArtist && uiState.selectedArtist != null -> ArtistDetailScreen(
                         server = currentServer,
                         artist = uiState.selectedArtist,
-                        topSongs = uiState.selectedArtistTopSongs,
+                        songs = uiState.selectedArtistSongs,
+                        songsAreTopSongs = uiState.selectedArtistSongsAreTopSongs,
                         cachedSongsBySongId = cachedSongsBySongId,
                         streamCachedSongIds = uiState.streamCachedSongIds,
                         downloadingSongIds = uiState.downloadingSongIds,

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -117,6 +117,8 @@
     <string name="library_loading_artist">正在加载艺术家</string>
     <string name="library_popular_songs">热门歌曲</string>
     <string name="library_popular_songs_subtitle">%1$s 的精选</string>
+    <string name="library_artist_songs">歌曲</string>
+    <string name="library_artist_songs_subtitle">%1$s 的歌曲</string>
     <string name="library_albums">专辑</string>
     <string name="library_albums_subtitle_full_release">查看完整专辑页面</string>
     <string name="library_loading_album">正在加载专辑</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -252,6 +252,7 @@
     <string name="error_load_artist_details">无法加载艺术家详情。</string>
     <string name="error_load_album_details">无法加载专辑详情。</string>
     <string name="error_load_playlist">无法加载播放列表。</string>
+    <string name="error_cached_detail_unavailable">此详情尚未缓存，离线不可用。</string>
     <string name="error_start_playback">无法开始播放。</string>
     <string name="message_added_to_queue">已将 %1$s 加入队列。</string>
     <string name="error_queue_song">无法将歌曲加入队列。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,8 @@
     <string name="library_loading_artist">Loading artist</string>
     <string name="library_popular_songs">Popular songs</string>
     <string name="library_popular_songs_subtitle">Quick picks for %1$s</string>
+    <string name="library_artist_songs">Songs</string>
+    <string name="library_artist_songs_subtitle">Songs by %1$s</string>
     <string name="library_albums">Albums</string>
     <string name="library_albums_subtitle_full_release">Tap into the full release page</string>
     <string name="library_loading_album">Loading album</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,7 @@
     <string name="error_load_artist_details">Unable to load artist details.</string>
     <string name="error_load_album_details">Unable to load album details.</string>
     <string name="error_load_playlist">Unable to load playlist.</string>
+    <string name="error_cached_detail_unavailable">This detail is not cached for offline use.</string>
     <string name="error_start_playback">Unable to start playback.</string>
     <string name="message_added_to_queue">Added %1$s to the queue.</string>
     <string name="error_queue_song">Unable to queue the song.</string>


### PR DESCRIPTION
## Summary
- Add Room v12 detail cache tables for artist, album, playlist details, song metadata, and detail membership.
- Cache artist/album/playlist detail responses after successful online loads.
- Allow offline artist/album/playlist detail screens to open from cached detail data.
- Infer offline album and artist detail from cached song metadata when full detail cache is missing.
- Backfill song metadata from existing cached library songs during migration.

## Notes
- Playlist membership cannot be inferred from the songs index, so playlist details still require the playlist detail to have been opened online before full offline use.
- Artist fallback uses local song metadata and is labeled as regular songs, not server-provided popular songs.
