### PR TITLE
fix: improve settings and mini player accessibility

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -341,6 +341,7 @@ private fun RootShell(
                             uiState = uiState,
                             contentPadding = PaddingValues(),
                             bottomOverlayPadding = capsuleOverlayPadding,
+                            onClose = { onShowSettingsChange(false) },
                             onManageServers = onManageServers,
                             onSelectServer = onSelectServer,
                             onUpdateStreamQuality = onUpdateStreamQuality,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -314,16 +314,26 @@ fun NowPlayingCapsule(
                     )
                 }
                 IconButton(onClick = onSkipToPrevious, enabled = track != null) {
-                    Icon(imageVector = Icons.Rounded.SkipPrevious, contentDescription = null)
+                    Icon(
+                        imageVector = Icons.Rounded.SkipPrevious,
+                        contentDescription = stringResource(R.string.player_previous),
+                    )
                 }
                 IconButton(onClick = onPlayPause, enabled = track != null) {
                     Icon(
                         imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                        contentDescription = null,
+                        contentDescription = if (isPlaying) {
+                            stringResource(R.string.player_pause)
+                        } else {
+                            stringResource(R.string.player_play)
+                        },
                     )
                 }
                 IconButton(onClick = onSkipToNext, enabled = track != null) {
-                    Icon(imageVector = Icons.Rounded.SkipNext, contentDescription = null)
+                    Icon(
+                        imageVector = Icons.Rounded.SkipNext,
+                        contentDescription = stringResource(R.string.player_next),
+                    )
                 }
             }
         }

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -18,10 +18,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CloudDownload
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.DeleteOutline
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.PlayArrow
-import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Storage
 import androidx.compose.material.icons.rounded.Upload
 import androidx.compose.material.icons.rounded.TextFields
@@ -95,6 +95,7 @@ fun SettingsScreen(
     uiState: SakiAppUiState,
     contentPadding: PaddingValues,
     bottomOverlayPadding: Dp = 0.dp,
+    onClose: () -> Unit,
     onManageServers: () -> Unit,
     onSelectServer: (Long) -> Unit,
     onUpdateStreamQuality: (StreamQuality) -> Unit,
@@ -167,8 +168,17 @@ fun SettingsScreen(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(text = stringResource(R.string.settings_title), style = MaterialTheme.typography.displaySmall)
-                        Icon(Icons.Rounded.Settings, contentDescription = null)
+                        Text(
+                            text = stringResource(R.string.settings_title),
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.displaySmall,
+                        )
+                        IconButton(onClick = onClose) {
+                            Icon(
+                                imageVector = Icons.Rounded.Close,
+                                contentDescription = stringResource(R.string.common_close),
+                            )
+                        }
                     }
                     Text(
                         text = stringResource(R.string.settings_intro),


### PR DESCRIPTION
## Summary
- Replace the settings header decoration with a visible close button wired to dismiss the settings overlay.
- Add localized content descriptions for mini player previous, play/pause, and next controls.
- Keep the existing mini player layout and visual treatment unchanged.

## Validation
- `./gradlew assembleDebug -q`
- `bash ./deploy.sh 10.111.111.90:34567`
- `adb exec-out screencap -p > /tmp/saki_codex_screen.png`
- `adb exec-out uiautomator dump /dev/tty` confirmed `关闭`, `上一首`, `播放`, and `下一首` accessibility labels.
- Tapped the new close button via adb and confirmed the settings overlay closes.

Part of #251