### PR TITLE
feat: timeline-aware custom buffer prefetch

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
@@ -169,10 +169,10 @@ class DefaultStreamCacheRepository @Inject constructor(
             val isFullyCached = if (contentLength != C.LENGTH_UNSET.toLong() && contentLength > 0L) {
                 streamCache.isCached(key, 0, contentLength)
             } else {
-                // No Content-Length (e.g. transcoded stream): consider cached if there is
-                // a single contiguous span starting at 0 with meaningful size
-                val spans = streamCache.getCachedSpans(key)
-                spans.size == 1 && spans.first().position == 0L && cachedBytes > 0L
+                // No Content-Length (e.g. transcoded stream): consider cached if the
+                // resource has a contiguous cached prefix starting at 0. SimpleCache
+                // may split a completed CacheWriter result into multiple spans.
+                hasContiguousCachedPrefix(key)
             }
             if (isFullyCached) {
                 cachedSongIdsByServerAndQuality
@@ -188,6 +188,22 @@ class DefaultStreamCacheRepository @Inject constructor(
             },
             bytesByServer = bytesByServer.toMap(),
         )
+    }
+
+    private fun hasContiguousCachedPrefix(key: String): Boolean {
+        val spans = streamCache.getCachedSpans(key).sortedBy { span -> span.position }
+        if (spans.isEmpty() || spans.first().position != 0L) return false
+
+        var coveredUntil = 0L
+        for (span in spans) {
+            if (span.length <= 0L) continue
+            if (span.position > coveredUntil) return false
+            val spanEnd = span.position + span.length
+            if (spanEnd > coveredUntil) {
+                coveredUntil = spanEnd
+            }
+        }
+        return coveredUntil > 0L
     }
 }
 

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -136,7 +136,7 @@ class SakiPlaybackService : MediaSessionService() {
     private var streamPrefetchJob: Job? = null
     private var streamPrefetchReevaluationJob: Job? = null
     private var activeStreamPrefetchKey: String? = null
-    private val completedStreamPrefetchKeys = ConcurrentHashMap.newKeySet<String>()
+    private val completedStreamPrefetchKeysByTarget = ConcurrentHashMap<StreamPrefetchTargetKey, String>()
     @Volatile
     private var activeStreamCacheWriter: CacheWriter? = null
 
@@ -560,13 +560,20 @@ class SakiPlaybackService : MediaSessionService() {
             if (!request.isCached && request.localPath == null && !endpointSelector.isOfflineDegraded(request.serverId)) {
                 val quality = request.requestedStreamQuality(prefs)
                 val prefetchRequest = request.withStreamQuality(quality)
+                val targetKey = StreamPrefetchTargetKey(
+                    serverId = request.serverId,
+                    songId = request.songId,
+                    qualityKey = quality.storageKey,
+                )
+                val isSatisfied = isStreamPrefetchSatisfied(request.serverId, request.songId, quality)
                 keyParts +=
-                    "$index:${request.serverId}:${request.songId}:${quality.storageKey}:${quality.format.orEmpty()}"
-                if (!isStreamPrefetchSatisfied(request.serverId, request.songId, quality)) {
+                    "$index:${targetKey.planKey()}:${if (isSatisfied) "done" else "pending"}"
+                if (!isSatisfied) {
                     targets += StreamPrefetchTarget(
                         request = prefetchRequest,
                         quality = quality,
                         queueIndex = index,
+                        targetKey = targetKey,
                     )
                 }
             }
@@ -612,33 +619,33 @@ class SakiPlaybackService : MediaSessionService() {
         if (streamCacheRepository.findCachedQualityKey(serverId, songId, preferredQuality) != null) {
             return true
         }
-        return findCompletedStreamPrefetchKey(serverId, songId, preferredQuality) != null
+        return findCompletedStreamPrefetchCacheKey(serverId, songId, preferredQuality) != null
     }
 
-    private fun findCompletedStreamPrefetchKey(
+    private fun findCompletedStreamPrefetchCacheKey(
         serverId: Long,
         songId: String,
         preferredQuality: StreamQuality,
     ): String? {
-        val exactKey = streamCacheRepository.buildCacheKey(serverId, songId, preferredQuality)
-        if (isCompletedStreamPrefetchKey(exactKey)) return exactKey
+        val exactTargetKey = StreamPrefetchTargetKey(serverId, songId, preferredQuality.storageKey)
+        isCompletedStreamPrefetchCacheKey(exactTargetKey)?.let { return it }
 
         val preferredIndex = StreamQuality.entries.indexOf(preferredQuality)
         if (preferredIndex < 0) return null
         for (index in 0..preferredIndex) {
             val quality = StreamQuality.entries[index]
             if (quality == preferredQuality) continue
-            val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, quality)
-            if (isCompletedStreamPrefetchKey(cacheKey)) return cacheKey
+            val targetKey = StreamPrefetchTargetKey(serverId, songId, quality.storageKey)
+            isCompletedStreamPrefetchCacheKey(targetKey)?.let { return it }
         }
         return null
     }
 
-    private fun isCompletedStreamPrefetchKey(cacheKey: String): Boolean {
-        if (!completedStreamPrefetchKeys.contains(cacheKey)) return false
-        if (streamCache.getCachedSpans(cacheKey).any { span -> span.length > 0L }) return true
-        completedStreamPrefetchKeys.remove(cacheKey)
-        return false
+    private fun isCompletedStreamPrefetchCacheKey(targetKey: StreamPrefetchTargetKey): String? {
+        val cacheKey = completedStreamPrefetchKeysByTarget[targetKey] ?: return null
+        if (streamCache.getCachedSpans(cacheKey).any { span -> span.length > 0L }) return cacheKey
+        completedStreamPrefetchKeysByTarget.remove(targetKey, cacheKey)
+        return null
     }
 
     private suspend fun prefetchTimelineToDisk(plan: StreamPrefetchPlan) {
@@ -648,7 +655,7 @@ class SakiPlaybackService : MediaSessionService() {
                 return@forEach
             }
             val cacheKey = prefetchStreamToDisk(target.request) ?: return@forEach
-            completedStreamPrefetchKeys.add(cacheKey)
+            completedStreamPrefetchKeysByTarget[target.targetKey] = cacheKey
         }
     }
 
@@ -692,7 +699,16 @@ class SakiPlaybackService : MediaSessionService() {
         val request: PlaybackRequest,
         val quality: StreamQuality,
         val queueIndex: Int,
+        val targetKey: StreamPrefetchTargetKey,
     )
+
+    private data class StreamPrefetchTargetKey(
+        val serverId: Long,
+        val songId: String,
+        val qualityKey: String,
+    ) {
+        fun planKey(): String = "$serverId:$songId:$qualityKey"
+    }
 
     /**
      * Resolves placeholder `saki://stream` URIs to real Subsonic stream URLs at the moment

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -481,6 +481,7 @@ class SakiPlaybackService : MediaSessionService() {
         streamPrefetchReevaluationJob = playerScope.launch {
             while (true) {
                 delay(STREAM_PREFETCH_REEVALUATION_MS)
+                if (streamPrefetchJob?.isActive == true) continue
                 syncCurrentStreamPrefetch()
             }
         }
@@ -573,7 +574,7 @@ class SakiPlaybackService : MediaSessionService() {
                 val isSatisfied = isStreamPrefetchSatisfied(request.serverId, request.songId, quality)
                 val isDeferred = isStreamPrefetchDeferred(targetKey, nowMs)
                 val trackEndFromCurrentMs = remainingTrackMs?.let { distanceFromCurrentMs + it }
-                val isHandledByPlayerBuffer = index == currentIndex ||
+                val isHandledByPlayerBuffer =
                     trackEndFromCurrentMs?.let { it <= CUSTOM_PLAYER_MAX_BUFFER_MS } == true
                 val targetState = when {
                     isSatisfied -> "done"

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.media.audiofx.LoudnessEnhancer
 import android.net.Uri
 import android.os.Bundle
+import android.os.SystemClock
 import android.util.Log
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -77,6 +78,7 @@ import okhttp3.OkHttpClient
 private const val CUSTOM_PLAYER_MAX_BUFFER_MS = 5 * 60 * 1_000
 private const val STREAM_PREFETCH_LOG_TAG = "SakiStreamPrefetch"
 private const val STREAM_PREFETCH_REEVALUATION_MS = 30_000L
+private const val STREAM_PREFETCH_RETRY_DELAY_MS = 30_000L
 
 private fun Long.coerceKnownDuration(): Long? {
     return takeIf { it != C.TIME_UNSET && it > 0L }
@@ -137,7 +139,7 @@ class SakiPlaybackService : MediaSessionService() {
     private var streamPrefetchReevaluationJob: Job? = null
     private var activeStreamPrefetchKey: String? = null
     private val completedStreamPrefetchKeysByTarget = ConcurrentHashMap<StreamPrefetchTargetKey, String>()
-    private val blockedStreamPrefetchTargets = ConcurrentHashMap.newKeySet<StreamPrefetchTargetKey>()
+    private val deferredStreamPrefetchTargets = ConcurrentHashMap<StreamPrefetchTargetKey, Long>()
     @Volatile
     private var activeStreamCacheWriter: CacheWriter? = null
 
@@ -545,6 +547,7 @@ class SakiPlaybackService : MediaSessionService() {
         val targets = mutableListOf<StreamPrefetchTarget>()
         val keyParts = mutableListOf<String>()
         val window = Timeline.Window()
+        val nowMs = SystemClock.elapsedRealtime()
         var distanceFromCurrentMs = 0L
         while (remainingBudgetMs > 0L && index != C.INDEX_UNSET && visited < mediaItemCount) {
             val mediaItem = getMediaItemAt(index)
@@ -568,11 +571,13 @@ class SakiPlaybackService : MediaSessionService() {
                     qualityKey = quality.storageKey,
                 )
                 val isSatisfied = isStreamPrefetchSatisfied(request.serverId, request.songId, quality)
-                val isBlocked = blockedStreamPrefetchTargets.contains(targetKey)
-                val isHandledByPlayerBuffer = distanceFromCurrentMs <= CUSTOM_PLAYER_MAX_BUFFER_MS
+                val isDeferred = isStreamPrefetchDeferred(targetKey, nowMs)
+                val trackEndFromCurrentMs = remainingTrackMs?.let { distanceFromCurrentMs + it }
+                val isHandledByPlayerBuffer = index == currentIndex ||
+                    trackEndFromCurrentMs?.let { it <= CUSTOM_PLAYER_MAX_BUFFER_MS } == true
                 val targetState = when {
                     isSatisfied -> "done"
-                    isBlocked -> "blocked"
+                    isDeferred -> "deferred"
                     isHandledByPlayerBuffer -> "player"
                     else -> "pending"
                 }
@@ -654,6 +659,16 @@ class SakiPlaybackService : MediaSessionService() {
         return null
     }
 
+    private fun isStreamPrefetchDeferred(
+        targetKey: StreamPrefetchTargetKey,
+        nowMs: Long,
+    ): Boolean {
+        val retryAtMs = deferredStreamPrefetchTargets[targetKey] ?: return false
+        if (retryAtMs > nowMs) return true
+        deferredStreamPrefetchTargets.remove(targetKey, retryAtMs)
+        return false
+    }
+
     private fun isCompletedStreamPrefetchCacheKey(targetKey: StreamPrefetchTargetKey): String? {
         val cacheKey = completedStreamPrefetchKeysByTarget[targetKey] ?: return null
         if (streamCache.getCachedSpans(cacheKey).any { span -> span.length > 0L }) return cacheKey
@@ -670,8 +685,10 @@ class SakiPlaybackService : MediaSessionService() {
             val result = prefetchStreamToDisk(target.request) ?: return@forEach
             if (result.cachedBytes > 0L) {
                 completedStreamPrefetchKeysByTarget[target.targetKey] = result.cacheKey
+                deferredStreamPrefetchTargets.remove(target.targetKey)
             } else {
-                blockedStreamPrefetchTargets.add(target.targetKey)
+                deferredStreamPrefetchTargets[target.targetKey] =
+                    SystemClock.elapsedRealtime() + STREAM_PREFETCH_RETRY_DELAY_MS
             }
         }
     }

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -11,6 +11,7 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.DefaultDataSource
@@ -74,6 +75,10 @@ import okhttp3.OkHttpClient
 
 private const val CUSTOM_PLAYER_MAX_BUFFER_MS = 5 * 60 * 1_000
 private const val STREAM_PREFETCH_LOG_TAG = "SakiStreamPrefetch"
+
+private fun Long.coerceKnownDuration(): Long? {
+    return takeIf { it != C.TIME_UNSET && it > 0L }
+}
 
 @AndroidEntryPoint
 @UnstableApi
@@ -407,50 +412,28 @@ class SakiPlaybackService : MediaSessionService() {
             return
         }
         val prefs = cachedPlaybackPrefs ?: return
-        val mediaItem = activePlayer.currentMediaItem
-        val request = mediaItem?.toPlaybackRequestOrNull()
-        if (
-            prefs.bufferStrategy != BufferStrategy.CUSTOM ||
-            prefs.customBufferSeconds * 1_000 <= CUSTOM_PLAYER_MAX_BUFFER_MS ||
-            activePlayer.playbackState == Player.STATE_IDLE ||
-            activePlayer.playbackState == Player.STATE_ENDED ||
-            request == null ||
-            request.isCached ||
-            request.localPath != null ||
-            request.durationMs?.let { it <= CUSTOM_PLAYER_MAX_BUFFER_MS } == true ||
-            endpointSelector.isOfflineDegraded(request.serverId)
-        ) {
+        val plan = activePlayer.buildStreamPrefetchPlan(prefs)
+        if (plan == null) {
             cancelStreamPrefetch()
             return
         }
 
-        val requestedQuality = request.requestedStreamQuality(prefs)
-        val prefetchKey = buildString {
-            append(request.serverId)
-            append('|')
-            append(request.songId)
-            append('|')
-            append(requestedQuality.storageKey)
-            append('|')
-            append(request.format.orEmpty())
-            append('|')
-            append(prefs.customBufferSeconds)
-        }
-        if (activeStreamPrefetchKey == prefetchKey && streamPrefetchJob?.isActive == true) {
+        if (activeStreamPrefetchKey == plan.key && streamPrefetchJob?.isActive == true) {
             return
         }
 
-        if (streamCacheRepository.findCachedQualityKey(request.serverId, request.songId, requestedQuality) != null) {
+        if (plan.targets.isEmpty()) {
             cancelStreamPrefetch()
             return
         }
 
         cancelStreamPrefetch()
-        activeStreamPrefetchKey = prefetchKey
+        activeStreamPrefetchKey = plan.key
         streamPrefetchJob = serviceScope.launch(Dispatchers.IO) {
-            runCatching {
-                prefetchStreamToDisk(request)
-            }.onFailure { throwable ->
+            val result = runCatching {
+                prefetchTimelineToDisk(plan)
+            }
+            result.onFailure { throwable ->
                 if (throwable is CancellationException) {
                     throw throwable
                 }
@@ -458,6 +441,12 @@ class SakiPlaybackService : MediaSessionService() {
                     return@onFailure
                 }
                 Log.w(STREAM_PREFETCH_LOG_TAG, "Failed to prefetch stream cache", throwable)
+            }
+            if (activeStreamPrefetchKey == plan.key) {
+                activeStreamPrefetchKey = null
+                if (result.isSuccess) {
+                    playerScope.launch { syncCurrentStreamPrefetch() }
+                }
             }
         }
     }
@@ -481,6 +470,16 @@ class SakiPlaybackService : MediaSessionService() {
         }
     }
 
+    private fun PlaybackRequest.withStreamQuality(quality: StreamQuality): PlaybackRequest {
+        return copy(
+            qualityLabel = quality.label,
+            streamCacheKey = streamCacheRepository.buildCacheKey(serverId, songId, quality),
+            maxBitRate = quality.maxBitRate,
+            format = quality.format,
+            bitRate = estimatedPlaybackBitRateKbps(sourceBitRate, quality.maxBitRate),
+        )
+    }
+
     private fun PlaybackRequest.toStreamPlaceholderUri(): Uri {
         return Uri.Builder()
             .scheme("saki")
@@ -498,6 +497,90 @@ class SakiPlaybackService : MediaSessionService() {
         return DataSpec.Builder()
             .setUri(toStreamPlaceholderUri())
             .build()
+    }
+
+    private fun ExoPlayer.buildStreamPrefetchPlan(prefs: PlaybackPreferences): StreamPrefetchPlan? {
+        val customBufferMs = prefs.customBufferSeconds * 1_000L
+        val currentIndex = currentMediaItemIndex
+        if (
+            prefs.bufferStrategy != BufferStrategy.CUSTOM ||
+            customBufferMs <= CUSTOM_PLAYER_MAX_BUFFER_MS ||
+            playbackState == Player.STATE_IDLE ||
+            playbackState == Player.STATE_ENDED ||
+            currentIndex == C.INDEX_UNSET ||
+            mediaItemCount <= 0 ||
+            currentTimeline.windowCount == 0
+        ) {
+            return null
+        }
+
+        var remainingBudgetMs = customBufferMs
+        var index = currentIndex
+        var visited = 0
+        val targets = mutableListOf<StreamPrefetchTarget>()
+        val keyParts = mutableListOf<String>()
+        while (remainingBudgetMs > 0L && index != C.INDEX_UNSET && visited < mediaItemCount) {
+            val mediaItem = getMediaItemAt(index)
+            val request = mediaItem.toPlaybackRequestOrNull() ?: break
+            val durationMs = mediaItem.durationForPrefetchMs(index == currentIndex)
+            val positionMs = if (index == currentIndex) currentPosition.coerceAtLeast(0L) else 0L
+            val remainingTrackMs = durationMs
+                ?.minus(positionMs)
+                ?.coerceAtLeast(0L)
+            if (request.isCached || request.localPath != null || endpointSelector.isOfflineDegraded(request.serverId)) {
+                remainingTrackMs?.let { remainingBudgetMs -= it } ?: break
+            } else {
+                val quality = request.requestedStreamQuality(prefs)
+                val prefetchRequest = request.withStreamQuality(quality)
+                keyParts +=
+                    "$index:${request.serverId}:${request.songId}:${quality.storageKey}:${quality.format.orEmpty()}"
+                if (streamCacheRepository.findCachedQualityKey(request.serverId, request.songId, quality) == null) {
+                    targets += StreamPrefetchTarget(
+                        request = prefetchRequest,
+                        quality = quality,
+                        queueIndex = index,
+                    )
+                }
+                remainingTrackMs?.let { remainingBudgetMs -= it } ?: break
+            }
+
+            if (repeatMode == Player.REPEAT_MODE_ONE) break
+            val nextIndex = currentTimeline.getNextWindowIndex(index, repeatMode, shuffleModeEnabled)
+            if (nextIndex == C.INDEX_UNSET || nextIndex == index) break
+            index = nextIndex
+            visited++
+        }
+
+        if (keyParts.isEmpty()) return null
+        return StreamPrefetchPlan(
+            key = keyParts.joinToString(separator = "|", prefix = "$customBufferMs:$repeatMode:$shuffleModeEnabled:"),
+            targets = targets,
+        )
+    }
+
+    private fun MediaItem.durationForPrefetchMs(isCurrent: Boolean): Long? {
+        val playerDuration = if (isCurrent) {
+            player?.duration?.coerceKnownDuration()
+        } else {
+            null
+        }
+        return playerDuration ?: metadataDurationMs()
+    }
+
+    private suspend fun prefetchTimelineToDisk(plan: StreamPrefetchPlan) {
+        plan.targets.forEach { target ->
+            currentCoroutineContext().ensureActive()
+            if (
+                streamCacheRepository.findCachedQualityKey(
+                    target.request.serverId,
+                    target.request.songId,
+                    target.quality,
+                ) != null
+            ) {
+                return@forEach
+            }
+            prefetchStreamToDisk(target.request)
+        }
     }
 
     private suspend fun prefetchStreamToDisk(request: PlaybackRequest) {
@@ -528,6 +611,17 @@ class SakiPlaybackService : MediaSessionService() {
             }
         }
     }
+
+    private data class StreamPrefetchPlan(
+        val key: String,
+        val targets: List<StreamPrefetchTarget>,
+    )
+
+    private data class StreamPrefetchTarget(
+        val request: PlaybackRequest,
+        val quality: StreamQuality,
+        val queueIndex: Int,
+    )
 
     /**
      * Resolves placeholder `saki://stream` URIs to real Subsonic stream URLs at the moment
@@ -875,6 +969,10 @@ class SakiPlaybackService : MediaSessionService() {
     }
 
     private inner class StreamPrefetchListener : Player.Listener {
+        override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+            syncCurrentStreamPrefetch()
+        }
+
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
             syncCurrentStreamPrefetch()
         }
@@ -884,6 +982,14 @@ class SakiPlaybackService : MediaSessionService() {
         }
 
         override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+            syncCurrentStreamPrefetch()
+        }
+
+        override fun onRepeatModeChanged(repeatMode: Int) {
+            syncCurrentStreamPrefetch()
+        }
+
+        override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
             syncCurrentStreamPrefetch()
         }
     }

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -137,6 +137,7 @@ class SakiPlaybackService : MediaSessionService() {
     private var streamPrefetchReevaluationJob: Job? = null
     private var activeStreamPrefetchKey: String? = null
     private val completedStreamPrefetchKeysByTarget = ConcurrentHashMap<StreamPrefetchTargetKey, String>()
+    private val blockedStreamPrefetchTargets = ConcurrentHashMap.newKeySet<StreamPrefetchTargetKey>()
     @Volatile
     private var activeStreamCacheWriter: CacheWriter? = null
 
@@ -544,6 +545,7 @@ class SakiPlaybackService : MediaSessionService() {
         val targets = mutableListOf<StreamPrefetchTarget>()
         val keyParts = mutableListOf<String>()
         val window = Timeline.Window()
+        var distanceFromCurrentMs = 0L
         while (remainingBudgetMs > 0L && index != C.INDEX_UNSET && visited < mediaItemCount) {
             val mediaItem = getMediaItemAt(index)
             val request = mediaItem.toPlaybackRequestOrNull() ?: break
@@ -566,9 +568,17 @@ class SakiPlaybackService : MediaSessionService() {
                     qualityKey = quality.storageKey,
                 )
                 val isSatisfied = isStreamPrefetchSatisfied(request.serverId, request.songId, quality)
+                val isBlocked = blockedStreamPrefetchTargets.contains(targetKey)
+                val isHandledByPlayerBuffer = distanceFromCurrentMs <= CUSTOM_PLAYER_MAX_BUFFER_MS
+                val targetState = when {
+                    isSatisfied -> "done"
+                    isBlocked -> "blocked"
+                    isHandledByPlayerBuffer -> "player"
+                    else -> "pending"
+                }
                 keyParts +=
-                    "$index:${targetKey.planKey()}:${if (isSatisfied) "done" else "pending"}"
-                if (!isSatisfied) {
+                    "$index:${targetKey.planKey()}:$targetState"
+                if (targetState == "pending") {
                     targets += StreamPrefetchTarget(
                         request = prefetchRequest,
                         quality = quality,
@@ -578,7 +588,10 @@ class SakiPlaybackService : MediaSessionService() {
                 }
             }
 
-            remainingTrackMs?.let { remainingBudgetMs -= it } ?: break
+            remainingTrackMs?.let {
+                remainingBudgetMs -= it
+                distanceFromCurrentMs += it
+            } ?: break
             if (repeatMode == Player.REPEAT_MODE_ONE) break
             val nextIndex = currentTimeline.getNextWindowIndex(index, repeatMode, shuffleModeEnabled)
             if (nextIndex == C.INDEX_UNSET || nextIndex == index) break
@@ -654,12 +667,16 @@ class SakiPlaybackService : MediaSessionService() {
             if (isStreamPrefetchSatisfied(target.request.serverId, target.request.songId, target.quality)) {
                 return@forEach
             }
-            val cacheKey = prefetchStreamToDisk(target.request) ?: return@forEach
-            completedStreamPrefetchKeysByTarget[target.targetKey] = cacheKey
+            val result = prefetchStreamToDisk(target.request) ?: return@forEach
+            if (result.cachedBytes > 0L) {
+                completedStreamPrefetchKeysByTarget[target.targetKey] = result.cacheKey
+            } else {
+                blockedStreamPrefetchTargets.add(target.targetKey)
+            }
         }
     }
 
-    private suspend fun prefetchStreamToDisk(request: PlaybackRequest): String? {
+    private suspend fun prefetchStreamToDisk(request: PlaybackRequest): StreamPrefetchResult? {
         currentCoroutineContext().ensureActive()
         val resolvedSpec = resolveStreamDataSpec(
             dataSpec = request.toStreamPlaceholderDataSpec(),
@@ -668,12 +685,15 @@ class SakiPlaybackService : MediaSessionService() {
         currentCoroutineContext().ensureActive()
         val cacheKey = resolvedSpec.key?.takeIf { key -> key.isNotBlank() } ?: return null
         if (resolvedSpec.uri.scheme == "saki-cache") {
-            return cacheKey
+            return StreamPrefetchResult(cacheKey = cacheKey, cachedBytes = cachedBytes(cacheKey))
         }
+        val prefetchSpec = resolvedSpec.buildUpon()
+            .setFlags(resolvedSpec.flags or DataSpec.FLAG_ALLOW_CACHE_FRAGMENTATION)
+            .build()
 
         val writer = CacheWriter(
             streamCacheDataSourceFactory.createDataSource(),
-            resolvedSpec,
+            prefetchSpec,
             null,
             null,
         )
@@ -687,12 +707,21 @@ class SakiPlaybackService : MediaSessionService() {
                 activeStreamCacheWriter = null
             }
         }
-        return cacheKey
+        return StreamPrefetchResult(cacheKey = cacheKey, cachedBytes = cachedBytes(cacheKey))
+    }
+
+    private fun cachedBytes(cacheKey: String): Long {
+        return streamCache.getCachedSpans(cacheKey).sumOf { span -> span.length }
     }
 
     private data class StreamPrefetchPlan(
         val key: String,
         val targets: List<StreamPrefetchTarget>,
+    )
+
+    private data class StreamPrefetchResult(
+        val cacheKey: String,
+        val cachedBytes: Long,
     )
 
     private data class StreamPrefetchTarget(

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -54,6 +54,7 @@ import java.net.ConnectException
 import java.net.NoRouteToHostException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -75,6 +76,7 @@ import okhttp3.OkHttpClient
 
 private const val CUSTOM_PLAYER_MAX_BUFFER_MS = 5 * 60 * 1_000
 private const val STREAM_PREFETCH_LOG_TAG = "SakiStreamPrefetch"
+private const val STREAM_PREFETCH_REEVALUATION_MS = 30_000L
 
 private fun Long.coerceKnownDuration(): Long? {
     return takeIf { it != C.TIME_UNSET && it > 0L }
@@ -132,7 +134,9 @@ class SakiPlaybackService : MediaSessionService() {
     private var loudnessEnhancerSessionId: Int = C.AUDIO_SESSION_ID_UNSET
     private lateinit var streamCacheDataSourceFactory: CacheDataSource.Factory
     private var streamPrefetchJob: Job? = null
+    private var streamPrefetchReevaluationJob: Job? = null
     private var activeStreamPrefetchKey: String? = null
+    private val completedStreamPrefetchKeys = ConcurrentHashMap.newKeySet<String>()
     @Volatile
     private var activeStreamCacheWriter: CacheWriter? = null
 
@@ -417,17 +421,18 @@ class SakiPlaybackService : MediaSessionService() {
             cancelStreamPrefetch()
             return
         }
+        scheduleStreamPrefetchReevaluation()
 
         if (activeStreamPrefetchKey == plan.key && streamPrefetchJob?.isActive == true) {
             return
         }
 
         if (plan.targets.isEmpty()) {
-            cancelStreamPrefetch()
+            cancelActiveStreamPrefetch()
             return
         }
 
-        cancelStreamPrefetch()
+        cancelActiveStreamPrefetch()
         activeStreamPrefetchKey = plan.key
         streamPrefetchJob = serviceScope.launch(Dispatchers.IO) {
             val result = runCatching {
@@ -442,21 +447,40 @@ class SakiPlaybackService : MediaSessionService() {
                 }
                 Log.w(STREAM_PREFETCH_LOG_TAG, "Failed to prefetch stream cache", throwable)
             }
-            if (activeStreamPrefetchKey == plan.key) {
-                activeStreamPrefetchKey = null
-                if (result.isSuccess) {
-                    playerScope.launch { syncCurrentStreamPrefetch() }
+            playerScope.launch {
+                if (activeStreamPrefetchKey == plan.key) {
+                    activeStreamPrefetchKey = null
+                    streamPrefetchJob = null
+                    if (result.isSuccess) {
+                        syncCurrentStreamPrefetch()
+                    }
                 }
             }
         }
     }
 
     private fun cancelStreamPrefetch() {
+        cancelActiveStreamPrefetch()
+        streamPrefetchReevaluationJob?.cancel()
+        streamPrefetchReevaluationJob = null
+    }
+
+    private fun cancelActiveStreamPrefetch() {
         activeStreamPrefetchKey = null
         activeStreamCacheWriter?.cancel()
         activeStreamCacheWriter = null
         streamPrefetchJob?.cancel()
         streamPrefetchJob = null
+    }
+
+    private fun scheduleStreamPrefetchReevaluation() {
+        if (streamPrefetchReevaluationJob?.isActive == true) return
+        streamPrefetchReevaluationJob = playerScope.launch {
+            while (true) {
+                delay(STREAM_PREFETCH_REEVALUATION_MS)
+                syncCurrentStreamPrefetch()
+            }
+        }
     }
 
     private fun PlaybackRequest.requestedStreamQuality(prefs: PlaybackPreferences): StreamQuality {
@@ -519,31 +543,35 @@ class SakiPlaybackService : MediaSessionService() {
         var visited = 0
         val targets = mutableListOf<StreamPrefetchTarget>()
         val keyParts = mutableListOf<String>()
+        val window = Timeline.Window()
         while (remainingBudgetMs > 0L && index != C.INDEX_UNSET && visited < mediaItemCount) {
             val mediaItem = getMediaItemAt(index)
             val request = mediaItem.toPlaybackRequestOrNull() ?: break
-            val durationMs = mediaItem.durationForPrefetchMs(index == currentIndex)
+            val durationMs = durationForPrefetchMs(
+                index = index,
+                mediaItem = mediaItem,
+                request = request,
+                window = window,
+            )
             val positionMs = if (index == currentIndex) currentPosition.coerceAtLeast(0L) else 0L
             val remainingTrackMs = durationMs
                 ?.minus(positionMs)
                 ?.coerceAtLeast(0L)
-            if (request.isCached || request.localPath != null || endpointSelector.isOfflineDegraded(request.serverId)) {
-                remainingTrackMs?.let { remainingBudgetMs -= it } ?: break
-            } else {
+            if (!request.isCached && request.localPath == null && !endpointSelector.isOfflineDegraded(request.serverId)) {
                 val quality = request.requestedStreamQuality(prefs)
                 val prefetchRequest = request.withStreamQuality(quality)
                 keyParts +=
                     "$index:${request.serverId}:${request.songId}:${quality.storageKey}:${quality.format.orEmpty()}"
-                if (streamCacheRepository.findCachedQualityKey(request.serverId, request.songId, quality) == null) {
+                if (!isStreamPrefetchSatisfied(request.serverId, request.songId, quality)) {
                     targets += StreamPrefetchTarget(
                         request = prefetchRequest,
                         quality = quality,
                         queueIndex = index,
                     )
                 }
-                remainingTrackMs?.let { remainingBudgetMs -= it } ?: break
             }
 
+            remainingTrackMs?.let { remainingBudgetMs -= it } ?: break
             if (repeatMode == Player.REPEAT_MODE_ONE) break
             val nextIndex = currentTimeline.getNextWindowIndex(index, repeatMode, shuffleModeEnabled)
             if (nextIndex == C.INDEX_UNSET || nextIndex == index) break
@@ -558,40 +586,82 @@ class SakiPlaybackService : MediaSessionService() {
         )
     }
 
-    private fun MediaItem.durationForPrefetchMs(isCurrent: Boolean): Long? {
-        val playerDuration = if (isCurrent) {
-            player?.duration?.coerceKnownDuration()
+    private fun ExoPlayer.durationForPrefetchMs(
+        index: Int,
+        mediaItem: MediaItem,
+        request: PlaybackRequest,
+        window: Timeline.Window,
+    ): Long? {
+        val playerDuration = if (index == currentMediaItemIndex) {
+            duration.coerceKnownDuration()
         } else {
             null
         }
-        return playerDuration ?: metadataDurationMs()
+        val timelineDuration = currentTimeline.getWindow(index, window).durationMs.coerceKnownDuration()
+        return playerDuration
+            ?: timelineDuration
+            ?: request.durationMs?.coerceKnownDuration()
+            ?: mediaItem.metadataDurationMs()
+    }
+
+    private fun isStreamPrefetchSatisfied(
+        serverId: Long,
+        songId: String,
+        preferredQuality: StreamQuality,
+    ): Boolean {
+        if (streamCacheRepository.findCachedQualityKey(serverId, songId, preferredQuality) != null) {
+            return true
+        }
+        return findCompletedStreamPrefetchKey(serverId, songId, preferredQuality) != null
+    }
+
+    private fun findCompletedStreamPrefetchKey(
+        serverId: Long,
+        songId: String,
+        preferredQuality: StreamQuality,
+    ): String? {
+        val exactKey = streamCacheRepository.buildCacheKey(serverId, songId, preferredQuality)
+        if (isCompletedStreamPrefetchKey(exactKey)) return exactKey
+
+        val preferredIndex = StreamQuality.entries.indexOf(preferredQuality)
+        if (preferredIndex < 0) return null
+        for (index in 0..preferredIndex) {
+            val quality = StreamQuality.entries[index]
+            if (quality == preferredQuality) continue
+            val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, quality)
+            if (isCompletedStreamPrefetchKey(cacheKey)) return cacheKey
+        }
+        return null
+    }
+
+    private fun isCompletedStreamPrefetchKey(cacheKey: String): Boolean {
+        if (!completedStreamPrefetchKeys.contains(cacheKey)) return false
+        if (streamCache.getCachedSpans(cacheKey).any { span -> span.length > 0L }) return true
+        completedStreamPrefetchKeys.remove(cacheKey)
+        return false
     }
 
     private suspend fun prefetchTimelineToDisk(plan: StreamPrefetchPlan) {
         plan.targets.forEach { target ->
             currentCoroutineContext().ensureActive()
-            if (
-                streamCacheRepository.findCachedQualityKey(
-                    target.request.serverId,
-                    target.request.songId,
-                    target.quality,
-                ) != null
-            ) {
+            if (isStreamPrefetchSatisfied(target.request.serverId, target.request.songId, target.quality)) {
                 return@forEach
             }
-            prefetchStreamToDisk(target.request)
+            val cacheKey = prefetchStreamToDisk(target.request) ?: return@forEach
+            completedStreamPrefetchKeys.add(cacheKey)
         }
     }
 
-    private suspend fun prefetchStreamToDisk(request: PlaybackRequest) {
+    private suspend fun prefetchStreamToDisk(request: PlaybackRequest): String? {
         currentCoroutineContext().ensureActive()
         val resolvedSpec = resolveStreamDataSpec(
             dataSpec = request.toStreamPlaceholderDataSpec(),
             allowCachedResource = false,
         )
         currentCoroutineContext().ensureActive()
-        if (resolvedSpec.uri.scheme == "saki-cache" || resolvedSpec.key.isNullOrBlank()) {
-            return
+        val cacheKey = resolvedSpec.key?.takeIf { key -> key.isNotBlank() } ?: return null
+        if (resolvedSpec.uri.scheme == "saki-cache") {
+            return cacheKey
         }
 
         val writer = CacheWriter(
@@ -610,6 +680,7 @@ class SakiPlaybackService : MediaSessionService() {
                 activeStreamCacheWriter = null
             }
         }
+        return cacheKey
     }
 
     private data class StreamPrefetchPlan(


### PR DESCRIPTION
Closes #242

## Summary

Extends CUSTOM buffer prefetch to cover the configured duration across multiple queue items, not just the current track.

## Changes

`SakiPlaybackService.kt`:

- **`buildStreamPrefetchPlan`** — walks the player timeline from `currentIndex` forward using `Timeline.getNextWindowIndex(index, repeatMode, shuffleModeEnabled)`, accumulating tracks until the configured buffer duration budget is exhausted. Produces an ordered list of `StreamPrefetchTarget`s.
- **`prefetchTimelineToDisk`** — iterates targets serially, calling `prefetchStreamToDisk` (single `CacheWriter`) for each uncached track.
- **`StreamPrefetchListener`** — now also reacts to `onTimelineChanged`, `onRepeatModeChanged`, `onShuffleModeEnabledChanged` to recompute the plan.
- After a plan completes successfully, re-evaluates to pick up newly-eligible tracks (e.g. playback advanced).

## Behavior

| Scenario | Behavior |
|----------|----------|
| Current track shorter than configured duration | Prefetch continues into next queue items |
| Shuffle enabled | Uses player's shuffle order via `getNextWindowIndex` |
| Repeat-all | Wraps around queue; stops when budget exhausted |
| Repeat-one | Only prefetches current track, then stops |
| Track already cached / local / offline-degraded | Skipped but duration still deducted from budget |
| Queue mutation / mode change | Plan key invalidates → cancel + recompute |

## Not changed

- Player in-memory buffer remains short and heap-bounded (#238)
- NORMAL strategy unchanged
- Progress bar still reflects current-track cache only (per #242 spec)
- Single `CacheWriter` at a time, no concurrent disk/network load