### PR TITLE
feat: add predictive back gesture animations

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
@@ -1,0 +1,74 @@
+package org.hdhmc.saki.presentation
+
+import android.view.animation.PathInterpolator
+import androidx.activity.BackEventCompat
+import androidx.activity.compose.PredictiveBackHandler
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+
+private val PredictiveBackInterpolator = PathInterpolator(0.1f, 0.1f, 0f, 1f)
+
+@Composable
+fun Modifier.predictiveBackMotion(
+    enabled: Boolean,
+    onBack: () -> Unit,
+): Modifier {
+    var progress by remember { mutableFloatStateOf(0f) }
+    var swipeEdge by remember { mutableIntStateOf(BackEventCompat.EDGE_LEFT) }
+    var touchY by remember { mutableFloatStateOf(0f) }
+    // Only animate on cancel (progress -> 0), snap during gesture
+    val animatedProgress by animateFloatAsState(
+        targetValue = progress,
+        animationSpec = spring(stiffness = 400f),
+    )
+    val latestOnBack by rememberUpdatedState(onBack)
+    PredictiveBackHandler(enabled = enabled) { backEvents ->
+        try {
+            backEvents.collect { event ->
+                progress = event.progress
+                swipeEdge = event.swipeEdge
+                touchY = event.touchY
+            }
+            latestOnBack()
+        } catch (_: kotlinx.coroutines.CancellationException) {
+            // User cancelled — animatedProgress springs back to 0
+        } finally {
+            progress = 0f
+        }
+    }
+
+    // Use raw progress during gesture, animated on cancel
+    val displayProgress = if (progress > 0f) progress else animatedProgress
+    val interpolated = if (displayProgress <= 0f) 0f
+    else PredictiveBackInterpolator.getInterpolation(displayProgress.coerceIn(0f, 1f))
+    val margin8dp = with(LocalDensity.current) { 8.dp.toPx() }
+    val currentSwipeEdge = swipeEdge
+    val currentTouchY = touchY
+
+    return if (interpolated <= 0f) this
+    else this.graphicsLayer {
+        val scale = 1f - (interpolated * 0.1f)
+        scaleX = scale
+        scaleY = scale
+        val maxShiftX = (size.width / 20f - margin8dp).coerceAtLeast(0f)
+        translationX = interpolated * maxShiftX * if (currentSwipeEdge == BackEventCompat.EDGE_LEFT) 1f else -1f
+        val centerY = size.height / 2f
+        val maxShiftY = (size.height / 20f - margin8dp).coerceAtLeast(0f)
+        val yOffset = if (centerY > 0f) (currentTouchY - centerY) / centerY else 0f
+        translationY = interpolated * maxShiftY * yOffset
+        shape = RoundedCornerShape((interpolated * 28f).dp)
+        clip = true
+    }
+}

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -1,7 +1,11 @@
 package org.hdhmc.saki.presentation
 
 import android.content.Intent
-import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -274,9 +278,10 @@ private fun RootShell(
     var capsuleHeightPx by remember { mutableIntStateOf(defaultCapsuleHeightPx) }
     val capsuleOverlayPadding = with(density) { capsuleHeightPx.toDp() }
 
-    BackHandler(enabled = showSettings) {
-        onShowSettingsChange(false)
-    }
+    val settingsBackModifier = Modifier.predictiveBackMotion(
+        enabled = showSettings,
+        onBack = { onShowSettingsChange(false) },
+    )
 
     Box(
         modifier = Modifier
@@ -285,72 +290,78 @@ private fun RootShell(
     ) {
         CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
             Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-                if (showSettings) {
-                    SettingsScreen(
-                        uiState = uiState,
-                        contentPadding = PaddingValues(),
-                        bottomOverlayPadding = capsuleOverlayPadding,
-                        onManageServers = onManageServers,
-                        onSelectServer = onSelectServer,
-                        onUpdateStreamQuality = onUpdateStreamQuality,
-                        onUpdateDownloadQuality = onUpdateDownloadQuality,
-                        onUpdateAdaptiveQuality = onUpdateAdaptiveQuality,
-                        onUpdateWifiStreamQuality = onUpdateWifiStreamQuality,
-                        onUpdateMobileStreamQuality = onUpdateMobileStreamQuality,
-                        onUpdateSoundBalancing = onUpdateSoundBalancing,
-                        onUpdateStreamCacheSizeMb = onUpdateStreamCacheSizeMb,
-                        onClearStreamCache = onClearStreamCache,
-                        onUpdateImageCacheSizeMb = onUpdateImageCacheSizeMb,
-                        onClearImageCache = onClearImageCache,
-                        onUpdateSongMetadata = onUpdateSongMetadata,
-                        onUpdateTextScale = onUpdateTextScale,
-                        onUpdateLanguage = onUpdateLanguage,
-                        onUpdateThemeMode = onUpdateThemeMode,
-                        onUpdateDefaultBrowseTab = onUpdateDefaultBrowseTab,
-                        onUpdateDefaultAlbumFeed = onUpdateDefaultAlbumFeed,
-                        onUpdateBluetoothLyrics = onUpdateBluetoothLyrics,
-                        onUpdateBufferStrategy = onUpdateBufferStrategy,
-                        onUpdateCustomBufferSeconds = onUpdateCustomBufferSeconds,
-                        onExportConfig = onExportConfig,
-                        onImportConfig = onImportConfig,
-                        onPlayCachedSong = onPlayCachedSong,
-                        onPlayCachedQueue = onPlayCachedQueue,
-                        onDeleteCachedSong = onDeleteCachedSong,
-                        onClearCachedSongs = onClearCachedSongs,
-                    )
-                } else {
-                    BrowseScreen(
-                        uiState = uiState,
-                        isOfflineDegraded = endpointStatus.isOfflineDegraded,
-                        contentPadding = PaddingValues(),
-                        bottomOverlayPadding = capsuleOverlayPadding,
-                        onManageServers = onManageServers,
-                        onSelectBrowseSection = onSelectBrowseSection,
-                        onSetSearchActive = onSetSearchActive,
-                        onUpdateSearchQuery = onUpdateSearchQuery,
-                        onRemoveRecentSearchQuery = onRemoveRecentSearchQuery,
-                        onClearRecentSearchQueries = onClearRecentSearchQueries,
-                        onRefreshCurrentTab = onRefreshCurrentTab,
-                        onSelectAlbumFeed = onSelectAlbumFeed,
-                        onLoadMoreAlbums = onLoadMoreAlbums,
-                        onLoadPreviousSongs = onLoadPreviousSongs,
-                        onLoadMoreSongs = onLoadMoreSongs,
-                        onUpdateAlbumViewMode = onUpdateAlbumViewMode,
-                        onOpenArtist = onOpenArtist,
-                        onCloseArtist = onCloseArtist,
-                        onOpenAlbum = onOpenAlbum,
-                        onCloseAlbum = onCloseAlbum,
-                        onOpenPlaylist = onOpenPlaylist,
-                        onClosePlaylist = onClosePlaylist,
-                        onPlaySongs = onPlaySongs,
-                        onPlayLibrarySongs = onPlayLibrarySongs,
-                        onQueueSong = onQueueSong,
-                        onPlaySongNext = onPlaySongNext,
-                        onOfflineSongUnavailable = onOfflineSongUnavailable,
-                        onToggleSongDownload = onToggleSongDownload,
-                        onOpenSettings = { onShowSettingsChange(true) },
-                        onImportConfig = onImportConfig,
-                    )
+                BrowseScreen(
+                    uiState = uiState,
+                    isOfflineDegraded = endpointStatus.isOfflineDegraded,
+                    contentPadding = PaddingValues(),
+                    bottomOverlayPadding = capsuleOverlayPadding,
+                    onManageServers = onManageServers,
+                    onSelectBrowseSection = onSelectBrowseSection,
+                    onSetSearchActive = onSetSearchActive,
+                    onUpdateSearchQuery = onUpdateSearchQuery,
+                    onRemoveRecentSearchQuery = onRemoveRecentSearchQuery,
+                    onClearRecentSearchQueries = onClearRecentSearchQueries,
+                    onRefreshCurrentTab = onRefreshCurrentTab,
+                    onSelectAlbumFeed = onSelectAlbumFeed,
+                    onLoadMoreAlbums = onLoadMoreAlbums,
+                    onLoadPreviousSongs = onLoadPreviousSongs,
+                    onLoadMoreSongs = onLoadMoreSongs,
+                    onUpdateAlbumViewMode = onUpdateAlbumViewMode,
+                    onOpenArtist = onOpenArtist,
+                    onCloseArtist = onCloseArtist,
+                    onOpenAlbum = onOpenAlbum,
+                    onCloseAlbum = onCloseAlbum,
+                    onOpenPlaylist = onOpenPlaylist,
+                    onClosePlaylist = onClosePlaylist,
+                    onPlaySongs = onPlaySongs,
+                    onPlayLibrarySongs = onPlayLibrarySongs,
+                    onQueueSong = onQueueSong,
+                    onPlaySongNext = onPlaySongNext,
+                    onOfflineSongUnavailable = onOfflineSongUnavailable,
+                    onToggleSongDownload = onToggleSongDownload,
+                    onOpenSettings = { onShowSettingsChange(true) },
+                    onImportConfig = onImportConfig,
+                )
+
+                AnimatedVisibility(
+                    visible = showSettings,
+                    enter = fadeIn(spring(stiffness = Spring.StiffnessMediumLow)),
+                    exit = fadeOut(spring(stiffness = Spring.StiffnessMediumLow)),
+                ) {
+                    Box(modifier = Modifier.fillMaxSize().then(settingsBackModifier)) {
+                        SettingsScreen(
+                            uiState = uiState,
+                            contentPadding = PaddingValues(),
+                            bottomOverlayPadding = capsuleOverlayPadding,
+                            onManageServers = onManageServers,
+                            onSelectServer = onSelectServer,
+                            onUpdateStreamQuality = onUpdateStreamQuality,
+                            onUpdateDownloadQuality = onUpdateDownloadQuality,
+                            onUpdateAdaptiveQuality = onUpdateAdaptiveQuality,
+                            onUpdateWifiStreamQuality = onUpdateWifiStreamQuality,
+                            onUpdateMobileStreamQuality = onUpdateMobileStreamQuality,
+                            onUpdateSoundBalancing = onUpdateSoundBalancing,
+                            onUpdateStreamCacheSizeMb = onUpdateStreamCacheSizeMb,
+                            onClearStreamCache = onClearStreamCache,
+                            onUpdateImageCacheSizeMb = onUpdateImageCacheSizeMb,
+                            onClearImageCache = onClearImageCache,
+                            onUpdateSongMetadata = onUpdateSongMetadata,
+                            onUpdateTextScale = onUpdateTextScale,
+                            onUpdateLanguage = onUpdateLanguage,
+                            onUpdateThemeMode = onUpdateThemeMode,
+                            onUpdateDefaultBrowseTab = onUpdateDefaultBrowseTab,
+                            onUpdateDefaultAlbumFeed = onUpdateDefaultAlbumFeed,
+                            onUpdateBluetoothLyrics = onUpdateBluetoothLyrics,
+                            onUpdateBufferStrategy = onUpdateBufferStrategy,
+                            onUpdateCustomBufferSeconds = onUpdateCustomBufferSeconds,
+                            onExportConfig = onExportConfig,
+                            onImportConfig = onImportConfig,
+                            onPlayCachedSong = onPlayCachedSong,
+                            onPlayCachedQueue = onPlayCachedQueue,
+                            onDeleteCachedSong = onDeleteCachedSong,
+                            onClearCachedSongs = onClearCachedSongs,
+                        )
+                    }
                 }
 
                 SnackbarHost(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -1,7 +1,6 @@
 package org.hdhmc.saki.presentation.library
 
 import android.util.LruCache
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animate
@@ -131,6 +130,7 @@ import androidx.compose.ui.unit.sp
 import androidx.palette.graphics.Palette
 import org.hdhmc.saki.R
 import org.hdhmc.saki.presentation.EndpointProbeInfo
+import org.hdhmc.saki.presentation.predictiveBackMotion
 import org.hdhmc.saki.domain.model.PlaybackQueueItem
 import org.hdhmc.saki.domain.model.PlaybackProgressState
 import org.hdhmc.saki.domain.model.PlaybackRuntimeInfo
@@ -423,10 +423,11 @@ fun NowPlayingOverlay(
         }
     }
 
-    BackHandler(enabled = visible) {
-        onDismiss()
-    }
     val latestOnDismiss by rememberUpdatedState(onDismiss)
+    val predictiveBackModifier = Modifier.predictiveBackMotion(
+        enabled = visible,
+        onBack = { latestOnDismiss() },
+    )
 
     // Reset lyrics overlay when Now Playing is dismissed
     LaunchedEffect(visible) {
@@ -527,6 +528,7 @@ fun NowPlayingOverlay(
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
+                .then(predictiveBackModifier)
                 .background(background)
                 .statusBarsPadding()
                 .navigationBarsPadding()


### PR DESCRIPTION
Closes #231

## Changes

- **New `Modifier.predictiveBackMotion()`** — reusable extension encapsulating M3 predictive back spec:
  - Scale to 90% at max progress
  - X/Y translation following swipe edge and touch position (8dp margin)
  - 28dp corner radius
  - Decelerate interpolator `PathInterpolator(0.1, 0.1, 0, 1)`
  - Spring-based cancel animation via `animateFloatAsState`

- **NowPlaying overlay** — replaced `BackHandler` with `PredictiveBackHandler` via shared modifier

- **Settings page** — replaced `BackHandler` + `if/else` with `predictiveBackMotion` + `AnimatedVisibility` overlay, so BrowseScreen stays rendered underneath for back preview

## Compatibility

- Android 13+: full gesture preview
- Below 13: standard back, no crash
- Works on HyperOS regardless of system predictive back support