### PR TITLE
fix: stabilize Now Playing layout by fixing line heights

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -558,11 +558,11 @@ fun NowPlayingOverlay(
             val titleStyle = when {
                 track.title.length >= 34 -> MaterialTheme.typography.titleLarge.copy(
                     fontSize = 20.sp,
-                    lineHeight = 24.sp,
+                    lineHeight = 28.sp,
                 )
                 denseTitle || shortScreen -> MaterialTheme.typography.titleLarge.copy(
                     fontSize = 22.sp,
-                    lineHeight = 26.sp,
+                    lineHeight = 28.sp,
                 )
                 else -> MaterialTheme.typography.headlineMedium.copy(
                     fontSize = 24.sp,
@@ -571,7 +571,7 @@ fun NowPlayingOverlay(
             }
             val metadataStyle = MaterialTheme.typography.bodyLarge.copy(
                 fontSize = if (denseMetadata || shortScreen) 16.sp else 17.sp,
-                lineHeight = if (denseMetadata || shortScreen) 20.sp else 22.sp,
+                lineHeight = 22.sp,
             )
             val horizontalPadding = if (shortScreen) 16.dp else 20.dp
             val verticalSpacing = if (shortScreen) 8.dp else 12.dp


### PR DESCRIPTION
Closes #240

## Problem

Now Playing layout shifts vertically when switching between tracks with different title/metadata lengths. The `lineHeight` changed dynamically (24/26/28sp for title, 20/22sp for metadata) based on character count thresholds, causing the artwork, controls, and text to jump.

## Fix

Fix `lineHeight` to the maximum value for each text element:
- Title: always 28sp (fontSize still adapts: 20/22/24sp)
- Metadata: always 22sp (fontSize still adapts: 16/17sp)

Since both are `maxLines = 1`, the container height is determined solely by lineHeight. Fixing it eliminates layout shifts while preserving the visual density adaptation of font size.