### PR TITLE
style: introduce Saki visual theme tokens

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/AppBackgrounds.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/AppBackgrounds.kt
@@ -8,15 +8,19 @@ import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.MaterialTheme
+import org.hdhmc.saki.ui.theme.SakiTheme
 
 @Composable
 fun rememberBrowseBackgroundBrush(): Brush {
     val colorScheme = MaterialTheme.colorScheme
-    return remember(colorScheme) {
+    val visuals = SakiTheme.visuals
+    return remember(colorScheme, visuals) {
         Brush.verticalGradient(
             listOf(
-                colorScheme.primary.copy(alpha = 0.16f).compositeOver(colorScheme.background),
-                colorScheme.tertiary.copy(alpha = 0.10f).compositeOver(colorScheme.surface),
+                colorScheme.primary.copy(alpha = visuals.backgroundPrimaryOverlayAlpha)
+                    .compositeOver(colorScheme.background),
+                colorScheme.tertiary.copy(alpha = visuals.backgroundTertiaryOverlayAlpha)
+                    .compositeOver(colorScheme.surface),
                 colorScheme.background,
             ),
         )

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -65,6 +65,9 @@ import org.hdhmc.saki.domain.model.Playlist
 import org.hdhmc.saki.domain.model.PlaylistSummary
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.Song
+import org.hdhmc.saki.ui.theme.sakiCardContainerColor
+import org.hdhmc.saki.ui.theme.sakiSubtleCardContainerColor
+import org.hdhmc.saki.ui.theme.sakiTonalContainerColor
 
 @Composable
 fun ArtistDetailScreen(
@@ -387,7 +390,7 @@ fun ArtistShortcutCard(artist: ArtistSummary, onOpenArtist: (String) -> Unit) {
             .padding(end = 12.dp)
             .clickable { onOpenArtist(artist.id) },
         shape = MaterialTheme.shapes.extraLarge,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)),
+        colors = CardDefaults.cardColors(containerColor = sakiCardContainerColor()),
     ) {
         Column(
             modifier = Modifier.padding(18.dp),
@@ -412,7 +415,7 @@ fun AlbumCard(album: AlbumSummary, server: ServerConfig, onOpenAlbum: (String) -
         modifier = Modifier
             .padding(6.dp),
         shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)),
+        colors = CardDefaults.cardColors(containerColor = sakiCardContainerColor()),
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             ArtworkCard(
@@ -444,7 +447,7 @@ private fun AlbumMiniCard(album: AlbumSummary, server: ServerConfig, onOpenAlbum
             .padding(end = 12.dp)
             .clickable { onOpenAlbum(album.id) },
         shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)),
+        colors = CardDefaults.cardColors(containerColor = sakiCardContainerColor()),
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             ArtworkCard(
@@ -691,7 +694,7 @@ fun NoServerBrowseState(modifier: Modifier, onManageServers: () -> Unit, onImpor
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Card(
             shape = MaterialTheme.shapes.extraLarge,
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)),
+            colors = CardDefaults.cardColors(containerColor = sakiCardContainerColor()),
         ) {
             Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text(text = stringResource(R.string.browse_needs_server), style = MaterialTheme.typography.displaySmall)
@@ -736,7 +739,7 @@ fun SectionTitle(
 
 @Composable
 fun LoadingStateCard(label: String) {
-    Card(shape = MaterialTheme.shapes.large, colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))) {
+    Card(shape = MaterialTheme.shapes.large, colors = CardDefaults.cardColors(containerColor = sakiCardContainerColor())) {
         Row(modifier = Modifier.padding(18.dp), verticalAlignment = Alignment.CenterVertically) {
             CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
             Text(text = label, modifier = Modifier.padding(start = 12.dp), style = MaterialTheme.typography.bodyLarge)
@@ -761,7 +764,7 @@ fun ErrorStateCard(message: String) {
 
 @Composable
 fun EmptyStateCard(title: String, body: String, icon: androidx.compose.ui.graphics.vector.ImageVector? = null) {
-    Card(shape = MaterialTheme.shapes.large, colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.88f))) {
+    Card(shape = MaterialTheme.shapes.large, colors = CardDefaults.cardColors(containerColor = sakiSubtleCardContainerColor())) {
         Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             if (icon != null) {
                 Icon(icon, contentDescription = null, modifier = Modifier.size(32.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -786,7 +789,7 @@ private fun RowCard(
             .fillMaxWidth()
             .padding(vertical = 6.dp),
         shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.88f)),
+        colors = CardDefaults.cardColors(containerColor = sakiSubtleCardContainerColor()),
     ) {
         Row(modifier = Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
             if (artwork != null) {
@@ -826,7 +829,7 @@ private fun SheetActionRow(
             .fillMaxWidth()
             .clickable(enabled = enabled, onClick = onClick),
         shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f),
+        color = sakiTonalContainerColor(),
     ) {
         Row(modifier = Modifier.padding(horizontal = 14.dp, vertical = 14.dp), verticalAlignment = Alignment.CenterVertically) {
             Icon(icon, contentDescription = null, tint = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline)

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -84,6 +84,9 @@ import org.hdhmc.saki.presentation.library.THUMBNAIL_COVER_ART_SIZE_PX
 import org.hdhmc.saki.presentation.library.resolveArtworkModel
 import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
+import org.hdhmc.saki.ui.theme.sakiCardContainerColor
+import org.hdhmc.saki.ui.theme.sakiSelectedContainerColor
+import org.hdhmc.saki.ui.theme.sakiTonalContainerColor
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -155,7 +158,7 @@ fun SettingsScreen(
             Card(
                 shape = MaterialTheme.shapes.extraLarge,
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+                    containerColor = sakiCardContainerColor(),
                 ),
             ) {
                 Column(modifier = Modifier.padding(22.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -907,7 +910,7 @@ private fun SettingsSectionCard(
     Card(
         shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+            containerColor = sakiCardContainerColor(),
         ),
     ) {
         Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
@@ -948,9 +951,9 @@ private fun ServerRow(
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(
             containerColor = if (selected) {
-                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f)
+                sakiSelectedContainerColor()
             } else {
-                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f)
+                sakiTonalContainerColor()
             },
         ),
     ) {

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/SakiTheme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/SakiTheme.kt
@@ -1,0 +1,58 @@
+package org.hdhmc.saki.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+data class SakiVisualTokens(
+    val backgroundPrimaryOverlayAlpha: Float = 0.16f,
+    val backgroundTertiaryOverlayAlpha: Float = 0.10f,
+    val cardContainerAlpha: Float = 0.90f,
+    val subtleCardContainerAlpha: Float = 0.88f,
+    val selectedContainerAlpha: Float = 0.90f,
+    val tonalContainerAlpha: Float = 0.42f,
+)
+
+internal val DefaultSakiVisualTokens = SakiVisualTokens()
+
+internal val MaterialExpressiveSakiVisualTokens = SakiVisualTokens(
+    backgroundPrimaryOverlayAlpha = 0.12f,
+    backgroundTertiaryOverlayAlpha = 0.16f,
+    cardContainerAlpha = 0.94f,
+    subtleCardContainerAlpha = 0.92f,
+    selectedContainerAlpha = 0.86f,
+    tonalContainerAlpha = 0.50f,
+)
+
+internal val LocalSakiVisualTokens = staticCompositionLocalOf { DefaultSakiVisualTokens }
+
+object SakiTheme {
+    val visuals: SakiVisualTokens
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalSakiVisualTokens.current
+}
+
+@Composable
+@ReadOnlyComposable
+fun sakiCardContainerColor(): Color =
+    MaterialTheme.colorScheme.surface.copy(alpha = SakiTheme.visuals.cardContainerAlpha)
+
+@Composable
+@ReadOnlyComposable
+fun sakiSubtleCardContainerColor(): Color =
+    MaterialTheme.colorScheme.surface.copy(alpha = SakiTheme.visuals.subtleCardContainerAlpha)
+
+@Composable
+@ReadOnlyComposable
+fun sakiSelectedContainerColor(): Color =
+    MaterialTheme.colorScheme.primaryContainer.copy(alpha = SakiTheme.visuals.selectedContainerAlpha)
+
+@Composable
+@ReadOnlyComposable
+fun sakiTonalContainerColor(): Color =
+    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = SakiTheme.visuals.tonalContainerAlpha)

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.expressiveLightColorScheme
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -71,24 +72,31 @@ fun SakiAndroidTheme(
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    when (themeStyle) {
-        ThemeStyle.SAKI -> {
-            MaterialTheme(
-                colorScheme = sakiColorScheme(darkTheme = darkTheme, dynamicColor = dynamicColor),
-                typography = Typography,
-                shapes = SakiShapes,
-                content = content,
-            )
-        }
+    CompositionLocalProvider(LocalSakiVisualTokens provides sakiVisualTokens(themeStyle)) {
+        when (themeStyle) {
+            ThemeStyle.SAKI -> {
+                MaterialTheme(
+                    colorScheme = sakiColorScheme(darkTheme = darkTheme, dynamicColor = dynamicColor),
+                    typography = Typography,
+                    shapes = SakiShapes,
+                    content = content,
+                )
+            }
 
-        ThemeStyle.MATERIAL_EXPRESSIVE -> {
-            MaterialExpressiveTheme(
-                colorScheme = if (darkTheme) darkColorScheme() else expressiveLightColorScheme(),
-                motionScheme = MotionScheme.expressive(),
-                content = content,
-            )
+            ThemeStyle.MATERIAL_EXPRESSIVE -> {
+                MaterialExpressiveTheme(
+                    colorScheme = if (darkTheme) darkColorScheme() else expressiveLightColorScheme(),
+                    motionScheme = MotionScheme.expressive(),
+                    content = content,
+                )
+            }
         }
     }
+}
+
+private fun sakiVisualTokens(themeStyle: ThemeStyle) = when (themeStyle) {
+    ThemeStyle.SAKI -> DefaultSakiVisualTokens
+    ThemeStyle.MATERIAL_EXPRESSIVE -> MaterialExpressiveSakiVisualTokens
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- Add SakiVisualTokens and provide them from SakiAndroidTheme based on the selected ThemeStyle.
- Route browse/settings background and common card/container alpha values through visual tokens.
- Keep the existing Saki style values unchanged while giving the Material 3 Expressive style a small token-level visual difference.

## Scope
- This is the first incremental step for #257.
- It intentionally focuses on Browse and Settings surfaces where hard-coded background/card alpha values were concentrated.
- Now Playing, server config, artwork shape, and broader page-level visual migration are left for follow-up steps.

## Validation
- git diff --check passed.
- Local Gradle build was not run because this environment does not have JAVA_HOME / java configured; CI should verify compilation.

Closes #257