### PR TITLE
refactor: fix buffer strategy target-bytes cap, remove AGGRESSIVE

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/domain/model/PlaybackModels.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/PlaybackModels.kt
@@ -118,7 +118,6 @@ enum class BufferStrategy(
     val label: String,
 ) {
     NORMAL("normal", "Normal"),
-    AGGRESSIVE("aggressive", "Aggressive"),
     CUSTOM("custom", "Custom"),
     ;
 
@@ -128,10 +127,10 @@ enum class BufferStrategy(
     }
 }
 
-const val DEFAULT_CUSTOM_BUFFER_SECONDS = 45
-const val MIN_CUSTOM_BUFFER_SECONDS = 15
-const val MAX_CUSTOM_BUFFER_SECONDS = 600
-const val CUSTOM_BUFFER_STEP_SECONDS = 15
+const val DEFAULT_CUSTOM_BUFFER_SECONDS = 60
+const val MIN_CUSTOM_BUFFER_SECONDS = 30
+const val MAX_CUSTOM_BUFFER_SECONDS = 1800
+const val CUSTOM_BUFFER_STEP_SECONDS = 30
 
 fun normalizeCustomBufferSeconds(seconds: Int): Int {
     val clamped = seconds.coerceIn(MIN_CUSTOM_BUFFER_SECONDS, MAX_CUSTOM_BUFFER_SECONDS)

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiLoadControl.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiLoadControl.kt
@@ -1,0 +1,67 @@
+package org.hdhmc.saki.playback
+
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.LoadControl
+import androidx.media3.exoplayer.trackselection.ExoTrackSelection
+import androidx.media3.exoplayer.upstream.DefaultAllocator
+
+/**
+ * Custom [DefaultLoadControl] that raises the target-bytes cap so the
+ * configured [maxBufferMs] actually drives loading.
+ *
+ * The default behaviour computes a target from track bitrate × a fixed
+ * buffer duration. For high-bitrate FLAC (~1400 kbps) this hits the byte
+ * cap long before [maxBufferMs] does, causing the loader to stop at
+ * ~30-50% of the track. When [lenientBufferBytes] is true we return a
+ * larger fixed cap so [maxBufferMs] becomes the effective limit.
+ *
+ * The cap is 256 MiB — enough for ~24 min of 1500 kbps audio across all
+ * buffered periods in the player, but low enough to avoid OOM on
+ * low-RAM devices (Java heap is typically 192-256 MB).
+ *
+ * Note: this applies to the shared allocator's total buffered bytes for
+ * the player, not per track. Actual memory use is still gated by
+ * [maxBufferMs] and the allocator's on-demand allocation.
+ */
+@UnstableApi
+class SakiLoadControl(
+    private val lenientBufferBytes: Boolean,
+    minBufferMs: Int,
+    maxBufferMs: Int,
+    bufferForPlaybackMs: Int,
+    bufferForPlaybackAfterRebufferMs: Int,
+) : DefaultLoadControl(
+    DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE),
+    minBufferMs,
+    minBufferMs,
+    maxBufferMs,
+    maxBufferMs,
+    bufferForPlaybackMs,
+    bufferForPlaybackMs,
+    bufferForPlaybackAfterRebufferMs,
+    bufferForPlaybackAfterRebufferMs,
+    DEFAULT_TARGET_BUFFER_BYTES,
+    DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS,
+    DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS_FOR_LOCAL_PLAYBACK,
+    DEFAULT_BACK_BUFFER_DURATION_MS,
+    DEFAULT_RETAIN_BACK_BUFFER_FROM_KEYFRAME,
+) {
+    override fun calculateTargetBufferBytes(
+        parameters: LoadControl.Parameters,
+        trackSelectionArray: Array<out ExoTrackSelection?>,
+    ): Int {
+        return if (lenientBufferBytes) {
+            LENIENT_TARGET_BUFFER_BYTES
+        } else {
+            super.calculateTargetBufferBytes(parameters, trackSelectionArray)
+        }
+    }
+
+    companion object {
+        // 256 MiB cap — high enough to not bottleneck realistic buffer
+        // durations, low enough to avoid OOM on low-RAM devices.
+        private const val LENIENT_TARGET_BUFFER_BYTES = 256 * 1024 * 1024
+    }
+}

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -141,19 +141,19 @@ class SakiPlaybackService : MediaSessionService() {
         cachedPlaybackPrefs = initialPrefs
 
         val maxBufferMs = when (initialPrefs.bufferStrategy) {
-            org.hdhmc.saki.domain.model.BufferStrategy.AGGRESSIVE -> Int.MAX_VALUE
             org.hdhmc.saki.domain.model.BufferStrategy.CUSTOM ->
                 initialPrefs.customBufferSeconds * 1_000
             else -> DefaultLoadControl.DEFAULT_MAX_BUFFER_MS
         }
-        val loadControl = DefaultLoadControl.Builder()
-            .setBufferDurationsMs(
-                minOf(DefaultLoadControl.DEFAULT_MIN_BUFFER_MS, maxBufferMs),
-                maxBufferMs,
-                DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
+        val loadControl = SakiLoadControl(
+            lenientBufferBytes = initialPrefs.bufferStrategy !=
+                org.hdhmc.saki.domain.model.BufferStrategy.NORMAL,
+            minBufferMs = minOf(DefaultLoadControl.DEFAULT_MIN_BUFFER_MS, maxBufferMs),
+            maxBufferMs = maxBufferMs,
+            bufferForPlaybackMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
+            bufferForPlaybackAfterRebufferMs =
                 DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
-            )
-            .build()
+        )
 
         val exoPlayer = ExoPlayer.Builder(this)
             .setAudioAttributes(audioAttributes, true)

--- a/app/src/main/java/org/hdhmc/saki/presentation/LabelResources.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/LabelResources.kt
@@ -31,7 +31,6 @@ fun SoundBalancingMode.labelRes(): Int = when (this) {
 @StringRes
 fun BufferStrategy.labelRes(): Int = when (this) {
     BufferStrategy.NORMAL -> R.string.buffer_strategy_normal
-    BufferStrategy.AGGRESSIVE -> R.string.buffer_strategy_aggressive
     BufferStrategy.CUSTOM -> R.string.buffer_strategy_custom
 }
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -306,14 +306,14 @@ fun SettingsScreen(
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    BufferStrategy.AGGRESSIVE -> Text(
-                        text = stringResource(R.string.settings_buffer_strategy_aggressive_body),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
                     BufferStrategy.CUSTOM -> {
                         Text(
-                            text = stringResource(R.string.settings_buffer_ahead_seconds, bufferSliderValue.toBufferSeconds()),
+                            text = stringResource(R.string.settings_buffer_strategy_custom_body),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = stringResource(R.string.settings_buffer_ahead_duration, formatBufferDuration(bufferSliderValue.toBufferSeconds())),
                             style = MaterialTheme.typography.titleMedium,
                         )
                         Slider(
@@ -334,12 +334,12 @@ fun SettingsScreen(
                             horizontalArrangement = Arrangement.SpaceBetween,
                         ) {
                             Text(
-                                text = stringResource(R.string.settings_seconds_short, MIN_CUSTOM_BUFFER_SECONDS),
+                                text = formatBufferDuration(MIN_CUSTOM_BUFFER_SECONDS),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                             Text(
-                                text = stringResource(R.string.settings_seconds_short, MAX_CUSTOM_BUFFER_SECONDS),
+                                text = formatBufferDuration(MAX_CUSTOM_BUFFER_SECONDS),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -1028,6 +1028,17 @@ private fun Float.toBufferSeconds(): Int {
     val stepsFromMin = ((this - MIN_CUSTOM_BUFFER_SECONDS) / CUSTOM_BUFFER_STEP_SECONDS).roundToInt()
     return (MIN_CUSTOM_BUFFER_SECONDS + (stepsFromMin * CUSTOM_BUFFER_STEP_SECONDS))
         .coerceIn(MIN_CUSTOM_BUFFER_SECONDS, MAX_CUSTOM_BUFFER_SECONDS)
+}
+
+@Composable
+private fun formatBufferDuration(totalSeconds: Int): String {
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return when {
+        minutes == 0 -> stringResource(R.string.settings_seconds_short, seconds)
+        seconds == 0 -> stringResource(R.string.settings_minutes_short, minutes)
+        else -> stringResource(R.string.settings_minutes_seconds_short, minutes, seconds)
+    }
 }
 
 private fun Float.toImageCacheSizeMb(): Int {

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -14,11 +14,13 @@
     <string name="settings_sound_balancing_title">音量均衡</string>
     <string name="settings_sound_balancing_body">利用 Android 音频会话效果减少曲目间的音量跳变。效果因设备而异。</string>
     <string name="settings_buffer_strategy_title">缓冲策略</string>
-    <string name="settings_buffer_strategy_body">控制播放时预缓冲当前曲目的量。</string>
+    <string name="settings_buffer_strategy_body">控制播放时预缓冲当前曲目的量。更大的缓冲区可降低拖动延迟，但会占用更多内存并可能预加载队列中的后续曲目。</string>
     <string name="settings_buffer_strategy_normal_body">默认缓冲（约 50 秒）。平衡内存占用与播放可靠性。</string>
-    <string name="settings_buffer_strategy_aggressive_body">缓冲整首曲目。适合稳定 WiFi 环境，可即时拖动。</string>
-    <string name="settings_buffer_ahead_seconds">预缓冲 %1$d 秒</string>
+    <string name="settings_buffer_strategy_custom_body">按所选时长预缓冲（总缓冲数据最多 256 MB）。时长越长越适合稳定 WiFi 环境，低内存设备不建议使用较长时长。</string>
+    <string name="settings_buffer_ahead_duration">预缓冲 %1$s</string>
     <string name="settings_seconds_short">%1$d 秒</string>
+    <string name="settings_minutes_short">%1$d 分钟</string>
+    <string name="settings_minutes_seconds_short">%1$d 分 %2$d 秒</string>
     <string name="settings_restart_required">更改将在重启应用后生效。</string>
     <string name="settings_text_size_title">字体大小</string>
     <string name="settings_text_size_body">调整应用内字体大小，不影响系统其他界面。</string>
@@ -70,7 +72,6 @@
     <string name="sound_balancing_medium">中</string>
     <string name="sound_balancing_high">高</string>
     <string name="buffer_strategy_normal">标准</string>
-    <string name="buffer_strategy_aggressive">激进</string>
     <string name="buffer_strategy_custom">自定义</string>
     <string name="text_scale_extra_small">极小</string>
     <string name="text_scale_small">小</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,11 +16,13 @@
     <string name="settings_sound_balancing_title">Sound balancing</string>
     <string name="settings_sound_balancing_body">Reduces perceived volume jumps across tracks using Android\'s audio session effects. Device support and results vary.</string>
     <string name="settings_buffer_strategy_title">Buffer strategy</string>
-    <string name="settings_buffer_strategy_body">Control how much of the current track is buffered ahead during playback.</string>
+    <string name="settings_buffer_strategy_body">Control how much of the current track is buffered ahead during playback. Larger buffers reduce seek latency but use more memory and may preload more items from the queue.</string>
     <string name="settings_buffer_strategy_normal_body">Default buffering (~50 s ahead). Balances memory use and playback reliability.</string>
-    <string name="settings_buffer_strategy_aggressive_body">Buffers the entire current track. Best on stable WiFi for instant seeking.</string>
-    <string name="settings_buffer_ahead_seconds">Buffer %1$d s ahead</string>
+    <string name="settings_buffer_strategy_custom_body">Buffer up to the chosen duration (total buffered data capped at 256 MB). Longer durations are best on stable WiFi; not recommended for low-RAM devices.</string>
+    <string name="settings_buffer_ahead_duration">Buffer %1$s ahead</string>
     <string name="settings_seconds_short">%1$d s</string>
+    <string name="settings_minutes_short">%1$d min</string>
+    <string name="settings_minutes_seconds_short">%1$d min %2$d s</string>
     <string name="settings_restart_required">Changes take effect after restarting the app.</string>
     <string name="settings_text_size_title">Text size</string>
     <string name="settings_text_size_body">Scale the app typography without changing the rest of the system UI.</string>
@@ -78,7 +80,6 @@
     <string name="sound_balancing_medium">Medium</string>
     <string name="sound_balancing_high">High</string>
     <string name="buffer_strategy_normal">Normal</string>
-    <string name="buffer_strategy_aggressive">Aggressive</string>
     <string name="buffer_strategy_custom">Custom</string>
     <string name="text_scale_extra_small">Extra small</string>
     <string name="text_scale_small">Small</string>


### PR DESCRIPTION
Closes #233, closes #116

## Root cause of #116

`DefaultLoadControl.calculateTargetBufferBytes` computes a byte cap from track bitrate × a short fixed buffer duration. For high-bitrate FLAC (~1400 kbps) this hits the byte cap long before `maxBufferMs` does, so the loader stops at ~30-50% of the track even when `maxBufferMs = Int.MAX_VALUE`.

## Why AGGRESSIVE is gone

`maxBufferMs = Int.MAX_VALUE` meant the current MediaPeriod never reached its limit, so ExoPlayer happily preloaded dozens of upcoming items from the queue (user reported 20+ tracks cached after playing 3). With `AGGRESSIVE` replaced by a more configurable `CUSTOM`, users who want "buffer the whole track" can dial in 5-30 min themselves and see a realistic time estimate, with clear wording about memory impact.

## Changes

- **`SakiLoadControl`** — subclass of `DefaultLoadControl` that returns a 256 MiB target-bytes cap in lenient mode, bypassing the bitrate-based calculation that caused #116. Still an upper bound; actual usage is gated by `maxBufferMs` and the allocator.
- **Remove `AGGRESSIVE`** enum value, label string, description string, settings UI branch, and `when` case.
- **Raise CUSTOM range** to 30 s – 30 min (step 30 s). Default 60 s.
- **Format buffer duration** as `1 min 30 s` / `30 min` / `30 s` instead of showing `1800 s`. Three new string resources cover the permutations in English and Chinese.
- **Preference migration** — `fromStorageKey` already falls back to NORMAL on unknown keys, so existing `aggressive` values silently become NORMAL.
- **Settings body copy** updated to explain the mechanism and low-RAM warning.

## Memory safety

- NORMAL: unchanged (DefaultLoadControl's bitrate-based cap).
- CUSTOM: 30 min × 1500 kbps ≈ 337 MB uncapped → clamped to 256 MiB. Typical Java heap on low-RAM devices is 192-256 MB, so the cap just reaches the edge rather than causing OOM.
- User-facing warning in settings that longer durations aren't recommended for low-RAM devices.