### PR TITLE
style: polish Material Expressive app chrome

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -37,8 +37,10 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
@@ -68,6 +70,7 @@ import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.ui.theme.sakiCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiSubtleCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiTonalContainerColor
+import org.hdhmc.saki.ui.theme.SakiTheme
 
 @Composable
 fun ArtistDetailScreen(
@@ -483,6 +486,7 @@ fun SongRow(
     onClick: () -> Unit,
     onMore: () -> Unit,
 ) {
+    val visuals = SakiTheme.visuals
     val isUnavailableOffline = isOfflineDegraded && !isOfflinePlayable
     Row(
         modifier = Modifier
@@ -537,7 +541,11 @@ fun SongRow(
             }
         }
         IconButton(onClick = onMore) {
-            Icon(Icons.Rounded.MoreVert, contentDescription = stringResource(R.string.library_more_actions))
+            Icon(
+                imageVector = Icons.Rounded.MoreVert,
+                contentDescription = stringResource(R.string.library_more_actions),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = visuals.browseRowActionIconAlpha),
+            )
         }
     }
 }
@@ -737,11 +745,16 @@ fun SectionTitle(
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun LoadingStateCard(label: String) {
     Card(shape = MaterialTheme.shapes.large, colors = CardDefaults.cardColors(containerColor = sakiCardContainerColor())) {
         Row(modifier = Modifier.padding(18.dp), verticalAlignment = Alignment.CenterVertically) {
-            CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            if (SakiTheme.visuals.useExpressiveLoadingIndicator) {
+                LoadingIndicator(modifier = Modifier.size(28.dp))
+            } else {
+                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            }
             Text(text = label, modifier = Modifier.padding(start = 12.dp), style = MaterialTheme.typography.bodyLarge)
         }
     }
@@ -783,6 +796,7 @@ private fun RowCard(
     artworkRequestSizePx: Int? = null,
     onClick: () -> Unit,
 ) {
+    val visuals = SakiTheme.visuals
     Card(
         onClick = onClick,
         modifier = Modifier
@@ -811,7 +825,11 @@ private fun RowCard(
                     Text(text = subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
-            Icon(Icons.AutoMirrored.Rounded.ArrowForward, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = visuals.browseRowNavigationIconAlpha),
+            )
         }
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -8,12 +8,15 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +27,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -56,6 +60,7 @@ import androidx.compose.material.icons.rounded.ViewList
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -63,6 +68,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -110,6 +116,8 @@ import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.presentation.SakiAppUiState
 import org.hdhmc.saki.presentation.asString
+import org.hdhmc.saki.ui.theme.SakiChromeIconButton
+import org.hdhmc.saki.ui.theme.SakiTheme
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.filter
@@ -445,7 +453,7 @@ private fun OfflineModeBanner(modifier: Modifier = Modifier) {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun BrowsePager(
     modifier: Modifier,
@@ -550,6 +558,23 @@ private fun BrowsePager(
                 onRefresh = onRefreshCurrentTab,
                 modifier = Modifier.weight(1f),
                 state = pullState,
+                indicator = {
+                    if (SakiTheme.visuals.useExpressiveLoadingIndicator) {
+                        PullToRefreshDefaults.LoadingIndicator(
+                            state = pullState,
+                            isRefreshing = isRefreshing,
+                            modifier = Modifier
+                                .align(Alignment.TopCenter)
+                                .size(SakiTheme.visuals.pullRefreshLoadingIndicatorSize),
+                        )
+                    } else {
+                        PullToRefreshDefaults.Indicator(
+                            state = pullState,
+                            isRefreshing = isRefreshing,
+                            modifier = Modifier.align(Alignment.TopCenter),
+                        )
+                    }
+                },
             ) {
                 Column(modifier = Modifier.fillMaxSize()) {
                     LazyRow(
@@ -559,16 +584,10 @@ private fun BrowsePager(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         items(sections) { section ->
-                            FilterChip(
+                            BrowseSectionChip(
+                                section = section,
                                 selected = uiState.selectedBrowseSection == section,
                                 onClick = { onSelectBrowseSection(section) },
-                                label = {
-                                    Text(
-                                        text = section.localizedLabel(),
-                                        style = MaterialTheme.typography.labelMedium,
-                                        maxLines = 1,
-                                    )
-                                },
                             )
                         }
                     }
@@ -691,12 +710,82 @@ private fun BrowseHeroCard(
                 overflow = TextOverflow.Ellipsis,
             )
             Spacer(modifier = Modifier.width(8.dp))
-            IconButton(onClick = { onSearchActiveChange(true) }) {
-                Icon(Icons.Rounded.Search, contentDescription = stringResource(R.string.browse_search_server))
-            }
-            IconButton(onClick = onOpenSettings) {
-                Icon(Icons.Rounded.Settings, contentDescription = stringResource(R.string.browse_settings))
-            }
+            SakiChromeIconButton(
+                onClick = { onSearchActiveChange(true) },
+                icon = Icons.Rounded.Search,
+                contentDescription = stringResource(R.string.browse_search_server),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            SakiChromeIconButton(
+                onClick = onOpenSettings,
+                icon = Icons.Rounded.Settings,
+                contentDescription = stringResource(R.string.browse_settings),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BrowseSectionChip(
+    section: BrowseSection,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val visuals = SakiTheme.visuals
+    if (visuals.browseSectionChipSelectedContainerAlpha <= 0f) {
+        FilterChip(
+            selected = selected,
+            onClick = onClick,
+            label = {
+                Text(
+                    text = section.localizedLabel(),
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
+                )
+            },
+        )
+    } else {
+        val chipShape = RoundedCornerShape(visuals.browseSectionChipCornerRadius)
+        Surface(
+            modifier = Modifier
+                .clip(chipShape)
+                .selectable(
+                    selected = selected,
+                    onClick = onClick,
+                    role = Role.Tab,
+                ),
+            shape = chipShape,
+            color = if (selected) {
+                MaterialTheme.colorScheme.secondaryContainer.copy(
+                    alpha = visuals.browseSectionChipSelectedContainerAlpha,
+                )
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerHighest.copy(
+                    alpha = visuals.browseSectionChipContainerAlpha,
+                )
+            },
+            contentColor = if (selected) {
+                MaterialTheme.colorScheme.onSecondaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            border = if (selected || visuals.browseSectionChipOutlineAlpha <= 0f) {
+                null
+            } else {
+                BorderStroke(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(
+                        alpha = visuals.browseSectionChipOutlineAlpha,
+                    ),
+                )
+            },
+        ) {
+            Text(
+                text = section.localizedLabel(),
+                modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp),
+                style = MaterialTheme.typography.labelLarge,
+                maxLines = 1,
+            )
         }
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -182,6 +182,11 @@ fun NowPlayingCapsule(
     onSkipToNext: () -> Unit,
 ) {
     val visuals = SakiTheme.visuals
+    val capsuleContainerColor = if (visuals.useExpressiveSurfaceContainers) {
+        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = visuals.nowPlayingCapsuleContainerAlpha)
+    } else {
+        MaterialTheme.colorScheme.surface.copy(alpha = visuals.nowPlayingCapsuleContainerAlpha)
+    }
     val elevation by animateDpAsState(
         targetValue = if (isPlaying) 12.dp else 6.dp,
         animationSpec = spring(
@@ -248,11 +253,9 @@ fun NowPlayingCapsule(
                     },
                 )
             },
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = RoundedCornerShape(visuals.miniPlayerContainerCornerRadius),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface.copy(
-                alpha = visuals.nowPlayingCapsuleContainerAlpha,
-            ),
+            containerColor = capsuleContainerColor,
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = elevation),
     ) {
@@ -266,9 +269,11 @@ fun NowPlayingCapsule(
             AnimatedVisibility(visible = track != null) {
                 Box(
                     modifier = Modifier
-                        .size(width = 36.dp, height = 3.dp)
+                        .size(width = visuals.miniPlayerHandleWidth, height = 3.dp)
                         .background(
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.28f),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                                alpha = visuals.miniPlayerHandleAlpha,
+                            ),
                             shape = RoundedCornerShape(100),
                         ),
                 )
@@ -290,7 +295,7 @@ fun NowPlayingCapsule(
                         model = model,
                         contentDescription = title,
                         modifier = Modifier.size(46.dp),
-                        cornerRadiusDp = 14,
+                        cornerRadiusDp = visuals.miniPlayerArtworkCornerRadius.value.roundToInt(),
                         requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
                     )
                 }
@@ -313,30 +318,59 @@ fun NowPlayingCapsule(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                IconButton(onClick = onSkipToPrevious, enabled = track != null) {
-                    Icon(
-                        imageVector = Icons.Rounded.SkipPrevious,
-                        contentDescription = stringResource(R.string.player_previous),
-                    )
-                }
-                IconButton(onClick = onPlayPause, enabled = track != null) {
-                    Icon(
-                        imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                        contentDescription = if (isPlaying) {
-                            stringResource(R.string.player_pause)
-                        } else {
-                            stringResource(R.string.player_play)
-                        },
-                    )
-                }
-                IconButton(onClick = onSkipToNext, enabled = track != null) {
-                    Icon(
-                        imageVector = Icons.Rounded.SkipNext,
-                        contentDescription = stringResource(R.string.player_next),
-                    )
-                }
+                MiniPlayerIconButton(
+                    icon = Icons.Rounded.SkipPrevious,
+                    contentDescription = stringResource(R.string.player_previous),
+                    onClick = onSkipToPrevious,
+                    enabled = track != null,
+                )
+                MiniPlayerIconButton(
+                    icon = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                    contentDescription = if (isPlaying) {
+                        stringResource(R.string.player_pause)
+                    } else {
+                        stringResource(R.string.player_play)
+                    },
+                    onClick = onPlayPause,
+                    enabled = track != null,
+                )
+                MiniPlayerIconButton(
+                    icon = Icons.Rounded.SkipNext,
+                    contentDescription = stringResource(R.string.player_next),
+                    onClick = onSkipToNext,
+                    enabled = track != null,
+                )
             }
         }
+    }
+}
+
+@Composable
+private fun MiniPlayerIconButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    enabled: Boolean,
+) {
+    val visuals = SakiTheme.visuals
+    if (visuals.miniPlayerControlContainerAlpha <= 0f) {
+        IconButton(onClick = onClick, enabled = enabled) {
+            Icon(imageVector = icon, contentDescription = contentDescription)
+        }
+    } else {
+        PressScaleIconButton(
+            icon = icon,
+            contentDescription = contentDescription,
+            onClick = onClick,
+            compact = true,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest.copy(
+                alpha = visuals.miniPlayerControlContainerAlpha,
+            ),
+            cornerRadius = visuals.miniPlayerControlCornerRadius,
+            iconSize = visuals.miniPlayerControlIconSize,
+            enabled = enabled,
+        )
     }
 }
 
@@ -796,7 +830,7 @@ fun NowPlayingOverlay(
                             val shuffleOnLabel = stringResource(R.string.player_shuffle_on)
                             val shuffleOffLabel = stringResource(R.string.player_shuffle_off)
                             Row(
-                                modifier = Modifier.offset(x = (-12).dp),
+                                modifier = Modifier.offset(x = -visuals.nowPlayingTopControlEdgeOffset),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
                                 ToggleIconButton(
@@ -826,7 +860,7 @@ fun NowPlayingOverlay(
                                     compact = true,
                                 )
                             }
-                            Box(modifier = Modifier.offset(x = 12.dp)) {
+                            Box(modifier = Modifier.offset(x = visuals.nowPlayingTopControlEdgeOffset)) {
                                 PressScaleIconButton(
                                     icon = Icons.Rounded.MoreVert,
                                     contentDescription = stringResource(R.string.player_more),
@@ -1379,13 +1413,19 @@ private fun PressScaleIconButton(
     iconSize: Dp = 24.dp,
     role: Role = Role.Button,
     semanticStateDescription: String? = null,
+    enabled: Boolean = true,
 ) {
-    val iconTint = tint ?: MaterialTheme.colorScheme.onBackground
+    val baseTint = tint ?: MaterialTheme.colorScheme.onBackground
+    val iconTint = if (enabled) {
+        baseTint
+    } else {
+        baseTint.copy(alpha = baseTint.alpha * 0.38f)
+    }
     val shape = RoundedCornerShape(cornerRadius)
     val interactionSource = remember { MutableInteractionSource() }
     val pressed by interactionSource.collectIsPressedAsState()
     val pressScale by animateFloatAsState(
-        targetValue = if (pressed) 0.85f else 1f,
+        targetValue = if (enabled && pressed) 0.85f else 1f,
         animationSpec = spring(
             dampingRatio = Spring.DampingRatioMediumBouncy,
             stiffness = Spring.StiffnessMedium,
@@ -1405,6 +1445,7 @@ private fun PressScaleIconButton(
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
+                enabled = enabled,
                 role = role,
                 onClick = onClick,
             )

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -84,6 +84,7 @@ import org.hdhmc.saki.presentation.library.THUMBNAIL_COVER_ART_SIZE_PX
 import org.hdhmc.saki.presentation.library.resolveArtworkModel
 import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
+import org.hdhmc.saki.ui.theme.SakiChromeIconButton
 import org.hdhmc.saki.ui.theme.sakiCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiSelectedContainerColor
 import org.hdhmc.saki.ui.theme.sakiTonalContainerColor
@@ -173,12 +174,11 @@ fun SettingsScreen(
                             modifier = Modifier.weight(1f),
                             style = MaterialTheme.typography.displaySmall,
                         )
-                        IconButton(onClick = onClose) {
-                            Icon(
-                                imageVector = Icons.Rounded.Close,
-                                contentDescription = stringResource(R.string.common_close),
-                            )
-                        }
+                        SakiChromeIconButton(
+                            onClick = onClose,
+                            icon = Icons.Rounded.Close,
+                            contentDescription = stringResource(R.string.common_close),
+                        )
                     }
                     Text(
                         text = stringResource(R.string.settings_intro),

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/SakiTheme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/SakiTheme.kt
@@ -1,11 +1,18 @@
 package org.hdhmc.saki.ui.theme
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.foundation.layout.size
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -17,6 +24,25 @@ data class SakiVisualTokens(
     val subtleCardContainerAlpha: Float = 0.88f,
     val selectedContainerAlpha: Float = 0.90f,
     val tonalContainerAlpha: Float = 0.42f,
+    val useExpressiveSurfaceContainers: Boolean = false,
+    val chromeIconButtonContainerAlpha: Float = 0f,
+    val chromeIconButtonCornerRadius: Dp = 24.dp,
+    val chromeIconButtonIconSize: Dp = 24.dp,
+    val browseSectionChipContainerAlpha: Float = 0f,
+    val browseSectionChipSelectedContainerAlpha: Float = 0f,
+    val browseSectionChipOutlineAlpha: Float = 0f,
+    val browseSectionChipCornerRadius: Dp = 18.dp,
+    val browseRowActionIconAlpha: Float = 1f,
+    val browseRowNavigationIconAlpha: Float = 1f,
+    val useExpressiveLoadingIndicator: Boolean = false,
+    val pullRefreshLoadingIndicatorSize: Dp = 36.dp,
+    val miniPlayerContainerCornerRadius: Dp = 28.dp,
+    val miniPlayerHandleWidth: Dp = 36.dp,
+    val miniPlayerHandleAlpha: Float = 0.28f,
+    val miniPlayerArtworkCornerRadius: Dp = 14.dp,
+    val miniPlayerControlContainerAlpha: Float = 0f,
+    val miniPlayerControlCornerRadius: Dp = 24.dp,
+    val miniPlayerControlIconSize: Dp = 24.dp,
     val nowPlayingBackgroundDominantOverlayAlpha: Float = 0.50f,
     val nowPlayingBackgroundAccentOverlayAlpha: Float = 0.35f,
     val nowPlayingBackgroundTailOverlayAlpha: Float = 0.12f,
@@ -33,6 +59,7 @@ data class SakiVisualTokens(
     val nowPlayingPrimaryControlIconSize: Dp = 24.dp,
     val nowPlayingPrimaryControlLabelSpacing: Dp = 10.dp,
     val nowPlayingSecondaryControlContainerAlpha: Float = 0f,
+    val nowPlayingTopControlEdgeOffset: Dp = 12.dp,
     val nowPlayingSecondaryControlCornerRadius: Dp = 28.dp,
     val nowPlayingSecondaryControlIconSize: Dp = 24.dp,
     val nowPlayingToggleContainerAlpha: Float = 0f,
@@ -47,10 +74,29 @@ internal val DefaultSakiVisualTokens = SakiVisualTokens()
 internal val MaterialExpressiveSakiVisualTokens = SakiVisualTokens(
     backgroundPrimaryOverlayAlpha = 0.12f,
     backgroundTertiaryOverlayAlpha = 0.16f,
-    cardContainerAlpha = 0.94f,
-    subtleCardContainerAlpha = 0.92f,
+    cardContainerAlpha = 0.98f,
+    subtleCardContainerAlpha = 0.96f,
     selectedContainerAlpha = 0.86f,
-    tonalContainerAlpha = 0.50f,
+    tonalContainerAlpha = 0.72f,
+    useExpressiveSurfaceContainers = true,
+    chromeIconButtonContainerAlpha = 1f,
+    chromeIconButtonCornerRadius = 24.dp,
+    chromeIconButtonIconSize = 24.dp,
+    browseSectionChipContainerAlpha = 1f,
+    browseSectionChipSelectedContainerAlpha = 1f,
+    browseSectionChipOutlineAlpha = 0.56f,
+    browseSectionChipCornerRadius = 22.dp,
+    browseRowActionIconAlpha = 0.72f,
+    browseRowNavigationIconAlpha = 0.64f,
+    useExpressiveLoadingIndicator = true,
+    pullRefreshLoadingIndicatorSize = 36.dp,
+    miniPlayerContainerCornerRadius = 32.dp,
+    miniPlayerHandleWidth = 44.dp,
+    miniPlayerHandleAlpha = 0.38f,
+    miniPlayerArtworkCornerRadius = 16.dp,
+    miniPlayerControlContainerAlpha = 1f,
+    miniPlayerControlCornerRadius = 24.dp,
+    miniPlayerControlIconSize = 24.dp,
     nowPlayingBackgroundDominantOverlayAlpha = 0.58f,
     nowPlayingBackgroundAccentOverlayAlpha = 0.42f,
     nowPlayingBackgroundTailOverlayAlpha = 0.16f,
@@ -67,6 +113,7 @@ internal val MaterialExpressiveSakiVisualTokens = SakiVisualTokens(
     nowPlayingPrimaryControlIconSize = 28.dp,
     nowPlayingPrimaryControlLabelSpacing = 12.dp,
     nowPlayingSecondaryControlContainerAlpha = 0.56f,
+    nowPlayingTopControlEdgeOffset = 0.dp,
     nowPlayingSecondaryControlCornerRadius = 24.dp,
     nowPlayingSecondaryControlIconSize = 26.dp,
     nowPlayingToggleContainerAlpha = 0.48f,
@@ -88,12 +135,20 @@ object SakiTheme {
 @Composable
 @ReadOnlyComposable
 fun sakiCardContainerColor(): Color =
-    MaterialTheme.colorScheme.surface.copy(alpha = SakiTheme.visuals.cardContainerAlpha)
+    if (SakiTheme.visuals.useExpressiveSurfaceContainers) {
+        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = SakiTheme.visuals.cardContainerAlpha)
+    } else {
+        MaterialTheme.colorScheme.surface.copy(alpha = SakiTheme.visuals.cardContainerAlpha)
+    }
 
 @Composable
 @ReadOnlyComposable
 fun sakiSubtleCardContainerColor(): Color =
-    MaterialTheme.colorScheme.surface.copy(alpha = SakiTheme.visuals.subtleCardContainerAlpha)
+    if (SakiTheme.visuals.useExpressiveSurfaceContainers) {
+        MaterialTheme.colorScheme.surfaceContainer.copy(alpha = SakiTheme.visuals.subtleCardContainerAlpha)
+    } else {
+        MaterialTheme.colorScheme.surface.copy(alpha = SakiTheme.visuals.subtleCardContainerAlpha)
+    }
 
 @Composable
 @ReadOnlyComposable
@@ -103,4 +158,40 @@ fun sakiSelectedContainerColor(): Color =
 @Composable
 @ReadOnlyComposable
 fun sakiTonalContainerColor(): Color =
-    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = SakiTheme.visuals.tonalContainerAlpha)
+    if (SakiTheme.visuals.useExpressiveSurfaceContainers) {
+        MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = SakiTheme.visuals.tonalContainerAlpha)
+    } else {
+        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = SakiTheme.visuals.tonalContainerAlpha)
+    }
+
+@Composable
+fun SakiChromeIconButton(
+    onClick: () -> Unit,
+    icon: ImageVector,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    val visuals = SakiTheme.visuals
+    if (visuals.chromeIconButtonContainerAlpha <= 0f) {
+        IconButton(onClick = onClick, modifier = modifier) {
+            Icon(icon, contentDescription = contentDescription)
+        }
+    } else {
+        Surface(
+            modifier = modifier,
+            shape = RoundedCornerShape(visuals.chromeIconButtonCornerRadius),
+            color = MaterialTheme.colorScheme.secondaryContainer.copy(
+                alpha = visuals.chromeIconButtonContainerAlpha,
+            ),
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ) {
+            IconButton(onClick = onClick) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = contentDescription,
+                    modifier = Modifier.size(visuals.chromeIconButtonIconSize),
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add shared Material Expressive chrome tokens and reuse them for Browse and Settings top icon buttons.
- Move Browse chips, row trailing icons, mini player controls, and pull refresh/loading states to token-driven M3E treatments while preserving the default Saki theme.
- Align Now Playing top controls with their restored M3E button containers and keep the existing default-theme edge offset.

## Links
- Closes #266
- Parent tracking: #251
- Related theme work: #30, #258, #262, #264

## Validation
- git diff --check
- ./gradlew assembleDebug -q
- Deployed to the test device and inspected Browse, Settings, pull refresh, row actions, mini player, and Now Playing screenshots.