### PR TITLE
fix: hide unsupported album feeds

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/domain/model/SubsonicModels.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/SubsonicModels.kt
@@ -72,13 +72,9 @@ enum class AlbumListType(val apiValue: String) {
     companion object {
         val defaultBrowseFeeds = listOf(
             NEWEST,
-            RECENT,
             RANDOM,
-            HIGHEST,
-            FREQUENT,
             ALPHABETICAL_BY_NAME,
             ALPHABETICAL_BY_ARTIST,
-            STARRED,
         )
 
         fun fromApiValue(apiValue: String?): AlbumListType? {


### PR DESCRIPTION
Closes #253

Related to #251

## Summary

- Hide album feed chips that depend on client features Saki does not currently support: recent playback scrobbling, frequent playback stats, album ratings, and starred albums.
- Keep the supported album feeds visible: Newest, Random, A-Z, and By artist.
- Leave the underlying AlbumListType enum/API support intact so the hidden feeds can be restored later when star/scrobble/rating support exists.

## Validation

- git diff --check
- Local Gradle compile was not run because JAVA_HOME is not configured in this environment.