### PR TITLE
fix: clarify playback bitrate display

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultCachedSongRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultCachedSongRepository.kt
@@ -384,9 +384,11 @@ private fun CachedSongEntity.toDomain(metadata: CachedSongMetadataEntity? = null
         discNumber = metadata?.discNumber ?: discNumber,
         suffix = suffix ?: metadata?.suffix.takeIf { quality.preferOriginalDownload },
         contentType = contentType ?: metadata?.contentType.takeIf { quality.preferOriginalDownload },
-        bitRateKbps = bitRate
-            ?: quality.maxBitRate.takeIf { bitrate -> !quality.preferOriginalDownload && bitrate != null && bitrate > 0 }
-            ?: metadata?.bitRate.takeIf { quality.preferOriginalDownload },
+        bitRateKbps = cachedDisplayBitRateKbps(
+            storedBitRate = bitRate,
+            sourceBitRate = metadata?.bitRate,
+            quality = quality,
+        ),
         sampleRate = sampleRate ?: metadata?.sampleRate,
         quality = quality,
         fileSizeBytes = fileSizeBytes,
@@ -399,9 +401,27 @@ private fun CachedSong.canPlayAt(preferredQuality: StreamQuality): Boolean {
 }
 
 private fun Song.cachedBitRateKbps(quality: StreamQuality): Int? {
-    return quality.maxBitRate
+    val requestedMaxBitRate = quality.maxBitRate
         ?.takeIf { bitrate -> bitrate > 0 && !quality.preferOriginalDownload }
-        ?: bitRate
+        ?: return bitRate?.takeIf { bitrate -> bitrate > 0 }
+    return bitRate?.takeIf { bitrate -> bitrate > 0 }?.coerceAtMost(requestedMaxBitRate)
+        ?: requestedMaxBitRate
+}
+
+private fun cachedDisplayBitRateKbps(
+    storedBitRate: Int?,
+    sourceBitRate: Int?,
+    quality: StreamQuality,
+): Int? {
+    val requestedMaxBitRate = quality.maxBitRate
+        ?.takeIf { bitrate -> bitrate > 0 && !quality.preferOriginalDownload }
+        ?: return storedBitRate?.takeIf { bitrate -> bitrate > 0 }
+            ?: sourceBitRate?.takeIf { bitrate -> bitrate > 0 }
+    val knownSourceBitRate = sourceBitRate?.takeIf { bitrate -> bitrate > 0 }
+    if (knownSourceBitRate != null && knownSourceBitRate <= requestedMaxBitRate) {
+        return knownSourceBitRate
+    }
+    return storedBitRate?.takeIf { bitrate -> bitrate > 0 } ?: requestedMaxBitRate
 }
 
 private fun CachedSongEntity.withPlaybackMetadataFrom(

--- a/app/src/main/java/org/hdhmc/saki/domain/model/PlaybackModels.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/PlaybackModels.kt
@@ -229,6 +229,7 @@ data class PlaybackQueueItem(
     val suffix: String? = null,
     val bitRateKbps: Int? = null,
     val sourceBitRateKbps: Int? = null,
+    val requestedMaxBitRateKbps: Int? = null,
     val sampleRate: Int? = null,
     val contentType: String? = null,
 )

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -163,8 +163,8 @@ class DefaultPlaybackManager @Inject constructor(
             streamCacheKey = streamCacheRepository.buildCacheKey(serverId, songId, quality),
             maxBitRate = quality.maxBitRate,
             format = quality.format,
-            bitRate = displayBitRateKbps(sourceBitRate ?: bitRate, quality.maxBitRate),
-            sourceBitRate = sourceBitRate ?: bitRate,
+            bitRate = estimatedPlaybackBitRateKbps(sourceBitRate, quality.maxBitRate),
+            sourceBitRate = sourceBitRate,
         ).toLogicalMediaItem()
     }
 
@@ -769,10 +769,11 @@ class DefaultPlaybackManager @Inject constructor(
                     }
                     item.copy(
                         qualityLabel = quality.label,
-                        bitRateKbps = displayBitRateKbps(
-                            sourceBitRate = item.sourceBitRateKbps ?: item.bitRateKbps,
+                        bitRateKbps = estimatedPlaybackBitRateKbps(
+                            sourceBitRate = item.sourceBitRateKbps,
                             maxBitRate = quality.maxBitRate,
                         ),
+                        requestedMaxBitRateKbps = quality.maxBitRate,
                     )
                 } else {
                     item

--- a/app/src/main/java/org/hdhmc/saki/playback/SubsonicPlaybackItems.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SubsonicPlaybackItems.kt
@@ -65,11 +65,14 @@ internal data class PlaybackRequest(
     val sampleRate: Int?,
 )
 
-internal fun displayBitRateKbps(
+internal fun estimatedPlaybackBitRateKbps(
     sourceBitRate: Int?,
     maxBitRate: Int?,
 ): Int? {
-    return maxBitRate?.takeIf { bitrate -> bitrate > 0 } ?: sourceBitRate
+    val knownSourceBitRate = sourceBitRate?.takeIf { bitrate -> bitrate > 0 }
+    val requestedMaxBitRate = maxBitRate?.takeIf { bitrate -> bitrate > 0 }
+        ?: return knownSourceBitRate
+    return knownSourceBitRate?.coerceAtMost(requestedMaxBitRate) ?: requestedMaxBitRate
 }
 
 internal fun Song.toPlaybackRequestMediaItem(
@@ -102,7 +105,7 @@ internal fun Song.toPlaybackRequestMediaItem(
         maxBitRate = maxBitRate,
         format = format,
         suffix = suffix,
-        bitRate = displayBitRateKbps(bitRate, maxBitRate),
+        bitRate = estimatedPlaybackBitRateKbps(bitRate, maxBitRate),
         sourceBitRate = bitRate,
         sampleRate = sampleRate,
     )
@@ -195,8 +198,7 @@ internal fun MediaItem.toPlaybackRequestOrNull(): PlaybackRequest? {
         suffix = extras.getString(EXTRA_SUFFIX),
         bitRate = extras.getInt(EXTRA_BIT_RATE).takeIf { extras.containsKey(EXTRA_BIT_RATE) },
         sourceBitRate = extras.getInt(EXTRA_SOURCE_BIT_RATE)
-            .takeIf { extras.containsKey(EXTRA_SOURCE_BIT_RATE) }
-            ?: extras.getInt(EXTRA_BIT_RATE).takeIf { extras.containsKey(EXTRA_BIT_RATE) },
+            .takeIf { extras.containsKey(EXTRA_SOURCE_BIT_RATE) },
         sampleRate = extras.getInt(EXTRA_SAMPLE_RATE).takeIf { extras.containsKey(EXTRA_SAMPLE_RATE) },
     )
 }
@@ -228,8 +230,8 @@ internal fun MediaItem.toQueueItemOrNull(): PlaybackQueueItem? {
         suffix = extras.getString(EXTRA_SUFFIX),
         bitRateKbps = extras.getInt(EXTRA_BIT_RATE).takeIf { extras.containsKey(EXTRA_BIT_RATE) },
         sourceBitRateKbps = extras.getInt(EXTRA_SOURCE_BIT_RATE)
-            .takeIf { extras.containsKey(EXTRA_SOURCE_BIT_RATE) }
-            ?: extras.getInt(EXTRA_BIT_RATE).takeIf { extras.containsKey(EXTRA_BIT_RATE) },
+            .takeIf { extras.containsKey(EXTRA_SOURCE_BIT_RATE) },
+        requestedMaxBitRateKbps = extras.getInt(EXTRA_MAX_BIT_RATE).takeIf { extras.containsKey(EXTRA_MAX_BIT_RATE) },
         sampleRate = extras.getInt(EXTRA_SAMPLE_RATE).takeIf { extras.containsKey(EXTRA_SAMPLE_RATE) },
         contentType = extras.getString(EXTRA_MIME_TYPE),
     )

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -105,6 +105,7 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.graphics.Color
@@ -137,7 +138,6 @@ import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.RepeatModeSetting
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.SongLyrics
-import org.hdhmc.saki.domain.model.StreamQuality
 import java.io.File
 import coil3.imageLoader
 import coil3.request.ImageRequest
@@ -973,21 +973,50 @@ fun NowPlayingOverlay(
                             )
                         }
                         // Tech info bar
-                        val runtimeInfo = playbackState.runtimeInfo
-                        val format = track.stableFormatLabel()
-                        val sampleRate = track.sampleRate?.let(::formatSampleRateShort)
-                        val bitrate = track.displayBitrate(
-                            runtimeInfo = runtimeInfo,
-                            preferStableMetadata = true,
-                        )
-                        val techParts = listOfNotNull(format, sampleRate, bitrate)
-                        if (techParts.isNotEmpty()) {
+                        val techTextCandidate = track
+                            .compactTechnicalInfoParts(
+                                playbackState.runtimeInfo?.takeIf { runtimeInfo -> runtimeInfo.hasCompactTechnicalInfo() },
+                            )
+                            .joinToString(" | ")
+                        var visibleTechText by remember { mutableStateOf("") }
+                        var visibleTechMediaId by remember { mutableStateOf<String?>(null) }
+                        LaunchedEffect(track.mediaId, techTextCandidate) {
+                            if (visibleTechMediaId != track.mediaId) {
+                                visibleTechMediaId = track.mediaId
+                                visibleTechText = ""
+                            }
+                            if (techTextCandidate.isBlank()) {
+                                visibleTechText = ""
+                            } else {
+                                delay(COMPACT_TECH_INFO_SETTLE_MS)
+                                visibleTechText = techTextCandidate
+                            }
+                        }
+                        AnimatedContent(
+                            targetState = visibleTechText,
+                            modifier = Modifier.fillMaxWidth(),
+                            transitionSpec = {
+                                fadeIn(tween(COMPACT_TECH_INFO_FADE_MS)) togetherWith
+                                    fadeOut(tween(COMPACT_TECH_INFO_FADE_MS))
+                            },
+                            label = "compact-tech-info",
+                        ) { text ->
                             Text(
-                                text = techParts.joinToString(" | "),
+                                text = text,
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .then(
+                                        if (text.isEmpty()) {
+                                            Modifier.clearAndSetSemantics {}
+                                        } else {
+                                            Modifier
+                                        },
+                                    ),
                                 textAlign = TextAlign.Center,
+                                minLines = 1,
+                                maxLines = 1,
                             )
                         }
                         // Queue toggle
@@ -1088,10 +1117,22 @@ fun NowPlayingOverlay(
                             },
                         )
                     }
+                    item { DetailLine(stringResource(R.string.detail_source_media), track.sourceMediaInfoLabel()) }
+                    if (!track.isCached) {
+                        item {
+                            DetailLine(
+                                stringResource(R.string.detail_requested_quality),
+                                track.requestedQualityInfoLabel(localizeQualityLabel(track.qualityLabel)),
+                            )
+                        }
+                    }
+                    item { DetailLine(stringResource(R.string.detail_playing_media), track.playingMediaInfoLabel(playbackState.runtimeInfo)) }
                     item { DetailLine(stringResource(R.string.detail_mime_type), playbackState.runtimeInfo?.sampleMimeType ?: track.contentType) }
                     item { DetailLine(stringResource(R.string.detail_container), playbackState.runtimeInfo?.containerMimeType) }
                     item { DetailLine(stringResource(R.string.detail_codec), playbackState.runtimeInfo?.codecs ?: track.suffix?.uppercase(java.util.Locale.ROOT)) }
-                    item { DetailLine(stringResource(R.string.detail_average_bitrate), track.displayBitrate(playbackState.runtimeInfo)) }
+                    playbackState.runtimeInfo?.averageBitrate?.let { averageBitrate ->
+                        item { DetailLine(stringResource(R.string.detail_average_bitrate), formatBitrate(averageBitrate)) }
+                    }
                     item { DetailLine(stringResource(R.string.detail_peak_bitrate), playbackState.runtimeInfo?.peakBitrate?.let(::formatBitrate)) }
                     item { DetailLine(stringResource(R.string.detail_sample_rate), (playbackState.runtimeInfo?.sampleRate ?: track.sampleRate)?.let(::formatSampleRate)) }
                     item { DetailLine(stringResource(R.string.detail_channels), playbackState.runtimeInfo?.channelCount?.toString()) }
@@ -1889,6 +1930,8 @@ private const val ARTWORK_PREWARM_RADIUS_PAGES = 3
 private const val ARTWORK_BACKGROUND_SETTLE_MS = 180
 private const val ARTWORK_BUTTON_SKIP_CONFIRM_TIMEOUT_MS = 900L
 private const val ARTWORK_BUTTON_SKIP_INITIAL_VELOCITY_PAGES = 3.5f
+private const val COMPACT_TECH_INFO_SETTLE_MS = 700L
+private const val COMPACT_TECH_INFO_FADE_MS = 700
 private const val PROGRAMMATIC_ARTWORK_SPRING_BASE_STIFFNESS = 140f
 private const val PROGRAMMATIC_ARTWORK_SPRING_DISTANCE_STIFFNESS = 60f
 private const val PROGRAMMATIC_ARTWORK_MAX_INITIAL_VELOCITY_PAGES = 8f
@@ -2088,22 +2131,82 @@ private fun formatBitrate(bitrate: Int): String {
     }
 }
 
-private fun PlaybackQueueItem.displayBitrate(
-    runtimeInfo: PlaybackRuntimeInfo?,
-    preferStableMetadata: Boolean = false,
-): String? {
-    val metadataBitrate = bitRateKbps?.let { "$it kbps" }
-    val runtimeBitrate = runtimeInfo?.averageBitrate?.let(::formatBitrate)
-    if (preferStableMetadata) return metadataBitrate ?: runtimeBitrate
-    return if (prefersMetadataBitrate()) {
-        metadataBitrate ?: runtimeBitrate
-    } else {
-        runtimeBitrate ?: metadataBitrate
-    }
+private fun PlaybackQueueItem.compactTechnicalInfoParts(runtimeInfo: PlaybackRuntimeInfo?): List<String> {
+    val showSourceTechnicalInfo = shouldShowSourceTechnicalInfo()
+    val stableFormat = stableFormatLabel().takeIf { showSourceTechnicalInfo }
+    val stableSampleRate = sampleRate?.let(::formatSampleRateShort).takeIf { showSourceTechnicalInfo }
+    return listOfNotNull(
+        runtimeInfo?.formatLabel() ?: stableFormat,
+        runtimeInfo?.sampleRate?.let(::formatSampleRateShort) ?: stableSampleRate,
+        runtimeInfo?.averageBitrate?.let(::formatBitrate) ?: stableBitrateDisplay()?.label(),
+    )
 }
 
-private fun PlaybackQueueItem.prefersMetadataBitrate(): Boolean {
-    return !qualityLabel.equals(StreamQuality.ORIGINAL.label, ignoreCase = true) && bitRateKbps != null
+private fun PlaybackQueueItem.sourceMediaInfoLabel(): String? {
+    return listOfNotNull(
+        stableFormatLabel(),
+        sampleRate?.let(::formatSampleRateShort),
+        sourceBitRateKbps?.takeIf { bitrate -> bitrate > 0 }?.let(::formatKbps),
+    ).joinNonEmpty()
+}
+
+private fun PlaybackQueueItem.requestedQualityInfoLabel(localizedQualityLabel: String): String? {
+    val requestedMaxBitRate = requestedMaxBitRateKbps?.takeIf { bitrate -> bitrate > 0 }
+    return requestedMaxBitRate?.let { bitrate -> "<=${formatKbps(bitrate)}" } ?: localizedQualityLabel
+}
+
+private fun PlaybackQueueItem.playingMediaInfoLabel(runtimeInfo: PlaybackRuntimeInfo?): String? {
+    val showSourceTechnicalInfo = shouldShowSourceTechnicalInfo()
+    return listOfNotNull(
+        runtimeInfo?.formatLabel() ?: stableFormatLabel().takeIf { showSourceTechnicalInfo },
+        runtimeInfo?.sampleRate?.let(::formatSampleRateShort)
+            ?: sampleRate?.let(::formatSampleRateShort).takeIf { showSourceTechnicalInfo },
+        runtimeInfo?.averageBitrate?.let(::formatBitrate) ?: stableBitrateDisplay()?.label(),
+    ).joinNonEmpty()
+}
+
+private fun PlaybackQueueItem.shouldShowSourceTechnicalInfo(): Boolean {
+    if (isCached) return true
+    val requestedMaxBitRate = requestedMaxBitRateKbps?.takeIf { bitrate -> bitrate > 0 }
+        ?: return true
+    val sourceBitRate = sourceBitRateKbps?.takeIf { bitrate -> bitrate > 0 } ?: return false
+    return sourceBitRate <= requestedMaxBitRate
+}
+
+private fun PlaybackQueueItem.stableBitrateDisplay(): BitrateDisplay? {
+    val requestedMaxBitRate = requestedMaxBitRateKbps?.takeIf { bitrate -> bitrate > 0 }
+    val sourceBitRate = sourceBitRateKbps?.takeIf { bitrate -> bitrate > 0 }
+    val displayBitRate = bitRateKbps?.takeIf { bitrate -> bitrate > 0 }
+    if (isCached || requestedMaxBitRate == null) {
+        return (displayBitRate ?: sourceBitRate)?.let { bitrate -> BitrateDisplay(bitrate) }
+    }
+    if (sourceBitRate != null && sourceBitRate <= requestedMaxBitRate) {
+        return BitrateDisplay(sourceBitRate)
+    }
+    return BitrateDisplay(requestedMaxBitRate, isUpperBound = true)
+}
+
+private data class BitrateDisplay(
+    val kbps: Int,
+    val isUpperBound: Boolean = false,
+) {
+    fun label(): String = if (isUpperBound) "<=${formatKbps(kbps)}" else formatKbps(kbps)
+}
+
+private fun formatKbps(kbps: Int): String = "$kbps kbps"
+
+private fun PlaybackRuntimeInfo.formatLabel(): String? {
+    return sampleMimeType?.mediaFormatLabel()
+        ?: containerMimeType?.mediaFormatLabel()
+        ?: codecs?.takeIf(String::isNotBlank)
+}
+
+private fun PlaybackRuntimeInfo.hasCompactTechnicalInfo(): Boolean {
+    return formatLabel() != null || sampleRate != null || averageBitrate != null
+}
+
+private fun List<String>.joinNonEmpty(): String? {
+    return takeIf { parts -> parts.isNotEmpty() }?.joinToString(" | ")
 }
 
 private fun PlaybackQueueItem.stableFormatLabel(): String? {
@@ -2111,14 +2214,19 @@ private fun PlaybackQueueItem.stableFormatLabel(): String? {
         ?.takeIf(String::isNotEmpty)
         ?.let { return it.uppercase(java.util.Locale.ROOT) }
 
-    return contentType?.substringAfter("/")
-        ?.substringBefore(";")
-        ?.trim()
-        ?.takeIf(String::isNotEmpty)
+    return contentType?.mediaFormatLabel()
+}
+
+private fun String.mediaFormatLabel(): String? {
+    return substringAfter("/")
+        .substringBefore(";")
+        .trim()
+        .takeIf(String::isNotEmpty)
         ?.let { subtype ->
             when (subtype.lowercase(java.util.Locale.ROOT)) {
                 "mpeg", "mp3" -> "MP3"
                 "mp4", "x-m4a", "m4a" -> "M4A"
+                "mp4a-latm", "aac" -> "AAC"
                 "flac" -> "FLAC"
                 "ogg", "oga" -> "OGG"
                 "opus" -> "Opus"

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -160,6 +160,9 @@
     <string name="detail_quality">质量</string>
     <string name="detail_server">服务器</string>
     <string name="detail_mode">模式</string>
+    <string name="detail_source_media">源文件</string>
+    <string name="detail_requested_quality">请求</string>
+    <string name="detail_playing_media">正在播放</string>
     <string name="detail_mime_type">MIME 类型</string>
     <string name="detail_container">容器</string>
     <string name="detail_codec">编解码器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,6 +168,9 @@
     <string name="detail_quality">Quality</string>
     <string name="detail_server">Server</string>
     <string name="detail_mode">Mode</string>
+    <string name="detail_source_media">Source</string>
+    <string name="detail_requested_quality">Request</string>
+    <string name="detail_playing_media">Playing</string>
     <string name="detail_mime_type">MIME type</string>
     <string name="detail_container">Container</string>
     <string name="detail_codec">Codec</string>

--- a/app/src/test/java/org/hdhmc/saki/playback/SubsonicPlaybackItemsTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/playback/SubsonicPlaybackItemsTest.kt
@@ -1,0 +1,21 @@
+package org.hdhmc.saki.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SubsonicPlaybackItemsTest {
+    @Test
+    fun estimatedPlaybackBitRateUsesSourceWhenBelowRequestedMaximum() {
+        assertEquals(128, estimatedPlaybackBitRateKbps(sourceBitRate = 128, maxBitRate = 320))
+    }
+
+    @Test
+    fun estimatedPlaybackBitRateUsesRequestedMaximumWhenSourceIsHigher() {
+        assertEquals(320, estimatedPlaybackBitRateKbps(sourceBitRate = 921, maxBitRate = 320))
+    }
+
+    @Test
+    fun estimatedPlaybackBitRateKeepsSourceForOriginalQuality() {
+        assertEquals(921, estimatedPlaybackBitRateKbps(sourceBitRate = 921, maxBitRate = 0))
+    }
+}


### PR DESCRIPTION
## Summary

- Distinguish requested transcode max bitrate from displayed playback bitrate.
- Show stable bitrate estimates without claiming `maxBitRate` is the actual media bitrate.
- Let compact technical info wait for stable data and update with a fade instead of flashing between transient states.
- Add detail rows for source/request/playing media info so runtime decoder metadata can be shown separately from source metadata.

## Details

Subsonic `maxBitRate` is a request ceiling, not a guarantee that the returned stream is actually encoded at that bitrate. A 128 kbps MP3 requested with `maxBitRate=320` can legitimately remain the original 128 kbps stream.

This PR changes playback display logic so low-bitrate sources requested with a higher max bitrate keep showing the source bitrate, while high-bitrate sources requested with a lower max bitrate are shown as an upper-bound estimate until runtime playback info is available.

For the compact now playing info bar, text changes now settle before becoming visible and then crossfade. This avoids one-frame jumps when switching tracks or when runtime info changes during playback.

Cached-song display bitrate uses the same estimate logic, but this PR does not change physical cache file identity or deduplication behavior. That follow-up is tracked separately in #223.

Fixes #222.

## Validation

- Ran `git diff --check`.
- Added a small JVM unit test for playback bitrate estimation.
- Android build not run locally; CI should validate.
