### PR TITLE
Fix endpoint status after server switching

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/remote/EndpointSelector.kt
@@ -47,6 +47,9 @@ class EndpointSelector @Inject constructor(
     private val forcedEndpoints = ConcurrentHashMap<Long, Long>()
     private val lastProbeResults = ConcurrentHashMap<Long, List<EndpointProbeResult>>()
     private val serverConfigs = ConcurrentHashMap<Long, ServerConfig>()
+    private val activeProbes = ConcurrentHashMap<Long, ActiveProbe>()
+    private val probeGenerations = ConcurrentHashMap<Long, Long>()
+    private val probingServers = ConcurrentHashMap<Long, Boolean>()
 
     private val _probeVersion = MutableStateFlow(0L)
     val probeVersion: StateFlow<Long> = _probeVersion.asStateFlow()
@@ -63,6 +66,12 @@ class EndpointSelector @Inject constructor(
         val endpoint: ServerEndpoint,
         val latencyMs: Long?,
         val reachable: Boolean,
+    )
+
+    private data class ActiveProbe(
+        val generation: Long,
+        val job: Job,
+        val firstReachable: CompletableDeferred<ServerEndpoint?>,
     )
 
     private var networkCallbackRegistered = false
@@ -110,88 +119,129 @@ class EndpointSelector @Inject constructor(
      * Remaining probes continue in background to find the optimal endpoint.
      * Cancels any previous in-flight probe for the same server.
      */
-    private val activeProbeJobs = ConcurrentHashMap<Long, Job>()
-
     suspend fun probe(serverId: Long, server: ServerConfig): ServerEndpoint? {
-        activeProbeJobs.remove(serverId)?.cancel()
-        serverConfigs[serverId] = server
-        val endpoints = server.endpoints
-        if (endpoints.isEmpty()) return null
-        if (endpoints.size == 1) {
-            val ep = endpoints.first()
-            val latency = pingEndpoint(ep, server)
-            lastProbeResults[serverId] = listOf(EndpointProbeResult(ep, latency, latency != null))
-            if (forcedEndpoints[serverId] == null) {
-                if (latency != null) {
-                    bestEndpoints[serverId] = ep.id
-                } else {
-                    bestEndpoints.remove(serverId)
-                }
-            }
-            _probeVersion.update { it + 1 }
-            return if (latency != null) ep else null
+        activeProbes.remove(serverId)?.let { activeProbe ->
+            activeProbe.job.cancel()
+            activeProbe.firstReachable.complete(null)
         }
-
-        val probeResults = ConcurrentHashMap<Long, Long>()
-        // Initialize all endpoints as unreachable
-        lastProbeResults[serverId] = endpoints.map { EndpointProbeResult(it, null, false) }
+        serverConfigs[serverId] = server
+        val endpoints = server.endpoints.sortedBy(ServerEndpoint::order)
+        val generation = nextProbeGeneration(serverId)
+        probingServers[serverId] = true
+        _probeVersion.update { it + 1 }
+        if (endpoints.isEmpty()) {
+            lastProbeResults.remove(serverId)
+            bestEndpoints.remove(serverId)
+            probingServers.remove(serverId)
+            _probeVersion.update { it + 1 }
+            return null
+        }
 
         val firstReachable = CompletableDeferred<ServerEndpoint?>()
+        val probeResults = ConcurrentHashMap<Long, Long>()
+        val completedEndpointIds = ConcurrentHashMap.newKeySet<Long>()
+        var probeFinished = false
 
-        val jobs = endpoints.map { endpoint ->
-            scope.launch {
-                val latency = pingEndpoint(endpoint, server)
-                if (latency != null) {
-                    probeResults[endpoint.id] = latency
-                    if (forcedEndpoints[serverId] == null) {
-                        val currentBestId = bestEndpoints[serverId]
-                        val currentBestLatency = currentBestId?.let { probeResults[it] }
-                        if (currentBestLatency == null || latency < currentBestLatency) {
-                            bestEndpoints[serverId] = endpoint.id
+        val parentJob = scope.launch {
+            try {
+                val jobs = endpoints.map { endpoint ->
+                    launch {
+                        val latency = pingEndpoint(endpoint, server)
+                        if (!isCurrentProbe(serverId, generation)) return@launch
+                        completedEndpointIds += endpoint.id
+                        if (latency != null) {
+                            probeResults[endpoint.id] = latency
+                            recordReachableEndpoint(serverId, endpoint, latency)
+                            firstReachable.complete(endpoint)
                         }
+                        publishProbeResults(serverId, endpoints, probeResults, completedEndpointIds, final = false)
                     }
                 }
-                // Update this endpoint's result incrementally
-                lastProbeResults[serverId] = endpoints.map { ep ->
-                    val lat = probeResults[ep.id]
-                    EndpointProbeResult(ep, lat, lat != null)
+                jobs.forEach { it.join() }
+                if (!isCurrentProbe(serverId, generation)) return@launch
+                if (probeResults.isEmpty() && forcedEndpoints[serverId] == null) {
+                    bestEndpoints.remove(serverId)
                 }
-                _probeVersion.update { it + 1 }
-                if (latency != null) firstReachable.complete(endpoint)
+                publishProbeResults(serverId, endpoints, probeResults, completedEndpointIds, final = true)
+                selectBestKnownReachableEndpoint(serverId)
+                clearProbeInProgress(serverId, generation)
+                probeFinished = true
+                firstReachable.complete(null)
+            } finally {
+                if (!probeFinished && isCurrentProbe(serverId, generation)) {
+                    clearProbeInProgress(serverId, generation)
+                }
             }
         }
 
-        // Single background coroutine: wait for all jobs, then finalize
-        val parentJob = scope.launch {
-            jobs.forEach { it.join() }
-            firstReachable.complete(null) // all failed
-            if (probeResults.isEmpty() && forcedEndpoints[serverId] == null) {
-                bestEndpoints.remove(serverId)
-            }
-            _probeVersion.update { it + 1 }
-        }
-        activeProbeJobs[serverId] = parentJob
+        activeProbes[serverId] = ActiveProbe(
+            generation = generation,
+            job = parentJob,
+            firstReachable = firstReachable,
+        )
 
         return firstReachable.await()
     }
 
     fun sortedEndpoints(serverId: Long, endpoints: List<ServerEndpoint>): List<ServerEndpoint> {
-        val bestId = bestEndpoints[serverId] ?: return endpoints
-        val best = endpoints.find { it.id == bestId } ?: return endpoints
-        return listOf(best) + endpoints.filter { it.id != bestId }
+        val bestId = bestEndpoints[serverId]
+        val failedIds = lastProbeResults[serverId]
+            .orEmpty()
+            .filterNot { result -> result.reachable }
+            .map { it.endpoint.id }
+            .toSet()
+        val ordered = endpoints.sortedBy { endpoint -> if (endpoint.id in failedIds) 1 else 0 }
+        val best = bestId?.let { id -> ordered.find { it.id == id } }
+        return if (best == null) {
+            ordered
+        } else {
+            listOf(best) + ordered.filter { it.id != best.id }
+        }
     }
 
     fun invalidate(serverId: Long, failedEndpointId: Long) {
         forcedEndpoints.remove(serverId, failedEndpointId)
-        if (bestEndpoints.remove(serverId, failedEndpointId)) {
-            _probeVersion.update { it + 1 }
+        val removedActiveEndpoint = bestEndpoints.remove(serverId, failedEndpointId)
+        val endpoint = serverConfigs[serverId]?.endpoints?.firstOrNull { it.id == failedEndpointId }
+            ?: return
+        upsertProbeResult(serverId, EndpointProbeResult(endpoint, latencyMs = null, reachable = false))
+        if (removedActiveEndpoint && forcedEndpoints[serverId] == null) {
+            selectBestKnownReachableEndpoint(serverId)
         }
+        _probeVersion.update { it + 1 }
     }
 
     fun getActiveEndpointId(serverId: Long): Long? = bestEndpoints[serverId]
 
+    fun getActiveEndpoint(serverId: Long): ServerEndpoint? {
+        val activeEndpointId = getActiveEndpointId(serverId) ?: return null
+        return serverConfigs[serverId]?.endpoints?.firstOrNull { it.id == activeEndpointId }
+    }
+
     fun getLastProbeResults(serverId: Long): List<EndpointProbeResult> =
         lastProbeResults[serverId] ?: emptyList()
+
+    fun isProbeInProgress(serverId: Long): Boolean = probingServers[serverId] == true
+
+    fun hasCompletedProbe(serverId: Long): Boolean {
+        if (isProbeInProgress(serverId)) return false
+        val endpointIds = serverConfigs[serverId]?.endpoints?.map { it.id }?.toSet().orEmpty()
+        if (endpointIds.isEmpty()) return false
+        val resultIds = lastProbeResults[serverId].orEmpty().map { it.endpoint.id }.toSet()
+        return resultIds.containsAll(endpointIds)
+    }
+
+    fun isOfflineDegraded(serverId: Long): Boolean {
+        if (bestEndpoints[serverId] != null) return false
+        val results = lastProbeResults[serverId].orEmpty()
+        return hasCompletedProbe(serverId) && results.none { it.reachable }
+    }
+
+    fun recordSuccess(serverId: Long, endpoint: ServerEndpoint, latencyMs: Long? = null) {
+        serverConfigs[serverId] ?: return
+        recordReachableEndpoint(serverId, endpoint, latencyMs)
+        _probeVersion.update { it + 1 }
+    }
 
     fun forceEndpoint(serverId: Long, endpointId: Long) {
         forcedEndpoints[serverId] = endpointId
@@ -202,6 +252,7 @@ class EndpointSelector @Inject constructor(
     fun clearForce(serverId: Long) {
         forcedEndpoints.remove(serverId)
         bestEndpoints.remove(serverId)
+        selectBestKnownReachableEndpoint(serverId)
         _probeVersion.update { it + 1 }
     }
 
@@ -229,6 +280,102 @@ class EndpointSelector @Inject constructor(
         return serverConfigs[serverId]?.endpoints
             ?.sortedBy(ServerEndpoint::order)
             ?.firstOrNull()
+    }
+
+    private fun nextProbeGeneration(serverId: Long): Long {
+        return probeGenerations.merge(serverId, 1L) { current, increment -> current + increment } ?: 1L
+    }
+
+    private fun isCurrentProbe(serverId: Long, generation: Long): Boolean {
+        return probeGenerations[serverId] == generation
+    }
+
+    private fun clearProbeInProgress(serverId: Long, generation: Long) {
+        probingServers.remove(serverId)
+        activeProbes.computeIfPresent(serverId) { _, activeProbe ->
+            activeProbe.takeUnless { it.generation == generation }
+        }
+        _probeVersion.update { it + 1 }
+    }
+
+    private fun recordReachableEndpoint(
+        serverId: Long,
+        endpoint: ServerEndpoint,
+        latencyMs: Long?,
+    ) {
+        val previous = lastProbeResults[serverId]
+            .orEmpty()
+            .firstOrNull { it.endpoint.id == endpoint.id }
+        upsertProbeResult(
+            serverId,
+            EndpointProbeResult(
+                endpoint = endpoint,
+                latencyMs = latencyMs ?: previous?.latencyMs,
+                reachable = true,
+            ),
+        )
+        if (forcedEndpoints[serverId] == null) {
+            val currentBestId = bestEndpoints[serverId]
+            val currentBestLatency = lastProbeResults[serverId]
+                .orEmpty()
+                .firstOrNull { it.endpoint.id == currentBestId }
+                ?.latencyMs
+            if (
+                currentBestId == null ||
+                latencyMs == null ||
+                currentBestLatency == null ||
+                latencyMs < currentBestLatency
+            ) {
+                bestEndpoints[serverId] = endpoint.id
+            }
+        }
+    }
+
+    private fun selectBestKnownReachableEndpoint(serverId: Long) {
+        if (forcedEndpoints[serverId] != null) return
+        val bestReachable = lastProbeResults[serverId]
+            .orEmpty()
+            .filter { result -> result.reachable }
+            .minByOrNull { result -> result.latencyMs ?: Long.MAX_VALUE }
+        if (bestReachable != null) {
+            bestEndpoints[serverId] = bestReachable.endpoint.id
+        } else {
+            bestEndpoints.remove(serverId)
+        }
+    }
+
+    private fun publishProbeResults(
+        serverId: Long,
+        endpoints: List<ServerEndpoint>,
+        reachableLatencies: Map<Long, Long>,
+        completedEndpointIds: Set<Long>,
+        final: Boolean,
+    ) {
+        val previousById = lastProbeResults[serverId].orEmpty().associateBy { it.endpoint.id }
+        lastProbeResults[serverId] = endpoints.mapNotNull { endpoint ->
+            val latency = reachableLatencies[endpoint.id]
+            when {
+                latency != null -> EndpointProbeResult(endpoint, latency, reachable = true)
+                final || endpoint.id in completedEndpointIds -> EndpointProbeResult(endpoint, null, reachable = false)
+                else -> previousById[endpoint.id]
+            }
+        }
+        _probeVersion.update { it + 1 }
+    }
+
+    private fun upsertProbeResult(serverId: Long, result: EndpointProbeResult) {
+        val server = serverConfigs[serverId]
+        val previousById = lastProbeResults[serverId]
+            .orEmpty()
+            .associateBy { it.endpoint.id }
+            .toMutableMap()
+        previousById[result.endpoint.id] = result
+        val orderedEndpoints = server?.endpoints?.sortedBy(ServerEndpoint::order).orEmpty()
+        lastProbeResults[serverId] = if (orderedEndpoints.isEmpty()) {
+            previousById.values.toList()
+        } else {
+            orderedEndpoints.mapNotNull { endpoint -> previousById[endpoint.id] }
+        }
     }
 
     private suspend fun pingEndpoint(endpoint: ServerEndpoint, server: ServerConfig): Long? {

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultSubsonicRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultSubsonicRepository.kt
@@ -345,6 +345,7 @@ class DefaultSubsonicRepository @Inject constructor(
                     query = query,
                     queryLists = extraQueryLists,
                 )
+                endpointSelector.recordSuccess(serverId, endpoint)
                 return SubsonicCallResult(
                     endpoint = endpoint,
                     data = transform(response),
@@ -437,6 +438,7 @@ class DefaultSubsonicRepository @Inject constructor(
     }
 
     private fun orderedEndpoints(server: ServerConfig): List<ServerEndpoint> {
+        endpointSelector.registerServer(server)
         return endpointSelector.sortedEndpoints(
             serverId = server.id,
             endpoints = server.endpoints.sortedBy(ServerEndpoint::order),

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -113,8 +113,7 @@ class DefaultPlaybackManager @Inject constructor(
     }
 
     private fun shouldPreferLocalCache(serverId: Long): Boolean {
-        val probeResults = endpointSelector.getLastProbeResults(serverId)
-        return probeResults.isNotEmpty() && probeResults.none { result -> result.reachable }
+        return endpointSelector.isOfflineDegraded(serverId)
     }
 
     private fun resolveQualityForSong(

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -407,9 +407,11 @@ class SakiPlaybackService : MediaSessionService() {
             if (streamRequest.candidates.isEmpty()) {
                 throw IOException("No stream candidates for song $songId on server $serverId")
             }
+            val candidate = streamRequest.candidates.first()
+            endpointSelector.recordSuccess(serverId, candidate.endpoint)
             val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, requestedQuality)
             return dataSpec.buildUpon()
-                .setUri(streamRequest.candidates.first().url)
+                .setUri(candidate.url)
                 .setKey(cacheKey)
                 .build()
         }
@@ -421,7 +423,9 @@ class SakiPlaybackService : MediaSessionService() {
             throw IOException("No stream candidates for song $songId on server $serverId")
         }
 
-        val realUrl = streamRequest.candidates.first().url
+        val candidate = streamRequest.candidates.first()
+        endpointSelector.recordSuccess(serverId, candidate.endpoint)
+        val realUrl = candidate.url
         val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, quality)
 
         return dataSpec.buildUpon()
@@ -431,8 +435,7 @@ class SakiPlaybackService : MediaSessionService() {
     }
 
     private fun shouldPreferLocalStreamCache(serverId: Long): Boolean {
-        val probeResults = endpointSelector.getLastProbeResults(serverId)
-        return probeResults.isNotEmpty() && probeResults.none { result -> result.reachable }
+        return endpointSelector.isOfflineDegraded(serverId)
     }
 
     private fun cachedStreamUri(cacheKey: String): Uri {

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -392,6 +392,7 @@ class SakiAppViewModel @Inject constructor(
     fun selectServer(serverId: Long) {
         val previousServerId = uiState.value.selectedServerId
         if (previousServerId == serverId) return
+        val server = uiState.value.servers.find { it.id == serverId } ?: return
 
         clearSearchState()
         mutableUiState.update { state ->
@@ -410,6 +411,12 @@ class SakiAppViewModel @Inject constructor(
                 isSongsLoadingMore = false,
                 songsError = null,
             )
+        }
+        endpointSelector.registerServer(server)
+        refreshEndpointStatus()
+        viewModelScope.launch {
+            endpointSelector.probe(serverId, server)
+            refreshEndpointStatus()
         }
         viewModelScope.launch {
             appPreferencesRepository.updateLastSelectedServerId(serverId)
@@ -1254,6 +1261,9 @@ class SakiAppViewModel @Inject constructor(
                 isSongsLoadingMore = if (serverChanged) false else state.isSongsLoadingMore,
             )
         }
+        if (serverChanged) {
+            refreshEndpointStatus()
+        }
 
         viewModelScope.launch {
             refreshCacheStorageSummary(selectedServerId)
@@ -1263,11 +1273,11 @@ class SakiAppViewModel @Inject constructor(
             // Show cached content immediately, then probe + network refresh
             loadCachedContent(selectedServerId)
             viewModelScope.launch {
-                servers.find { it.id == selectedServerId }?.let { server ->
+                val probedEndpoint = servers.find { it.id == selectedServerId }?.let { server ->
                     endpointSelector.probe(selectedServerId, server)
-                    refreshEndpointStatus()
                 }
-                val hasReachableEndpoint = endpointSelector.getActiveEndpointId(selectedServerId) != null &&
+                refreshEndpointStatus()
+                val hasReachableEndpoint = (probedEndpoint != null || endpointSelector.getActiveEndpointId(selectedServerId) != null) &&
                     !endpointStatus.value.isOfflineDegraded
                 if (uiState.value.playbackState.currentItem == null) {
                     if (hasReachableEndpoint) {
@@ -1963,14 +1973,20 @@ class SakiAppViewModel @Inject constructor(
     }
 
     fun refreshEndpointStatus() {
-        val serverId = uiState.value.selectedServerId ?: return
+        val serverId = uiState.value.selectedServerId
+        if (serverId == null) {
+            mutableEndpointStatus.value = EndpointStatus()
+            return
+        }
         val results = endpointSelector.getLastProbeResults(serverId)
-        val activeId = endpointSelector.getActiveEndpointId(serverId)
+        val activeEndpoint = endpointSelector.getActiveEndpoint(serverId)
         mutableEndpointStatus.update { current ->
             current.copy(
-                activeEndpointLabel = results.find { it.endpoint.id == activeId }?.endpoint?.label,
-                activeEndpointId = activeId,
+                activeEndpointLabel = activeEndpoint?.label,
+                activeEndpointId = activeEndpoint?.id,
                 isForced = endpointSelector.isForced(serverId),
+                isProbeComplete = endpointSelector.hasCompletedProbe(serverId),
+                isProbing = endpointSelector.isProbeInProgress(serverId),
                 probeResults = results.map { r ->
                     EndpointProbeInfo(
                         id = r.endpoint.id,
@@ -2002,7 +2018,7 @@ class SakiAppViewModel @Inject constructor(
                 endpointSelector.probe(serverId, server)
                 refreshEndpointStatus()
             } finally {
-                mutableEndpointStatus.update { it.copy(isProbing = false) }
+                refreshEndpointStatus()
             }
         }
     }
@@ -2070,9 +2086,12 @@ data class EndpointStatus(
     val isForced: Boolean = false,
     val probeResults: List<EndpointProbeInfo> = emptyList(),
     val isProbing: Boolean = false,
+    val isProbeComplete: Boolean = false,
 ) {
     val isOfflineDegraded: Boolean
-        get() = !isProbing &&
+        get() = activeEndpointId == null &&
+            isProbeComplete &&
+            !isProbing &&
             probeResults.isNotEmpty() &&
             probeResults.none { it.reachable }
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -808,7 +808,16 @@ fun NowPlayingOverlay(
                                         },
                                     )
                                     DropdownMenuItem(
-                                        text = { Text(activeEndpointLabel ?: stringResource(R.string.player_no_endpoint)) },
+                                        text = {
+                                            Text(
+                                                activeEndpointLabel
+                                                    ?: if (isProbing) {
+                                                        stringResource(R.string.player_probing)
+                                                    } else {
+                                                        stringResource(R.string.player_no_endpoint)
+                                                    },
+                                            )
+                                        },
                                         onClick = {
                                             showMenu = false
                                             showEndpointStatus = true


### PR DESCRIPTION
## Summary
- Register and probe the newly selected server when switching servers.
- Keep repository endpoint ordering registered with EndpointSelector so successful API fallback updates UI state.
- Record the stream endpoint selected by playback resolution so Now Playing endpoint status follows actual playback.

## Root cause
Playback and API calls could use endpoint candidates that were not reflected in EndpointSelector. After switching server, stream playback could succeed while Now Playing still had no active endpoint and no probe results until a manual retest.

## Related
Fixes #225
Related to #45

## Testing
- User tested on device: server switching playback works and endpoint UI now updates.
- Ran git diff --check.