### PR TITLE
feat: associate cached songs with song metadata

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
@@ -305,6 +305,11 @@ interface LibraryCacheDao {
                 WHERE cached_playlist_detail_songs.serverId = cached_song_metadata.serverId
                     AND cached_playlist_detail_songs.songId = cached_song_metadata.songId
             )
+            AND NOT EXISTS (
+                SELECT 1 FROM cached_songs
+                WHERE cached_songs.serverId = cached_song_metadata.serverId
+                    AND cached_songs.songId = cached_song_metadata.songId
+            )
         """,
     )
     suspend fun pruneSongMetadataBefore(serverId: Long, cachedAt: Long)
@@ -332,6 +337,11 @@ interface LibraryCacheDao {
                 SELECT 1 FROM cached_playlist_detail_songs
                 WHERE cached_playlist_detail_songs.serverId = cached_song_metadata.serverId
                     AND cached_playlist_detail_songs.songId = cached_song_metadata.songId
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM cached_songs
+                WHERE cached_songs.serverId = cached_song_metadata.serverId
+                    AND cached_songs.songId = cached_song_metadata.songId
             )
         """,
     )

--- a/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
@@ -18,6 +18,7 @@ import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistEntity
 import org.hdhmc.saki.data.local.entity.CachedSongMetadataEntity
 import org.hdhmc.saki.data.local.entity.CachedSongMetadataOrder
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface LibraryCacheDao {
@@ -349,6 +350,9 @@ interface LibraryCacheDao {
 
     @Query("SELECT * FROM cached_song_metadata WHERE serverId = :serverId AND songId IN (:songIds)")
     suspend fun getSongMetadata(serverId: Long, songIds: List<String>): List<CachedSongMetadataEntity>
+
+    @Query("SELECT COUNT(*) FROM cached_song_metadata")
+    fun observeSongMetadataInvalidations(): Flow<Int>
 
     @Query("SELECT songId, libraryOrder FROM cached_song_metadata WHERE serverId = :serverId AND songId IN (:songIds)")
     suspend fun getSongMetadataOrders(serverId: Long, songIds: List<String>): List<CachedSongMetadataOrder>

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultCachedSongRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultCachedSongRepository.kt
@@ -2,7 +2,9 @@ package org.hdhmc.saki.data.repository
 
 import android.content.Context
 import org.hdhmc.saki.data.local.dao.CachedSongDao
+import org.hdhmc.saki.data.local.dao.LibraryCacheDao
 import org.hdhmc.saki.data.local.entity.CachedSongEntity
+import org.hdhmc.saki.data.local.entity.CachedSongMetadataEntity
 import org.hdhmc.saki.di.IoDispatcher
 import org.hdhmc.saki.domain.model.AuthenticatedUrlCandidate
 import org.hdhmc.saki.domain.model.CacheStorageSummary
@@ -33,6 +35,7 @@ import okhttp3.Request
 class DefaultCachedSongRepository @Inject constructor(
     @param:ApplicationContext private val appContext: Context,
     private val cachedSongDao: CachedSongDao,
+    private val libraryCacheDao: LibraryCacheDao,
     private val okHttpClient: OkHttpClient,
     private val playbackPreferencesRepository: PlaybackPreferencesRepository,
     private val subsonicRepository: SubsonicRepository,
@@ -40,14 +43,15 @@ class DefaultCachedSongRepository @Inject constructor(
 ) : CachedSongRepository {
     override fun observeCachedSongs(): Flow<List<CachedSong>> {
         return cachedSongDao.observeCachedSongs()
-            .map { songs -> songs.map(CachedSongEntity::toDomain) }
+            .map { songs -> songs.toDomainWithMetadata(libraryCacheDao) }
     }
 
     override suspend fun getCachedSong(
         serverId: Long,
         songId: String,
     ): CachedSong? = withContext(ioDispatcher) {
-        cachedSongDao.getCachedSong(serverId, songId)?.toDomain()
+        cachedSongDao.getCachedSong(serverId, songId)
+            ?.let { entity -> entity.toDomainWithMetadata(libraryCacheDao) }
     }
 
     override suspend fun getPlayableCachedSong(
@@ -56,7 +60,7 @@ class DefaultCachedSongRepository @Inject constructor(
         preferredQuality: StreamQuality,
     ): CachedSong? = withContext(ioDispatcher) {
         cachedSongDao.getCachedSong(serverId, songId)
-            ?.toDomain()
+            ?.let { entity -> entity.toDomainWithMetadata(libraryCacheDao) }
             ?.takeIf { song -> song.canPlayAt(preferredQuality) }
     }
 
@@ -65,8 +69,8 @@ class DefaultCachedSongRepository @Inject constructor(
         preferredQuality: StreamQuality,
     ): Map<String, CachedSong> = withContext(ioDispatcher) {
         cachedSongDao.getCachedSongsForServer(serverId)
+            .toDomainWithMetadata(libraryCacheDao)
             .asSequence()
-            .map(CachedSongEntity::toDomain)
             .filter { song -> song.canPlayAt(preferredQuality) }
             .associateBy(CachedSong::songId)
     }
@@ -321,27 +325,64 @@ private data class DownloadedBinary(
     val suffix: String?,
 )
 
-private fun CachedSongEntity.toDomain(): CachedSong {
+private data class CachedSongMetadataKey(
+    val serverId: Long,
+    val songId: String,
+)
+
+private suspend fun CachedSongEntity.toDomainWithMetadata(
+    libraryCacheDao: LibraryCacheDao,
+): CachedSong {
+    val metadata = libraryCacheDao.getSongMetadata(serverId, listOf(songId)).firstOrNull()
+    return toDomain(metadata)
+}
+
+private suspend fun List<CachedSongEntity>.toDomainWithMetadata(
+    libraryCacheDao: LibraryCacheDao,
+): List<CachedSong> {
+    if (isEmpty()) return emptyList()
+
+    val metadataByKey = groupBy(CachedSongEntity::serverId)
+        .flatMap { (serverId, songs) ->
+            songs.map(CachedSongEntity::songId)
+                .distinct()
+                .chunked(IN_CLAUSE_QUERY_CHUNK_SIZE)
+                .flatMap { songIds ->
+                    libraryCacheDao.getSongMetadata(serverId, songIds)
+                        .map { metadata -> CachedSongMetadataKey(serverId, metadata.songId) to metadata }
+                }
+        }
+        .toMap()
+
+    return map { entity ->
+        entity.toDomain(metadataByKey[CachedSongMetadataKey(entity.serverId, entity.songId)])
+    }
+}
+
+private fun CachedSongEntity.toDomain(metadata: CachedSongMetadataEntity? = null): CachedSong {
+    val quality = StreamQuality.fromStorageKey(qualityKey)
     return CachedSong(
         cacheId = cacheId,
         serverId = serverId,
         songId = songId,
-        title = title,
-        album = album,
-        albumId = albumId,
-        artist = artist,
-        artistId = artistId,
-        coverArtId = coverArtId,
+        title = metadata?.title ?: title,
+        album = metadata?.album ?: album,
+        albumId = metadata?.albumId ?: albumId,
+        artist = metadata?.artist ?: artist,
+        artistId = metadata?.artistId ?: artistId,
+        coverArtId = metadata?.coverArtId ?: coverArtId,
         coverArtPath = coverArtPath,
         localPath = localPath,
-        durationSeconds = durationSeconds,
-        track = track,
-        discNumber = discNumber,
-        suffix = suffix,
-        contentType = contentType,
-        bitRateKbps = bitRate,
-        sampleRate = sampleRate,
-        quality = StreamQuality.fromStorageKey(qualityKey),
+        durationSeconds = metadata?.durationSeconds ?: durationSeconds,
+        track = metadata?.track ?: track,
+        discNumber = metadata?.discNumber ?: discNumber,
+        suffix = suffix ?: metadata?.suffix.takeIf { quality.preferOriginalDownload },
+        contentType = contentType ?: metadata?.contentType.takeIf { quality.preferOriginalDownload },
+        bitRateKbps = bitRate
+            ?: quality.maxBitRate.takeIf { bitrate -> !quality.preferOriginalDownload && bitrate != null && bitrate > 0 }
+            ?: metadata?.bitRate.takeIf { quality.preferOriginalDownload },
+        sampleRate = sampleRate ?: metadata?.sampleRate,
+        quality = quality,
         fileSizeBytes = fileSizeBytes,
         downloadedAt = downloadedAt,
     )
@@ -395,3 +436,5 @@ private fun IOException.shouldRetryNextEndpoint(): Boolean {
         this is SocketTimeoutException ||
         this is NoRouteToHostException
 }
+
+private const val IN_CLAUSE_QUERY_CHUNK_SIZE = 500

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultCachedSongRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultCachedSongRepository.kt
@@ -26,6 +26,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -42,8 +44,12 @@ class DefaultCachedSongRepository @Inject constructor(
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : CachedSongRepository {
     override fun observeCachedSongs(): Flow<List<CachedSong>> {
-        return cachedSongDao.observeCachedSongs()
+        return combine(
+            cachedSongDao.observeCachedSongs(),
+            libraryCacheDao.observeSongMetadataInvalidations(),
+        ) { songs, _ -> songs }
             .map { songs -> songs.toDomainWithMetadata(libraryCacheDao) }
+            .flowOn(ioDispatcher)
     }
 
     override suspend fun getCachedSong(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -975,7 +975,7 @@ fun NowPlayingOverlay(
                         // Tech info bar
                         val runtimeInfo = playbackState.runtimeInfo
                         val format = track.stableFormatLabel()
-                        val sampleRate = track.sampleRate?.let(::formatSampleRateShort)
+                        val sampleRate = track.stableSampleRateLabel()
                         val bitrate = track.displayBitrate(
                             runtimeInfo = runtimeInfo,
                             preferStableMetadata = true,
@@ -2107,6 +2107,8 @@ private fun PlaybackQueueItem.prefersMetadataBitrate(): Boolean {
 }
 
 private fun PlaybackQueueItem.stableFormatLabel(): String? {
+    if (!usesOriginalPlaybackMetadata()) return null
+
     suffix?.trim()
         ?.takeIf(String::isNotEmpty)
         ?.let { return it.uppercase(java.util.Locale.ROOT) }
@@ -2127,6 +2129,15 @@ private fun PlaybackQueueItem.stableFormatLabel(): String? {
                 else -> subtype.uppercase(java.util.Locale.ROOT)
             }
         }
+}
+
+private fun PlaybackQueueItem.stableSampleRateLabel(): String? {
+    if (!usesOriginalPlaybackMetadata()) return null
+    return sampleRate?.let(::formatSampleRateShort)
+}
+
+private fun PlaybackQueueItem.usesOriginalPlaybackMetadata(): Boolean {
+    return qualityLabel.equals(StreamQuality.ORIGINAL.label, ignoreCase = true)
 }
 
 private fun formatSampleRateShort(sampleRate: Int): String {

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -975,7 +975,7 @@ fun NowPlayingOverlay(
                         // Tech info bar
                         val runtimeInfo = playbackState.runtimeInfo
                         val format = track.stableFormatLabel()
-                        val sampleRate = track.stableSampleRateLabel()
+                        val sampleRate = track.sampleRate?.let(::formatSampleRateShort)
                         val bitrate = track.displayBitrate(
                             runtimeInfo = runtimeInfo,
                             preferStableMetadata = true,
@@ -2107,8 +2107,6 @@ private fun PlaybackQueueItem.prefersMetadataBitrate(): Boolean {
 }
 
 private fun PlaybackQueueItem.stableFormatLabel(): String? {
-    if (!usesOriginalPlaybackMetadata()) return null
-
     suffix?.trim()
         ?.takeIf(String::isNotEmpty)
         ?.let { return it.uppercase(java.util.Locale.ROOT) }
@@ -2129,15 +2127,6 @@ private fun PlaybackQueueItem.stableFormatLabel(): String? {
                 else -> subtype.uppercase(java.util.Locale.ROOT)
             }
         }
-}
-
-private fun PlaybackQueueItem.stableSampleRateLabel(): String? {
-    if (!usesOriginalPlaybackMetadata()) return null
-    return sampleRate?.let(::formatSampleRateShort)
-}
-
-private fun PlaybackQueueItem.usesOriginalPlaybackMetadata(): Boolean {
-    return qualityLabel.equals(StreamQuality.ORIGINAL.label, ignoreCase = true)
 }
 
 private fun formatSampleRateShort(sampleRate: Int): String {


### PR DESCRIPTION
## Summary

- Overlay canonical `cached_song_metadata` fields onto downloaded `CachedSong` records by `(serverId, songId)`.
- Preserve cache-specific playback fields such as local path, quality, file size, downloaded timestamp, and downloaded media metadata.
- Keep downloaded-song metadata rows from being pruned while the corresponding `cached_songs` row still exists.

## Scope

This addresses #219 with a soft association between download cache records and the song metadata cache.

The physical cache key model is unchanged:

- downloaded songs still use their existing `cached_songs` row and local file path;
- stream cache keys still remain `serverId + songId + qualityKey`;
- playback queue, shuffle, repeat, and playable checks are unchanged.

Info bar and transcode display behavior are intentionally left unchanged in this PR and should be handled separately.

## Validation

- Ran `git diff --check`.
- Local Android build not run; CI should validate compilation.
