### PR TITLE
style: add theme style preset foundation

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/MainActivity.kt
+++ b/app/src/main/java/org/hdhmc/saki/MainActivity.kt
@@ -5,7 +5,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import org.hdhmc.saki.presentation.SakiApp
-import org.hdhmc.saki.ui.theme.SakiAndroidTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -14,9 +13,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            SakiAndroidTheme {
-                SakiApp()
-            }
+            SakiApp()
         }
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/data/repository/ConfigBackupManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/ConfigBackupManager.kt
@@ -145,6 +145,12 @@ class ConfigBackupManager @Inject constructor(
                         DataStoreAppPreferencesRepository.KEY_DEFAULT_ALBUM_FEED.name -> {
                             ds[DataStoreAppPreferencesRepository.KEY_DEFAULT_ALBUM_FEED] = value; settingsApplied = true
                         }
+                        DataStoreAppPreferencesRepository.KEY_THEME_MODE.name -> {
+                            ds[DataStoreAppPreferencesRepository.KEY_THEME_MODE] = value; settingsApplied = true
+                        }
+                        DataStoreAppPreferencesRepository.KEY_THEME_STYLE.name -> {
+                            ds[DataStoreAppPreferencesRepository.KEY_THEME_STYLE] = value; settingsApplied = true
+                        }
                         DataStoreAppPreferencesRepository.KEY_SONGS_PAGE_SIZE.name -> {
                             ds[DataStoreAppPreferencesRepository.KEY_SONGS_PAGE_SIZE] =
                                 value.toIntOrNull()?.normalizeSongsPageSize() ?: return@forEach

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
@@ -15,6 +15,7 @@ import org.hdhmc.saki.domain.model.DEFAULT_SONGS_PAGE_SIZE
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
 import org.hdhmc.saki.domain.model.TextScale
 import org.hdhmc.saki.domain.model.ThemeMode
+import org.hdhmc.saki.domain.model.ThemeStyle
 import org.hdhmc.saki.domain.model.normalizeSongsPageSize
 import org.hdhmc.saki.domain.repository.AppPreferencesRepository
 import java.io.IOException
@@ -54,6 +55,10 @@ class DataStoreAppPreferencesRepository @Inject constructor(
 
     override suspend fun updateThemeMode(themeMode: ThemeMode) {
         dataStore.edit { it[KEY_THEME_MODE] = themeMode.storageKey }
+    }
+
+    override suspend fun updateThemeStyle(themeStyle: ThemeStyle) {
+        dataStore.edit { it[KEY_THEME_STYLE] = themeStyle.storageKey }
     }
 
     override suspend fun updateAlbumViewMode(mode: AlbumViewMode) {
@@ -121,6 +126,7 @@ class DataStoreAppPreferencesRepository @Inject constructor(
         val KEY_TEXT_SCALE = stringPreferencesKey("text_scale")
         val KEY_LANGUAGE = stringPreferencesKey("app_language")
         val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
+        val KEY_THEME_STYLE = stringPreferencesKey("theme_style")
         val KEY_ALBUM_VIEW_MODE = stringPreferencesKey("album_view_mode")
         val KEY_DEFAULT_BROWSE_TAB = stringPreferencesKey("default_browse_tab")
         val KEY_DEFAULT_ALBUM_FEED = stringPreferencesKey("default_album_feed")
@@ -134,6 +140,7 @@ private fun Preferences.toAppPreferences() = AppPreferences(
     textScale = TextScale.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_TEXT_SCALE]),
     language = AppLanguage.fromTag(this[DataStoreAppPreferencesRepository.KEY_LANGUAGE]),
     themeMode = ThemeMode.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_THEME_MODE]),
+    themeStyle = ThemeStyle.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_THEME_STYLE]),
     albumViewMode = AlbumViewMode.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_ALBUM_VIEW_MODE]),
     defaultBrowseTab = DefaultBrowseTab.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_DEFAULT_BROWSE_TAB]),
     defaultAlbumFeed = AlbumListType.fromApiValue(

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
@@ -10,6 +10,7 @@ import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
 import org.hdhmc.saki.domain.model.TextScale
 import org.hdhmc.saki.domain.model.ThemeMode
+import org.hdhmc.saki.domain.model.ThemeStyle
 import org.hdhmc.saki.domain.repository.AppPreferencesRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -44,6 +45,10 @@ class DefaultAppPreferencesRepository @Inject constructor(
     }
 
     override suspend fun updateThemeMode(themeMode: ThemeMode) {
+        // Theme preference is only supported via DataStore; no-op here
+    }
+
+    override suspend fun updateThemeStyle(themeStyle: ThemeStyle) {
         // Theme preference is only supported via DataStore; no-op here
     }
 

--- a/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
@@ -42,6 +42,7 @@ data class AppPreferences(
     val textScale: TextScale = TextScale.DEFAULT,
     val language: AppLanguage = AppLanguage.SYSTEM,
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    val themeStyle: ThemeStyle = ThemeStyle.SAKI,
     val albumViewMode: AlbumViewMode = AlbumViewMode.GRID,
     val defaultBrowseTab: DefaultBrowseTab = DefaultBrowseTab.ARTISTS,
     val defaultAlbumFeed: AlbumListType = AlbumListType.NEWEST,
@@ -94,6 +95,15 @@ enum class ThemeMode(val storageKey: String) {
     companion object {
         fun fromStorageKey(storageKey: String?): ThemeMode =
             entries.firstOrNull { it.storageKey == storageKey } ?: SYSTEM
+    }
+}
+
+enum class ThemeStyle(val storageKey: String) {
+    SAKI("saki");
+
+    companion object {
+        fun fromStorageKey(storageKey: String?): ThemeStyle =
+            entries.firstOrNull { it.storageKey == storageKey } ?: SAKI
     }
 }
 

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
@@ -7,6 +7,7 @@ import org.hdhmc.saki.domain.model.AlbumViewMode
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
 import org.hdhmc.saki.domain.model.TextScale
 import org.hdhmc.saki.domain.model.ThemeMode
+import org.hdhmc.saki.domain.model.ThemeStyle
 import kotlinx.coroutines.flow.Flow
 
 interface AppPreferencesRepository {
@@ -19,6 +20,8 @@ interface AppPreferencesRepository {
     suspend fun updateLanguage(language: AppLanguage)
 
     suspend fun updateThemeMode(themeMode: ThemeMode)
+
+    suspend fun updateThemeStyle(themeStyle: ThemeStyle)
 
     suspend fun updateAlbumViewMode(mode: AlbumViewMode)
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -43,11 +43,13 @@ import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.SongLyrics
 import org.hdhmc.saki.domain.model.ThemeMode
+import org.hdhmc.saki.domain.model.ThemeStyle
 import org.hdhmc.saki.presentation.library.BrowseScreen
 import org.hdhmc.saki.presentation.library.NowPlayingCapsule
 import org.hdhmc.saki.presentation.library.NowPlayingOverlay
 import org.hdhmc.saki.presentation.serverconfig.ServerConfigRoute
 import org.hdhmc.saki.presentation.settings.SettingsScreen
+import org.hdhmc.saki.ui.theme.SakiAndroidTheme
 
 @Composable
 fun SakiApp(
@@ -94,7 +96,8 @@ fun SakiApp(
         }
     }
 
-    CompositionLocalProvider(LocalDensity provides appDensity) {
+    SakiAndroidTheme(themeStyle = uiState.appPreferences.themeStyle) {
+        CompositionLocalProvider(LocalDensity provides appDensity) {
         Box(modifier = modifier.fillMaxSize()) {
             when {
                 !uiState.isAppReady -> {
@@ -156,6 +159,7 @@ fun SakiApp(
                         onUpdateTextScale = viewModel::updateTextScale,
                         onUpdateLanguage = viewModel::updateLanguage,
                         onUpdateThemeMode = viewModel::updateThemeMode,
+                        onUpdateThemeStyle = viewModel::updateThemeStyle,
                         onUpdateDefaultBrowseTab = viewModel::updateDefaultBrowseTab,
                         onUpdateDefaultAlbumFeed = viewModel::updateDefaultAlbumFeed,
                         onUpdateSongsPageSize = viewModel::updateSongsPageSize,
@@ -206,6 +210,7 @@ fun SakiApp(
                 }
             }
         }
+    }
     }
 }
 
@@ -260,6 +265,7 @@ private fun RootShell(
     onUpdateTextScale: (org.hdhmc.saki.domain.model.TextScale) -> Unit,
     onUpdateLanguage: (org.hdhmc.saki.domain.model.AppLanguage) -> Unit,
     onUpdateThemeMode: (ThemeMode) -> Unit,
+    onUpdateThemeStyle: (ThemeStyle) -> Unit,
     onUpdateDefaultBrowseTab: (org.hdhmc.saki.domain.model.DefaultBrowseTab) -> Unit,
     onUpdateDefaultAlbumFeed: (org.hdhmc.saki.domain.model.AlbumListType) -> Unit,
     onUpdateSongsPageSize: (Int) -> Unit,
@@ -351,6 +357,7 @@ private fun RootShell(
                             onUpdateTextScale = onUpdateTextScale,
                             onUpdateLanguage = onUpdateLanguage,
                             onUpdateThemeMode = onUpdateThemeMode,
+                            onUpdateThemeStyle = onUpdateThemeStyle,
                             onUpdateDefaultBrowseTab = onUpdateDefaultBrowseTab,
                             onUpdateDefaultAlbumFeed = onUpdateDefaultAlbumFeed,
                             onUpdateSongsPageSize = onUpdateSongsPageSize,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -13,6 +13,7 @@ import org.hdhmc.saki.domain.model.AlbumViewMode
 import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.ThemeMode
+import org.hdhmc.saki.domain.model.ThemeStyle
 import org.hdhmc.saki.domain.model.AlbumSummary
 import org.hdhmc.saki.domain.model.Artist
 import org.hdhmc.saki.domain.model.ArtistSummary
@@ -351,6 +352,12 @@ class SakiAppViewModel @Inject constructor(
                     androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode(nightMode)
                 }
             }
+        }
+    }
+
+    fun updateThemeStyle(themeStyle: ThemeStyle) {
+        viewModelScope.launch {
+            appPreferencesRepository.updateThemeStyle(themeStyle)
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -59,6 +59,7 @@ import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.CachedSong
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
 import org.hdhmc.saki.domain.model.ThemeMode
+import org.hdhmc.saki.domain.model.ThemeStyle
 import org.hdhmc.saki.domain.model.MAX_STREAM_CACHE_SIZE_MB
 import org.hdhmc.saki.domain.model.MIN_STREAM_CACHE_SIZE_MB
 import org.hdhmc.saki.domain.model.BufferStrategy
@@ -106,6 +107,7 @@ fun SettingsScreen(
     onUpdateTextScale: (TextScale) -> Unit,
     onUpdateLanguage: (AppLanguage) -> Unit,
     onUpdateThemeMode: (ThemeMode) -> Unit,
+    onUpdateThemeStyle: (ThemeStyle) -> Unit,
     onUpdateDefaultBrowseTab: (DefaultBrowseTab) -> Unit,
     onUpdateDefaultAlbumFeed: (AlbumListType) -> Unit,
     onUpdateSongsPageSize: (Int) -> Unit,
@@ -426,6 +428,11 @@ fun SettingsScreen(
                 action = null,
             ) {
                 val currentTheme = uiState.appPreferences.themeMode
+                val currentThemeStyle = uiState.appPreferences.themeStyle
+                Text(
+                    text = stringResource(R.string.settings_theme_mode_label),
+                    style = MaterialTheme.typography.labelLarge,
+                )
                 FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -444,6 +451,21 @@ fun SettingsScreen(
                         selected = currentTheme == ThemeMode.DARK,
                         onClick = { onUpdateThemeMode(ThemeMode.DARK) },
                         label = { Text(stringResource(R.string.settings_theme_dark)) },
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.settings_theme_style_label),
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    FilterChip(
+                        selected = currentThemeStyle == ThemeStyle.SAKI,
+                        onClick = { onUpdateThemeStyle(ThemeStyle.SAKI) },
+                        label = { Text(stringResource(R.string.settings_theme_style_saki)) },
                     )
                 }
             }

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import org.hdhmc.saki.domain.model.ThemeStyle
 
 private val DarkColorScheme = darkColorScheme(
     primary = MoonlitBlue,
@@ -60,18 +61,21 @@ private val LightColorScheme = lightColorScheme(
 @Composable
 fun SakiAndroidTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    themeStyle: ThemeStyle = ThemeStyle.SAKI,
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
+    val colorScheme = when (themeStyle) {
+        ThemeStyle.SAKI -> when {
+            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            }
 
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+            darkTheme -> DarkColorScheme
+            else -> LightColorScheme
+        }
     }
 
     MaterialTheme(

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -57,9 +57,12 @@
     <string name="settings_language_coverage">%1$d%%</string>
     <string name="settings_theme_title">主题</string>
     <string name="settings_theme_body">选择应用的外观。</string>
+    <string name="settings_theme_mode_label">明暗模式</string>
     <string name="settings_theme_system">跟随系统</string>
     <string name="settings_theme_light">浅色</string>
     <string name="settings_theme_dark">深色</string>
+    <string name="settings_theme_style_label">视觉风格</string>
+    <string name="settings_theme_style_saki">Saki</string>
     <string name="settings_default_browse_title">默认浏览标签</string>
     <string name="settings_default_browse_body">选择应用启动时显示的浏览标签。</string>
     <string name="settings_default_album_feed">默认专辑源</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,9 +59,12 @@
     <string name="settings_language_coverage">%1$d%%</string>
     <string name="settings_theme_title">Theme</string>
     <string name="settings_theme_body">Choose the app appearance.</string>
+    <string name="settings_theme_mode_label">Brightness</string>
     <string name="settings_theme_system">System default</string>
     <string name="settings_theme_light">Light</string>
     <string name="settings_theme_dark">Dark</string>
+    <string name="settings_theme_style_label">Style</string>
+    <string name="settings_theme_style_saki">Saki</string>
     <string name="settings_default_browse_title">Default Browse tab</string>
     <string name="settings_default_browse_body">Choose the Browse tab shown when the app starts.</string>
     <string name="settings_default_album_feed">Default album feed</string>


### PR DESCRIPTION
## Summary
- Add a persisted ThemeStyle preset preference separate from ThemeMode brightness selection.
- Thread ThemeStyle through DataStore, repositories, ViewModel, Settings, and SakiAndroidTheme.
- Move the Compose theme host into SakiApp so future visual presets can react to app preferences.
- Add settings labels for brightness mode and visual style, plus backup restore support for theme mode/style settings.

## Validation
- Not run locally; CI should verify build.

Closes #256