### PR TITLE
fix: Prevent custom buffer OOM

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
@@ -5,6 +5,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.cache.ContentMetadata
 import androidx.media3.datasource.cache.SimpleCache
 import org.hdhmc.saki.di.IoDispatcher
+import org.hdhmc.saki.domain.model.StreamCacheProgress
 import org.hdhmc.saki.domain.model.StreamCacheSummary
 import org.hdhmc.saki.domain.model.StreamQuality
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
@@ -81,6 +82,25 @@ class DefaultStreamCacheRepository @Inject constructor(
             if (byQuality[key]?.contains(songId) == true) return key
         }
         return null
+    }
+
+    override fun getStreamCacheProgress(
+        serverId: Long,
+        songId: String,
+        quality: StreamQuality,
+    ): StreamCacheProgress? {
+        val cacheKey = buildStreamCacheKey(serverId, songId, quality)
+        val contentLength = ContentMetadata.getContentLength(streamCache.getContentMetadata(cacheKey))
+            .takeIf { length -> length != C.LENGTH_UNSET.toLong() && length > 0L }
+            ?: return null
+        val cachedPrefixBytes = streamCache.getCachedLength(cacheKey, 0L, contentLength)
+            .takeIf { length -> length > 0L }
+            ?.coerceAtMost(contentLength)
+            ?: return null
+        return StreamCacheProgress(
+            cachedPrefixBytes = cachedPrefixBytes,
+            contentLengthBytes = contentLength,
+        )
     }
 
     override suspend fun getStreamCacheSummary(

--- a/app/src/main/java/org/hdhmc/saki/domain/model/PlaybackModels.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/PlaybackModels.kt
@@ -210,6 +210,11 @@ data class StreamCacheSummary(
     val bytes: Long = 0,
 )
 
+data class StreamCacheProgress(
+    val cachedPrefixBytes: Long,
+    val contentLengthBytes: Long,
+)
+
 data class PlaybackQueueItem(
     val mediaId: String,
     val songId: String,

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/StreamCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/StreamCacheRepository.kt
@@ -1,5 +1,6 @@
 package org.hdhmc.saki.domain.repository
 
+import org.hdhmc.saki.domain.model.StreamCacheProgress
 import org.hdhmc.saki.domain.model.StreamCacheSummary
 import org.hdhmc.saki.domain.model.StreamQuality
 import kotlinx.coroutines.flow.Flow
@@ -23,6 +24,8 @@ interface StreamCacheRepository {
      * or a higher quality if available, or null if not cached at all.
      */
     fun findCachedQualityKey(serverId: Long, songId: String, preferredQuality: StreamQuality): String?
+
+    fun getStreamCacheProgress(serverId: Long, songId: String, quality: StreamQuality): StreamCacheProgress?
 
     suspend fun clearStreamCache(serverId: Long? = null): Int
 }

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -100,6 +100,7 @@ class DefaultPlaybackManager @Inject constructor(
     private val mutablePlaybackState = MutableStateFlow(PlaybackSessionState())
     private val mutablePlaybackProgress = MutableStateFlow(PlaybackProgressState())
     @Volatile private var cacheReady = false
+    @Volatile private var streamCacheProgressSnapshot = StreamCacheProgressSnapshot()
 
     override val playbackState: StateFlow<PlaybackSessionState> = mutablePlaybackState.asStateFlow()
     override val playbackProgress: StateFlow<PlaybackProgressState> = mutablePlaybackProgress.asStateFlow()
@@ -191,6 +192,12 @@ class DefaultPlaybackManager @Inject constructor(
             streamCacheRepository.observeCacheVersion().collect {
                 if (it > 0L) cacheReady = true
                 controller?.let(::syncState)
+            }
+        }
+        scope.launch {
+            while (isActive) {
+                refreshStreamCacheProgress()
+                delay(STREAM_CACHE_PROGRESS_REFRESH_MS)
             }
         }
         scope.launch {
@@ -1316,7 +1323,7 @@ class DefaultPlaybackManager @Inject constructor(
             )
         } else null
         val streamCached = cachedQualityKey != null
-        val progress = toProgressState(player, currentRequest, cachedQualityKey)
+        val progress = toProgressState(player, currentRequest)
         mutablePlaybackProgress.value = progress
 
         mutablePlaybackState.update { state ->
@@ -1359,16 +1366,7 @@ class DefaultPlaybackManager @Inject constructor(
 
     private fun syncProgress(player: Player) {
         val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
-        val cachedQualityKey = currentRequest
-            ?.takeIf { request -> !request.isCached && cacheReady }
-            ?.let { request ->
-                streamCacheRepository.findCachedQualityKey(
-                    request.serverId,
-                    request.songId,
-                    playbackQuality(request.serverId),
-                )
-            }
-        mutablePlaybackProgress.value = toProgressState(player, currentRequest, cachedQualityKey)
+        mutablePlaybackProgress.value = toProgressState(player, currentRequest)
     }
 
     private fun syncExternalShuffleState(player: Player): Boolean {
@@ -1414,34 +1412,22 @@ class DefaultPlaybackManager @Inject constructor(
 
     private fun cacheBufferedPositionMs(
         request: PlaybackRequest?,
-        cachedQualityKey: String?,
         durationMs: Long,
     ): Long {
-        if (request == null || request.isCached || durationMs <= 0L) return 0L
-        val quality = cachedQualityKey
-            ?.let(StreamQuality::fromStorageKey)
-            ?: playbackQuality(request.serverId)
-        val cacheProgress = streamCacheRepository.getStreamCacheProgress(
-            serverId = request.serverId,
-            songId = request.songId,
-            quality = quality,
-        ) ?: return 0L
-        val cachedRatio = cacheProgress.cachedPrefixBytes.toDouble() / cacheProgress.contentLengthBytes.toDouble()
-        return (cachedRatio * durationMs)
-            .toLong()
-            .coerceIn(0L, durationMs)
+        val target = streamCacheProgressTarget(request, durationMs) ?: return 0L
+        val snapshot = streamCacheProgressSnapshot
+        return if (snapshot.target == target) snapshot.bufferedPositionMs else 0L
     }
 
     private fun toProgressState(
         player: Player,
         request: PlaybackRequest?,
-        cachedQualityKey: String? = null,
     ): PlaybackProgressState {
         val durationMs = player.duration.coerceKnownTime().takeIf { it > 0 }
             ?: player.currentMediaItem?.metadataDurationMs()
             ?: 0L
         val playerBufferedPositionMs = player.bufferedPosition.coerceKnownTime()
-        val cacheBufferedPositionMs = cacheBufferedPositionMs(request, cachedQualityKey, durationMs)
+        val cacheBufferedPositionMs = cacheBufferedPositionMs(request, durationMs)
         return PlaybackProgressState(
             positionMs = player.currentPosition.coerceKnownTime(),
             durationMs = durationMs,
@@ -1449,7 +1435,76 @@ class DefaultPlaybackManager @Inject constructor(
         )
     }
 
+    private suspend fun refreshStreamCacheProgress() {
+        val activeController = controller
+        val request = activeController?.currentMediaItem?.toPlaybackRequestOrNull()
+        val durationMs = activeController?.duration?.coerceKnownTime()?.takeIf { it > 0L }
+            ?: activeController?.currentMediaItem?.metadataDurationMs()
+            ?: 0L
+        val target = streamCacheProgressTarget(request, durationMs)
+        if (target == null || request == null) {
+            streamCacheProgressSnapshot = StreamCacheProgressSnapshot()
+            return
+        }
+
+        val preferredQuality = playbackQuality(request.serverId)
+        val snapshot = withContext(defaultDispatcher) {
+            val cachedQualityKey = if (cacheReady) {
+                streamCacheRepository.findCachedQualityKey(request.serverId, request.songId, preferredQuality)
+            } else {
+                null
+            }
+            val quality = cachedQualityKey?.let(StreamQuality::fromStorageKey) ?: preferredQuality
+            val cacheProgress = streamCacheRepository.getStreamCacheProgress(
+                serverId = request.serverId,
+                songId = request.songId,
+                quality = quality,
+            ) ?: return@withContext StreamCacheProgressSnapshot(target = target)
+            val cachedRatio = cacheProgress.cachedPrefixBytes.toDouble() / cacheProgress.contentLengthBytes.toDouble()
+            StreamCacheProgressSnapshot(
+                target = target,
+                bufferedPositionMs = (cachedRatio * durationMs)
+                    .toLong()
+                    .coerceIn(0L, durationMs),
+            )
+        }
+
+        val currentController = controller
+        val currentRequest = currentController?.currentMediaItem?.toPlaybackRequestOrNull()
+        val currentDurationMs = currentController?.duration?.coerceKnownTime()?.takeIf { it > 0L }
+            ?: currentController?.currentMediaItem?.metadataDurationMs()
+            ?: 0L
+        if (streamCacheProgressTarget(currentRequest, currentDurationMs) == target) {
+            streamCacheProgressSnapshot = snapshot
+            currentController?.let(::syncProgress)
+        }
+    }
+
+    private fun streamCacheProgressTarget(
+        request: PlaybackRequest?,
+        durationMs: Long,
+    ): StreamCacheProgressTarget? {
+        if (request == null || request.isCached || durationMs <= 0L) return null
+        return StreamCacheProgressTarget(
+            serverId = request.serverId,
+            songId = request.songId,
+            durationMs = durationMs,
+        )
+    }
+
+    private data class StreamCacheProgressTarget(
+        val serverId: Long,
+        val songId: String,
+        val durationMs: Long,
+    )
+
+    private data class StreamCacheProgressSnapshot(
+        val target: StreamCacheProgressTarget? = null,
+        val bufferedPositionMs: Long = 0L,
+    )
+
     private companion object {
+        const val STREAM_CACHE_PROGRESS_REFRESH_MS = 2_000L
         const val VIRTUAL_QUEUE_KEEP_BEFORE = 40
         const val VIRTUAL_QUEUE_KEEP_AFTER = 80
         const val VIRTUAL_QUEUE_INITIAL_LOAD_SIZE = VIRTUAL_QUEUE_KEEP_BEFORE + VIRTUAL_QUEUE_KEEP_AFTER + 1

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -1316,7 +1316,7 @@ class DefaultPlaybackManager @Inject constructor(
             )
         } else null
         val streamCached = cachedQualityKey != null
-        val progress = player.toProgressState()
+        val progress = toProgressState(player, currentRequest, cachedQualityKey)
         mutablePlaybackProgress.value = progress
 
         mutablePlaybackState.update { state ->
@@ -1358,7 +1358,17 @@ class DefaultPlaybackManager @Inject constructor(
     }
 
     private fun syncProgress(player: Player) {
-        mutablePlaybackProgress.value = player.toProgressState()
+        val currentRequest = player.currentMediaItem?.toPlaybackRequestOrNull()
+        val cachedQualityKey = currentRequest
+            ?.takeIf { request -> !request.isCached && cacheReady }
+            ?.let { request ->
+                streamCacheRepository.findCachedQualityKey(
+                    request.serverId,
+                    request.songId,
+                    playbackQuality(request.serverId),
+                )
+            }
+        mutablePlaybackProgress.value = toProgressState(player, currentRequest, cachedQualityKey)
     }
 
     private fun syncExternalShuffleState(player: Player): Boolean {
@@ -1402,6 +1412,43 @@ class DefaultPlaybackManager @Inject constructor(
         return playbackPreferencesRepository.getShuffleState()
     }
 
+    private fun cacheBufferedPositionMs(
+        request: PlaybackRequest?,
+        cachedQualityKey: String?,
+        durationMs: Long,
+    ): Long {
+        if (request == null || request.isCached || durationMs <= 0L) return 0L
+        val quality = cachedQualityKey
+            ?.let(StreamQuality::fromStorageKey)
+            ?: playbackQuality(request.serverId)
+        val cacheProgress = streamCacheRepository.getStreamCacheProgress(
+            serverId = request.serverId,
+            songId = request.songId,
+            quality = quality,
+        ) ?: return 0L
+        val cachedRatio = cacheProgress.cachedPrefixBytes.toDouble() / cacheProgress.contentLengthBytes.toDouble()
+        return (cachedRatio * durationMs)
+            .toLong()
+            .coerceIn(0L, durationMs)
+    }
+
+    private fun toProgressState(
+        player: Player,
+        request: PlaybackRequest?,
+        cachedQualityKey: String? = null,
+    ): PlaybackProgressState {
+        val durationMs = player.duration.coerceKnownTime().takeIf { it > 0 }
+            ?: player.currentMediaItem?.metadataDurationMs()
+            ?: 0L
+        val playerBufferedPositionMs = player.bufferedPosition.coerceKnownTime()
+        val cacheBufferedPositionMs = cacheBufferedPositionMs(request, cachedQualityKey, durationMs)
+        return PlaybackProgressState(
+            positionMs = player.currentPosition.coerceKnownTime(),
+            durationMs = durationMs,
+            bufferedPositionMs = maxOf(playerBufferedPositionMs, cacheBufferedPositionMs),
+        )
+    }
+
     private companion object {
         const val VIRTUAL_QUEUE_KEEP_BEFORE = 40
         const val VIRTUAL_QUEUE_KEEP_AFTER = 80
@@ -1436,16 +1483,6 @@ private suspend fun ListenableFuture<MediaController>.await(
 
 private fun Long.coerceKnownTime(): Long {
     return if (this == C.TIME_UNSET || this < 0L) 0L else this
-}
-
-private fun Player.toProgressState(): PlaybackProgressState {
-    return PlaybackProgressState(
-        positionMs = currentPosition.coerceKnownTime(),
-        durationMs = duration.coerceKnownTime().takeIf { it > 0 }
-            ?: currentMediaItem?.metadataDurationMs()
-            ?: 0L,
-        bufferedPositionMs = bufferedPosition.coerceKnownTime(),
-    )
 }
 
 private fun Int.toRepeatModeSetting(): RepeatModeSetting {

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiLoadControl.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiLoadControl.kt
@@ -3,35 +3,24 @@ package org.hdhmc.saki.playback
 import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultLoadControl
-import androidx.media3.exoplayer.LoadControl
-import androidx.media3.exoplayer.trackselection.ExoTrackSelection
 import androidx.media3.exoplayer.upstream.DefaultAllocator
 
 /**
- * Custom [DefaultLoadControl] that raises the target-bytes cap so the
- * configured [maxBufferMs] actually drives loading.
+ * Custom [DefaultLoadControl] wrapper used to keep remote stream buffering
+ * within a predictable Java heap budget.
  *
- * The default behaviour computes a target from track bitrate × a fixed
- * buffer duration. For high-bitrate FLAC (~1400 kbps) this hits the byte
- * cap long before [maxBufferMs] does, causing the loader to stop at
- * ~30-50% of the track. When [lenientBufferBytes] is true we return a
- * larger fixed cap so [maxBufferMs] becomes the effective limit.
- *
- * The cap is 256 MiB — enough for ~24 min of 1500 kbps audio across all
- * buffered periods in the player, but low enough to avoid OOM on
- * low-RAM devices (Java heap is typically 192-256 MB).
- *
- * Note: this applies to the shared allocator's total buffered bytes for
- * the player, not per track. Actual memory use is still gated by
- * [maxBufferMs] and the allocator's on-demand allocation.
+ * CUSTOM buffering uses a short player buffer plus disk prefetching. The
+ * byte cap must therefore remain effective; otherwise ExoPlayer may keep
+ * loading forward data into on-heap allocator segments until [maxBufferMs].
  */
 @UnstableApi
 class SakiLoadControl(
-    private val lenientBufferBytes: Boolean,
     minBufferMs: Int,
     maxBufferMs: Int,
     bufferForPlaybackMs: Int,
     bufferForPlaybackAfterRebufferMs: Int,
+    targetBufferBytes: Int = DEFAULT_TARGET_BUFFER_BYTES,
+    prioritizeTimeOverSizeThresholds: Boolean = DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS,
 ) : DefaultLoadControl(
     DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE),
     minBufferMs,
@@ -42,26 +31,24 @@ class SakiLoadControl(
     bufferForPlaybackMs,
     bufferForPlaybackAfterRebufferMs,
     bufferForPlaybackAfterRebufferMs,
-    DEFAULT_TARGET_BUFFER_BYTES,
-    DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS,
+    targetBufferBytes,
+    prioritizeTimeOverSizeThresholds,
     DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS_FOR_LOCAL_PLAYBACK,
     DEFAULT_BACK_BUFFER_DURATION_MS,
     DEFAULT_RETAIN_BACK_BUFFER_FROM_KEYFRAME,
 ) {
-    override fun calculateTargetBufferBytes(
-        parameters: LoadControl.Parameters,
-        trackSelectionArray: Array<out ExoTrackSelection?>,
-    ): Int {
-        return if (lenientBufferBytes) {
-            LENIENT_TARGET_BUFFER_BYTES
-        } else {
-            super.calculateTargetBufferBytes(parameters, trackSelectionArray)
-        }
-    }
-
     companion object {
-        // 256 MiB cap — high enough to not bottleneck realistic buffer
-        // durations, low enough to avoid OOM on low-RAM devices.
-        private const val LENIENT_TARGET_BUFFER_BYTES = 256 * 1024 * 1024
+        private const val MIN_CUSTOM_TARGET_BUFFER_BYTES = 16 * 1024 * 1024
+        private const val MAX_CUSTOM_TARGET_BUFFER_BYTES = 96 * 1024 * 1024
+
+        fun customTargetBufferBytes(): Int {
+            val heapQuarter = Runtime.getRuntime().maxMemory() / 4L
+            return heapQuarter
+                .coerceIn(
+                    MIN_CUSTOM_TARGET_BUFFER_BYTES.toLong(),
+                    MAX_CUSTOM_TARGET_BUFFER_BYTES.toLong(),
+                )
+                .toInt()
+        }
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -3,18 +3,20 @@ package org.hdhmc.saki.playback
 import android.app.PendingIntent
 import android.content.Intent
 import android.media.audiofx.LoudnessEnhancer
+import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import android.net.Uri
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.CacheWriter
 import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
@@ -30,10 +32,12 @@ import androidx.media3.session.SessionResult
 import org.hdhmc.saki.MainActivity
 import org.hdhmc.saki.R
 import org.hdhmc.saki.data.remote.HTTP_USER_AGENT
+import org.hdhmc.saki.domain.model.BufferStrategy
 import org.hdhmc.saki.domain.model.LyricLine
 import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshot
 import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshotSource
 import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshotSourceType
+import org.hdhmc.saki.domain.model.PlaybackPreferences
 import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.domain.model.SoundBalancingMode
 import org.hdhmc.saki.domain.model.StreamQuality
@@ -43,6 +47,7 @@ import org.hdhmc.saki.domain.repository.SubsonicRepository
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import dagger.hilt.android.AndroidEntryPoint
+import java.io.InterruptedIOException
 import java.io.IOException
 import java.net.ConnectException
 import java.net.NoRouteToHostException
@@ -52,6 +57,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -62,6 +68,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
+
+private const val CUSTOM_PLAYER_MAX_BUFFER_MS = 5 * 60 * 1_000
+private const val STREAM_PREFETCH_LOG_TAG = "SakiStreamPrefetch"
 
 @AndroidEntryPoint
 @UnstableApi
@@ -113,6 +122,11 @@ class SakiPlaybackService : MediaSessionService() {
     private var soundBalancingMode = SoundBalancingMode.OFF
     private var loudnessEnhancer: LoudnessEnhancer? = null
     private var loudnessEnhancerSessionId: Int = C.AUDIO_SESSION_ID_UNSET
+    private lateinit var streamCacheDataSourceFactory: CacheDataSource.Factory
+    private var streamPrefetchJob: Job? = null
+    private var activeStreamPrefetchKey: String? = null
+    @Volatile
+    private var activeStreamCacheWriter: CacheWriter? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -131,6 +145,7 @@ class SakiPlaybackService : MediaSessionService() {
             .setCache(streamCache)
             .setUpstreamDataSourceFactory(upstreamDataSourceFactory)
             .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+        streamCacheDataSourceFactory = cacheFactory
         val dataSourceFactory = ResolvingDataSource.Factory(cacheFactory) { dataSpec ->
             resolveStreamDataSpec(dataSpec)
         }
@@ -141,19 +156,30 @@ class SakiPlaybackService : MediaSessionService() {
         cachedPlaybackPrefs = initialPrefs
 
         val maxBufferMs = when (initialPrefs.bufferStrategy) {
-            org.hdhmc.saki.domain.model.BufferStrategy.CUSTOM ->
-                initialPrefs.customBufferSeconds * 1_000
+            BufferStrategy.CUSTOM ->
+                minOf(initialPrefs.customBufferSeconds * 1_000, CUSTOM_PLAYER_MAX_BUFFER_MS)
             else -> DefaultLoadControl.DEFAULT_MAX_BUFFER_MS
         }
-        val loadControl = SakiLoadControl(
-            lenientBufferBytes = initialPrefs.bufferStrategy !=
-                org.hdhmc.saki.domain.model.BufferStrategy.NORMAL,
-            minBufferMs = minOf(DefaultLoadControl.DEFAULT_MIN_BUFFER_MS, maxBufferMs),
-            maxBufferMs = maxBufferMs,
-            bufferForPlaybackMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
-            bufferForPlaybackAfterRebufferMs =
-                DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
-        )
+        val usesCustomBuffer = initialPrefs.bufferStrategy == BufferStrategy.CUSTOM
+        val loadControl = if (usesCustomBuffer) {
+            SakiLoadControl(
+                minBufferMs = minOf(DefaultLoadControl.DEFAULT_MIN_BUFFER_MS, maxBufferMs),
+                maxBufferMs = maxBufferMs,
+                bufferForPlaybackMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
+                bufferForPlaybackAfterRebufferMs =
+                    DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
+                targetBufferBytes = SakiLoadControl.customTargetBufferBytes(),
+                prioritizeTimeOverSizeThresholds = false,
+            )
+        } else {
+            SakiLoadControl(
+                minBufferMs = minOf(DefaultLoadControl.DEFAULT_MIN_BUFFER_MS, maxBufferMs),
+                maxBufferMs = maxBufferMs,
+                bufferForPlaybackMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
+                bufferForPlaybackAfterRebufferMs =
+                    DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
+            )
+        }
 
         val exoPlayer = ExoPlayer.Builder(this)
             .setAudioAttributes(audioAttributes, true)
@@ -168,6 +194,7 @@ class SakiPlaybackService : MediaSessionService() {
                 addListener(PlaybackRecoveryListener())
                 addListener(PlayQueueSaveListener())
                 addListener(NotificationMediaButtonListener())
+                addListener(StreamPrefetchListener())
                 addListener(object : Player.Listener {
                     override fun onTimelineChanged(timeline: androidx.media3.common.Timeline, reason: Int) {
                         val pending = pendingShuffleOrder ?: return
@@ -210,7 +237,17 @@ class SakiPlaybackService : MediaSessionService() {
 
         // Keep playback prefs in memory for the non-suspend ResolvingDataSource resolver
         playerScope.launch {
-            playbackPreferencesRepository.observePreferences().collect { cachedPlaybackPrefs = it }
+            playbackPreferencesRepository.observePreferences().collect {
+                cachedPlaybackPrefs = it
+                syncCurrentStreamPrefetch()
+            }
+        }
+
+        playerScope.launch {
+            networkTypeProvider.networkType
+                .collect {
+                    syncCurrentStreamPrefetch()
+                }
         }
 
         playerScope.launch {
@@ -359,14 +396,141 @@ class SakiPlaybackService : MediaSessionService() {
 
     /** Latest playback preferences, kept in memory to avoid blocking reads in the resolver. */
     @Volatile
-    private var cachedPlaybackPrefs: org.hdhmc.saki.domain.model.PlaybackPreferences? = null
+    private var cachedPlaybackPrefs: PlaybackPreferences? = null
+
+    private fun syncCurrentStreamPrefetch() {
+        val activePlayer = player ?: run {
+            cancelStreamPrefetch()
+            return
+        }
+        val prefs = cachedPlaybackPrefs ?: return
+        val mediaItem = activePlayer.currentMediaItem
+        val request = mediaItem?.toPlaybackRequestOrNull()
+        if (
+            prefs.bufferStrategy != BufferStrategy.CUSTOM ||
+            prefs.customBufferSeconds * 1_000 <= CUSTOM_PLAYER_MAX_BUFFER_MS ||
+            activePlayer.playbackState == Player.STATE_IDLE ||
+            activePlayer.playbackState == Player.STATE_ENDED ||
+            request == null ||
+            request.isCached ||
+            request.localPath != null ||
+            request.durationMs?.let { it <= CUSTOM_PLAYER_MAX_BUFFER_MS } == true ||
+            endpointSelector.isOfflineDegraded(request.serverId)
+        ) {
+            cancelStreamPrefetch()
+            return
+        }
+
+        val requestedQuality = request.requestedStreamQuality(prefs)
+        if (streamCacheRepository.findCachedQualityKey(request.serverId, request.songId, requestedQuality) != null) {
+            cancelStreamPrefetch()
+            return
+        }
+
+        val prefetchKey = buildString {
+            append(request.serverId)
+            append('|')
+            append(request.songId)
+            append('|')
+            append(requestedQuality.storageKey)
+            append('|')
+            append(request.format.orEmpty())
+            append('|')
+            append(prefs.customBufferSeconds)
+        }
+        if (activeStreamPrefetchKey == prefetchKey && streamPrefetchJob?.isActive == true) {
+            return
+        }
+
+        cancelStreamPrefetch()
+        activeStreamPrefetchKey = prefetchKey
+        streamPrefetchJob = serviceScope.launch(Dispatchers.IO) {
+            runCatching {
+                prefetchStreamToDisk(request)
+            }.onFailure { throwable ->
+                if (throwable is CancellationException) {
+                    throw throwable
+                }
+                if (throwable is InterruptedIOException) {
+                    return@onFailure
+                }
+                Log.w(STREAM_PREFETCH_LOG_TAG, "Failed to prefetch stream cache", throwable)
+            }
+        }
+    }
+
+    private fun cancelStreamPrefetch() {
+        activeStreamPrefetchKey = null
+        activeStreamCacheWriter?.cancel()
+        activeStreamCacheWriter = null
+        streamPrefetchJob?.cancel()
+        streamPrefetchJob = null
+    }
+
+    private fun PlaybackRequest.requestedStreamQuality(prefs: PlaybackPreferences): StreamQuality {
+        return if (prefs.adaptiveQualityEnabled) {
+            when (networkTypeProvider.networkType.value) {
+                org.hdhmc.saki.data.remote.NetworkType.WIFI -> prefs.wifiStreamQuality
+                org.hdhmc.saki.data.remote.NetworkType.MOBILE -> prefs.mobileStreamQuality
+            }
+        } else {
+            StreamQuality.entries.find { it.maxBitRate == maxBitRate } ?: StreamQuality.ORIGINAL
+        }
+    }
+
+    private fun PlaybackRequest.toStreamPlaceholderUri(): Uri {
+        return Uri.Builder()
+            .scheme("saki")
+            .authority("stream")
+            .appendQueryParameter("serverId", serverId.toString())
+            .appendQueryParameter("songId", songId)
+            .apply {
+                maxBitRate?.let { appendQueryParameter("maxBitRate", it.toString()) }
+                format?.let { appendQueryParameter("format", it) }
+            }
+            .build()
+    }
+
+    private fun PlaybackRequest.toStreamPlaceholderDataSpec(): DataSpec {
+        return DataSpec.Builder()
+            .setUri(toStreamPlaceholderUri())
+            .build()
+    }
+
+    private fun prefetchStreamToDisk(request: PlaybackRequest) {
+        val resolvedSpec = resolveStreamDataSpec(
+            dataSpec = request.toStreamPlaceholderDataSpec(),
+            allowCachedResource = false,
+        )
+        if (resolvedSpec.uri.scheme == "saki-cache" || resolvedSpec.key.isNullOrBlank()) {
+            return
+        }
+
+        val writer = CacheWriter(
+            streamCacheDataSourceFactory.createDataSource(),
+            resolvedSpec,
+            null,
+            null,
+        )
+        activeStreamCacheWriter = writer
+        try {
+            writer.cache()
+        } finally {
+            if (activeStreamCacheWriter === writer) {
+                activeStreamCacheWriter = null
+            }
+        }
+    }
 
     /**
      * Resolves placeholder `saki://stream` URIs to real Subsonic stream URLs at the moment
      * ExoPlayer actually opens the data source. This ensures the quality and endpoint are
      * determined by the current network state, not the queue build time.
      */
-    private fun resolveStreamDataSpec(dataSpec: DataSpec): DataSpec {
+    private fun resolveStreamDataSpec(
+        dataSpec: DataSpec,
+        allowCachedResource: Boolean = true,
+    ): DataSpec {
         val uri = dataSpec.uri
         if (uri.scheme != "saki" || uri.host != "stream") return dataSpec
 
@@ -393,7 +557,7 @@ class SakiPlaybackService : MediaSessionService() {
         val cachedResourceKey = cachedQuality?.let { quality ->
             streamCacheRepository.buildCacheKey(serverId, songId, quality)
         }
-        if (preferLocalCache && cachedResourceKey != null) {
+        if (allowCachedResource && preferLocalCache && cachedResourceKey != null) {
             return dataSpec.buildUpon()
                 .setUri(cachedStreamUri(cachedResourceKey))
                 .setKey(cachedResourceKey)
@@ -463,6 +627,7 @@ class SakiPlaybackService : MediaSessionService() {
 
     override fun onDestroy() {
         savePlayQueue(immediate = true)
+        cancelStreamPrefetch()
         releaseSoundBalancingEffect()
 
         mediaSession?.release()
@@ -666,16 +831,7 @@ class SakiPlaybackService : MediaSessionService() {
             }
 
             // Build placeholder URI — real stream URL resolved at play time by ResolvingDataSource
-            val placeholderUri = Uri.Builder()
-                .scheme("saki")
-                .authority("stream")
-                .appendQueryParameter("serverId", request.serverId.toString())
-                .appendQueryParameter("songId", request.songId)
-                .apply {
-                    request.maxBitRate?.let { appendQueryParameter("maxBitRate", it.toString()) }
-                    request.format?.let { appendQueryParameter("format", it) }
-                }
-                .build()
+            val placeholderUri = request.toStreamPlaceholderUri()
 
             // Resolve artwork URL using canonical endpoint (first by order) so
             // CoverArtEndpointInterceptor can rewrite it to the current best endpoint at load time
@@ -708,6 +864,20 @@ class SakiPlaybackService : MediaSessionService() {
                         .build(),
                 )
                 .build()
+        }
+    }
+
+    private inner class StreamPrefetchListener : Player.Listener {
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            syncCurrentStreamPrefetch()
+        }
+
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            syncCurrentStreamPrefetch()
+        }
+
+        override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+            syncCurrentStreamPrefetch()
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -60,13 +60,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.runInterruptible
 import okhttp3.OkHttpClient
 
 private const val CUSTOM_PLAYER_MAX_BUFFER_MS = 5 * 60 * 1_000
@@ -422,11 +425,6 @@ class SakiPlaybackService : MediaSessionService() {
         }
 
         val requestedQuality = request.requestedStreamQuality(prefs)
-        if (streamCacheRepository.findCachedQualityKey(request.serverId, request.songId, requestedQuality) != null) {
-            cancelStreamPrefetch()
-            return
-        }
-
         val prefetchKey = buildString {
             append(request.serverId)
             append('|')
@@ -439,6 +437,11 @@ class SakiPlaybackService : MediaSessionService() {
             append(prefs.customBufferSeconds)
         }
         if (activeStreamPrefetchKey == prefetchKey && streamPrefetchJob?.isActive == true) {
+            return
+        }
+
+        if (streamCacheRepository.findCachedQualityKey(request.serverId, request.songId, requestedQuality) != null) {
+            cancelStreamPrefetch()
             return
         }
 
@@ -497,11 +500,13 @@ class SakiPlaybackService : MediaSessionService() {
             .build()
     }
 
-    private fun prefetchStreamToDisk(request: PlaybackRequest) {
+    private suspend fun prefetchStreamToDisk(request: PlaybackRequest) {
+        currentCoroutineContext().ensureActive()
         val resolvedSpec = resolveStreamDataSpec(
             dataSpec = request.toStreamPlaceholderDataSpec(),
             allowCachedResource = false,
         )
+        currentCoroutineContext().ensureActive()
         if (resolvedSpec.uri.scheme == "saki-cache" || resolvedSpec.key.isNullOrBlank()) {
             return
         }
@@ -514,7 +519,9 @@ class SakiPlaybackService : MediaSessionService() {
         )
         activeStreamCacheWriter = writer
         try {
-            writer.cache()
+            runInterruptible(Dispatchers.IO) {
+                writer.cache()
+            }
         } finally {
             if (activeStreamCacheWriter === writer) {
                 activeStreamCacheWriter = null


### PR DESCRIPTION
## Summary

- Keep CUSTOM player buffering on a short 5-minute in-memory window with an effective byte cap.
- Move long CUSTOM buffering to disk by prefetching the current stream into SimpleCache with CacheWriter.
- Include contiguous stream-cache progress in buffered position when content length is available.

Closes #235

## Notes

- NORMAL buffer behavior is unchanged.
- Transcoded streams without stable Content-Length may still only show player-buffer progress even while disk prefetch writes cache data.

## Validation

- Ran `git diff --check`.
- User smoke-tested the branch locally.
- Local Android build was not run in this environment.