### PR TITLE
style: add Material 3 Expressive theme preset

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,9 +9,7 @@ plugins {
 android {
     namespace = "org.hdhmc.saki"
     compileSdk {
-        version = release(36) {
-            minorApiLevel = 1
-        }
+        version = release(37)
     }
 
     defaultConfig {

--- a/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
@@ -99,7 +99,8 @@ enum class ThemeMode(val storageKey: String) {
 }
 
 enum class ThemeStyle(val storageKey: String) {
-    SAKI("saki");
+    SAKI("saki"),
+    MATERIAL_EXPRESSIVE("material_expressive");
 
     companion object {
         fun fromStorageKey(storageKey: String?): ThemeStyle =

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -467,6 +467,11 @@ fun SettingsScreen(
                         onClick = { onUpdateThemeStyle(ThemeStyle.SAKI) },
                         label = { Text(stringResource(R.string.settings_theme_style_saki)) },
                     )
+                    FilterChip(
+                        selected = currentThemeStyle == ThemeStyle.MATERIAL_EXPRESSIVE,
+                        onClick = { onUpdateThemeStyle(ThemeStyle.MATERIAL_EXPRESSIVE) },
+                        label = { Text(stringResource(R.string.settings_theme_style_material_expressive)) },
+                    )
                 }
             }
         }

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
@@ -2,10 +2,14 @@ package org.hdhmc.saki.ui.theme
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialExpressiveTheme
+import androidx.compose.material3.MotionScheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.expressiveLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -58,6 +62,7 @@ private val LightColorScheme = lightColorScheme(
     outlineVariant = Color(0xFFBCCAD1),
 )
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun SakiAndroidTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
@@ -66,22 +71,33 @@ fun SakiAndroidTheme(
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when (themeStyle) {
-        ThemeStyle.SAKI -> when {
-            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-                val context = LocalContext.current
-                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-            }
+    when (themeStyle) {
+        ThemeStyle.SAKI -> {
+            MaterialTheme(
+                colorScheme = sakiColorScheme(darkTheme = darkTheme, dynamicColor = dynamicColor),
+                typography = Typography,
+                shapes = SakiShapes,
+                content = content,
+            )
+        }
 
-            darkTheme -> DarkColorScheme
-            else -> LightColorScheme
+        ThemeStyle.MATERIAL_EXPRESSIVE -> {
+            MaterialExpressiveTheme(
+                colorScheme = if (darkTheme) darkColorScheme() else expressiveLightColorScheme(),
+                motionScheme = MotionScheme.expressive(),
+                content = content,
+            )
         }
     }
+}
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        shapes = SakiShapes,
-        content = content
-    )
+@Composable
+private fun sakiColorScheme(darkTheme: Boolean, dynamicColor: Boolean) = when {
+    dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+        val context = LocalContext.current
+        if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+    }
+
+    darkTheme -> DarkColorScheme
+    else -> LightColorScheme
 }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -63,6 +63,7 @@
     <string name="settings_theme_dark">深色</string>
     <string name="settings_theme_style_label">视觉风格</string>
     <string name="settings_theme_style_saki">Saki</string>
+    <string name="settings_theme_style_material_expressive">Material 3 Expressive</string>
     <string name="settings_default_browse_title">默认浏览标签</string>
     <string name="settings_default_browse_body">选择应用启动时显示的浏览标签。</string>
     <string name="settings_default_album_feed">默认专辑源</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -63,6 +63,7 @@
     <string name="settings_theme_dark">深色</string>
     <string name="settings_theme_style_label">视觉风格</string>
     <string name="settings_theme_style_saki">Saki</string>
+    <!-- Material 3 Expressive is a product/style name and is intentionally kept in English. -->
     <string name="settings_theme_style_material_expressive">Material 3 Expressive</string>
     <string name="settings_default_browse_title">默认浏览标签</string>
     <string name="settings_default_browse_body">选择应用启动时显示的浏览标签。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_theme_style_label">Style</string>
     <string name="settings_theme_style_saki">Saki</string>
+    <string name="settings_theme_style_material_expressive">Material 3 Expressive</string>
     <string name="settings_default_browse_title">Default Browse tab</string>
     <string name="settings_default_browse_body">Choose the Browse tab shown when the app starts.</string>
     <string name="settings_default_album_feed">Default album feed</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ activityCompose = "1.13.0"
 appcompat = "1.7.0"
 kotlin = "2.2.10"
 composeBom = "2026.02.01"
+material3 = "1.5.0-alpha20"
 hilt = "2.57.1"
 ksp = "2.3.4"
 room = "2.8.4"
@@ -39,7 +40,7 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }


### PR DESCRIPTION
## Summary
- Add a Material 3 Expressive built-in theme style preset.
- Let Settings switch between the existing Saki style and the new Material 3 Expressive style.
- Use MaterialExpressiveTheme with expressive motion for the M3E preset while leaving the existing Saki style unchanged.
- Pin Material3 to 1.5.0-alpha20 and raise compileSdk to 37 because the expressive Material3 alpha pulls Compose UI dependencies that require API 37.

## Notes
- 	argetSdk remains 36; this only raises compile SDK for dependency compatibility.
- Visual changes are intentionally limited in this PR. App-specific hard-coded colors, alpha values, background brushes, and shape tokens remain for #257.

## Validation
- git diff --check passed.
- Local Gradle build was not run because this environment does not have JAVA_HOME / java configured; CI should verify compilation.

Closes #258