### PR TITLE
fix: prefetch small playlist details for offline use

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
@@ -202,6 +202,9 @@ interface LibraryCacheDao {
     @Query("SELECT * FROM cached_playlist_details WHERE serverId = :serverId AND playlistId = :playlistId LIMIT 1")
     suspend fun getPlaylistDetail(serverId: Long, playlistId: String): CachedPlaylistDetailEntity?
 
+    @Query("SELECT playlistId FROM cached_playlist_details WHERE serverId = :serverId AND playlistId IN (:playlistIds)")
+    suspend fun getCachedPlaylistDetailIds(serverId: Long, playlistIds: List<String>): List<String>
+
     @Query("SELECT * FROM cached_playlist_detail_songs WHERE serverId = :serverId AND playlistId = :playlistId ORDER BY sortOrder")
     suspend fun getPlaylistDetailSongs(serverId: Long, playlistId: String): List<CachedPlaylistDetailSongEntity>
 

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -125,7 +125,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
     ): Set<String> = withContext(ioDispatcher) {
         if (playlistIds.isEmpty()) return@withContext emptySet()
         playlistIds.distinct()
-            .chunked(SONG_METADATA_QUERY_CHUNK_SIZE)
+            .chunked(IN_CLAUSE_QUERY_CHUNK_SIZE)
             .flatMap { chunk -> dao.getCachedPlaylistDetailIds(serverId, chunk) }
             .toSet()
     }
@@ -327,10 +327,10 @@ class DefaultLibraryCacheRepository @Inject constructor(
         if (songIds.isEmpty()) return emptyList()
         val distinctSongIds = songIds.distinct()
         val metadataSongs = distinctSongIds
-            .chunked(SONG_METADATA_QUERY_CHUNK_SIZE)
+            .chunked(IN_CLAUSE_QUERY_CHUNK_SIZE)
             .flatMap { chunk -> dao.getSongMetadata(serverId, chunk).map { it.toDomain() } }
         val librarySongs = distinctSongIds
-            .chunked(SONG_METADATA_QUERY_CHUNK_SIZE)
+            .chunked(IN_CLAUSE_QUERY_CHUNK_SIZE)
             .flatMap { chunk -> dao.getLibrarySongs(serverId, chunk).map { it.toDomain() } }
         val songsById = (librarySongs + metadataSongs).associateBy(Song::id)
         return songIds.mapNotNull { songId -> songsById[songId] }
@@ -613,7 +613,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
     )
 
     private companion object {
-        const val SONG_METADATA_QUERY_CHUNK_SIZE = 500
+        const val IN_CLAUSE_QUERY_CHUNK_SIZE = 500
         const val SONG_METADATA_WRITE_CHUNK_SIZE = 500
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -119,6 +119,17 @@ class DefaultLibraryCacheRepository @Inject constructor(
         dao.replacePlaylists(serverId, entities)
     }
 
+    override suspend fun getCachedPlaylistDetailIds(
+        serverId: Long,
+        playlistIds: List<String>,
+    ): Set<String> = withContext(ioDispatcher) {
+        if (playlistIds.isEmpty()) return@withContext emptySet()
+        playlistIds.distinct()
+            .chunked(SONG_METADATA_QUERY_CHUNK_SIZE)
+            .flatMap { chunk -> dao.getCachedPlaylistDetailIds(serverId, chunk) }
+            .toSet()
+    }
+
     override suspend fun getSongs(serverId: Long): List<Song> = withContext(ioDispatcher) {
         dao.getSongs(serverId).map { it.toDomain() }
     }

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/LibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/LibraryCacheRepository.kt
@@ -16,6 +16,7 @@ interface LibraryCacheRepository {
     suspend fun saveAlbums(serverId: Long, type: AlbumListType, albums: List<AlbumSummary>)
     suspend fun getPlaylists(serverId: Long): List<PlaylistSummary>
     suspend fun savePlaylists(serverId: Long, playlists: List<PlaylistSummary>)
+    suspend fun getCachedPlaylistDetailIds(serverId: Long, playlistIds: List<String>): Set<String>
     suspend fun getSongs(serverId: Long): List<Song>
     suspend fun saveSongs(serverId: Long, songs: List<Song>)
     suspend fun getArtistDetail(serverId: Long, artistId: String): CachedArtistDetail?

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -1511,21 +1511,30 @@ class SakiAppViewModel @Inject constructor(
             .toList()
         if (candidates.isEmpty()) return
 
-        val cachedIds = runCatching {
+        val cachedIds = try {
             libraryCacheRepository.getCachedPlaylistDetailIds(serverId, candidates.map(PlaylistSummary::id))
-        }.onFailure {
-            Log.w("SakiApp", "Failed to read cached playlist detail ids", it)
-        }.getOrDefault(emptySet())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Log.w("SakiApp", "Failed to read cached playlist detail ids", e)
+            emptySet()
+        }
 
         candidates.filterNot { playlist -> playlist.id in cachedIds }.forEach { playlistSummary ->
             if (uiState.value.selectedServerId != serverId || endpointStatus.value.isOfflineDegraded) return
-            runCatching {
-                subsonicRepository.getPlaylist(serverId, playlistSummary.id).data
-            }.onSuccess { playlist ->
-                runCatching { libraryCacheRepository.savePlaylistDetail(serverId, playlist) }
-                    .onFailure { Log.w("SakiApp", "Failed to prefetch playlist detail", it) }
-            }.onFailure {
-                Log.w("SakiApp", "Failed to prefetch playlist detail", it)
+            try {
+                val playlist = subsonicRepository.getPlaylist(serverId, playlistSummary.id).data
+                try {
+                    libraryCacheRepository.savePlaylistDetail(serverId, playlist)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    Log.w("SakiApp", "Failed to prefetch playlist detail", e)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                Log.w("SakiApp", "Failed to prefetch playlist detail", e)
             }
         }
     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -65,6 +65,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 private const val ALBUMS_PAGE_SIZE = 36
+private const val PLAYLIST_DETAIL_PREFETCH_LIMIT = 12
+private const val PLAYLIST_DETAIL_PREFETCH_MAX_SONGS = 500
 
 @HiltViewModel
 @OptIn(FlowPreview::class)
@@ -1490,10 +1492,40 @@ class SakiAppViewModel @Inject constructor(
                 }
                 runCatching { libraryCacheRepository.savePlaylists(serverId, playlists) }
                     .onFailure { Log.w("SakiApp", "Failed to cache playlists", it) }
+                prefetchPlaylistDetails(serverId, playlists)
             }.onFailure { throwable ->
                 mutableUiState.update {
                     it.copy(isPlaylistsLoading = false, playlistsError = throwable.localizedOr(R.string.error_load_playlists))
                 }
+            }
+        }
+    }
+
+    private suspend fun prefetchPlaylistDetails(
+        serverId: Long,
+        playlists: List<PlaylistSummary>,
+    ) {
+        val candidates = playlists.asSequence()
+            .filter { playlist -> (playlist.songCount ?: Int.MAX_VALUE) <= PLAYLIST_DETAIL_PREFETCH_MAX_SONGS }
+            .take(PLAYLIST_DETAIL_PREFETCH_LIMIT)
+            .toList()
+        if (candidates.isEmpty()) return
+
+        val cachedIds = runCatching {
+            libraryCacheRepository.getCachedPlaylistDetailIds(serverId, candidates.map(PlaylistSummary::id))
+        }.onFailure {
+            Log.w("SakiApp", "Failed to read cached playlist detail ids", it)
+        }.getOrDefault(emptySet())
+
+        candidates.filterNot { playlist -> playlist.id in cachedIds }.forEach { playlistSummary ->
+            if (uiState.value.selectedServerId != serverId || endpointStatus.value.isOfflineDegraded) return
+            runCatching {
+                subsonicRepository.getPlaylist(serverId, playlistSummary.id).data
+            }.onSuccess { playlist ->
+                runCatching { libraryCacheRepository.savePlaylistDetail(serverId, playlist) }
+                    .onFailure { Log.w("SakiApp", "Failed to prefetch playlist detail", it) }
+            }.onFailure {
+                Log.w("SakiApp", "Failed to prefetch playlist detail", it)
             }
         }
     }


### PR DESCRIPTION
## Summary

After loading the playlist list online, automatically prefetch detail (songs) for the first 12 small playlists (songCount ≤ 500) into the local cache. This enables offline playlist browsing without requiring the user to manually open each playlist first.

## Changes

- Add `getCachedPlaylistDetailIds` DAO query to batch-check which playlist details are already cached.
- Expose the query through `LibraryCacheRepository`.
- Add `prefetchPlaylistDetails` in `SakiAppViewModel` — called after `savePlaylists`, filters candidates by size, skips already-cached ones, fetches and caches the rest sequentially.
- Early-exit if server changes or endpoint goes offline during prefetch.

## Design decisions

- Does **not** reverse-engineer playlist membership from cached songs — avoids showing wrong songs in offline playlists.
- No schema changes — uses existing `cached_playlist_details` / `cached_playlist_detail_songs` tables.
- Sequential fetching (not parallel) to avoid overwhelming the server.
- All errors are caught and logged without affecting the main playlist loading flow.

Relates to #108.