### PR TITLE
feat: unify colors on seed-generated M3 roles and add theme color picker

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.coil.network.okhttp)
     implementation(libs.androidx.palette.ktx)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.material.kolor)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/app/src/main/java/org/hdhmc/saki/data/repository/ConfigBackupManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/ConfigBackupManager.kt
@@ -151,6 +151,9 @@ class ConfigBackupManager @Inject constructor(
                         DataStoreAppPreferencesRepository.KEY_THEME_STYLE.name -> {
                             ds[DataStoreAppPreferencesRepository.KEY_THEME_STYLE] = value; settingsApplied = true
                         }
+                        DataStoreAppPreferencesRepository.KEY_THEME_SEED.name -> {
+                            ds[DataStoreAppPreferencesRepository.KEY_THEME_SEED] = value; settingsApplied = true
+                        }
                         DataStoreAppPreferencesRepository.KEY_SONGS_PAGE_SIZE.name -> {
                             ds[DataStoreAppPreferencesRepository.KEY_SONGS_PAGE_SIZE] =
                                 value.toIntOrNull()?.normalizeSongsPageSize() ?: return@forEach

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
@@ -12,6 +12,7 @@ import org.hdhmc.saki.domain.model.AlbumViewMode
 import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.DEFAULT_SONGS_PAGE_SIZE
+import org.hdhmc.saki.domain.model.DEFAULT_THEME_SEED_KEY
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
 import org.hdhmc.saki.domain.model.TextScale
 import org.hdhmc.saki.domain.model.ThemeMode
@@ -59,6 +60,10 @@ class DataStoreAppPreferencesRepository @Inject constructor(
 
     override suspend fun updateThemeStyle(themeStyle: ThemeStyle) {
         dataStore.edit { it[KEY_THEME_STYLE] = themeStyle.storageKey }
+    }
+
+    override suspend fun updateThemeSeed(seedKey: String) {
+        dataStore.edit { it[KEY_THEME_SEED] = seedKey }
     }
 
     override suspend fun updateAlbumViewMode(mode: AlbumViewMode) {
@@ -127,6 +132,7 @@ class DataStoreAppPreferencesRepository @Inject constructor(
         val KEY_LANGUAGE = stringPreferencesKey("app_language")
         val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
         val KEY_THEME_STYLE = stringPreferencesKey("theme_style")
+        val KEY_THEME_SEED = stringPreferencesKey("theme_seed")
         val KEY_ALBUM_VIEW_MODE = stringPreferencesKey("album_view_mode")
         val KEY_DEFAULT_BROWSE_TAB = stringPreferencesKey("default_browse_tab")
         val KEY_DEFAULT_ALBUM_FEED = stringPreferencesKey("default_album_feed")
@@ -141,6 +147,7 @@ private fun Preferences.toAppPreferences() = AppPreferences(
     language = AppLanguage.fromTag(this[DataStoreAppPreferencesRepository.KEY_LANGUAGE]),
     themeMode = ThemeMode.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_THEME_MODE]),
     themeStyle = ThemeStyle.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_THEME_STYLE]),
+    themeSeedKey = this[DataStoreAppPreferencesRepository.KEY_THEME_SEED] ?: DEFAULT_THEME_SEED_KEY,
     albumViewMode = AlbumViewMode.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_ALBUM_VIEW_MODE]),
     defaultBrowseTab = DefaultBrowseTab.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_DEFAULT_BROWSE_TAB]),
     defaultAlbumFeed = AlbumListType.fromApiValue(

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
@@ -52,6 +52,10 @@ class DefaultAppPreferencesRepository @Inject constructor(
         // Theme preference is only supported via DataStore; no-op here
     }
 
+    override suspend fun updateThemeSeed(seedKey: String) {
+        // Theme preference is only supported via DataStore; no-op here
+    }
+
     override suspend fun updateAlbumViewMode(mode: AlbumViewMode) {
         // Album view mode preference is only supported via DataStore; no-op here
     }

--- a/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
@@ -43,6 +43,7 @@ data class AppPreferences(
     val language: AppLanguage = AppLanguage.SYSTEM,
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val themeStyle: ThemeStyle = ThemeStyle.SAKI,
+    val themeSeedKey: String = DEFAULT_THEME_SEED_KEY,
     val albumViewMode: AlbumViewMode = AlbumViewMode.GRID,
     val defaultBrowseTab: DefaultBrowseTab = DefaultBrowseTab.ARTISTS,
     val defaultAlbumFeed: AlbumListType = AlbumListType.NEWEST,
@@ -50,6 +51,9 @@ data class AppPreferences(
     val lastSelectedServerId: Long? = null,
     val recentSearchQueries: List<String> = emptyList(),
 )
+
+/** Default theme seed preset key; see [org.hdhmc.saki.ui.theme.SakiThemePresets]. */
+const val DEFAULT_THEME_SEED_KEY = "harbor_blue"
 
 const val MIN_SONGS_PAGE_SIZE = 250
 const val MAX_SONGS_PAGE_SIZE = 3_000

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
@@ -23,6 +23,8 @@ interface AppPreferencesRepository {
 
     suspend fun updateThemeStyle(themeStyle: ThemeStyle)
 
+    suspend fun updateThemeSeed(seedKey: String)
+
     suspend fun updateAlbumViewMode(mode: AlbumViewMode)
 
     suspend fun updateDefaultBrowseTab(tab: DefaultBrowseTab)

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -49,6 +49,7 @@ import org.hdhmc.saki.presentation.library.NowPlayingCapsule
 import org.hdhmc.saki.presentation.library.NowPlayingOverlay
 import org.hdhmc.saki.presentation.serverconfig.ServerConfigRoute
 import org.hdhmc.saki.presentation.settings.SettingsScreen
+import org.hdhmc.saki.ui.theme.seedColorForKey
 import org.hdhmc.saki.ui.theme.SakiAndroidTheme
 
 @Composable
@@ -96,7 +97,10 @@ fun SakiApp(
         }
     }
 
-    SakiAndroidTheme(themeStyle = uiState.appPreferences.themeStyle) {
+    SakiAndroidTheme(
+        themeStyle = uiState.appPreferences.themeStyle,
+        seedColor = seedColorForKey(uiState.appPreferences.themeSeedKey),
+    ) {
         CompositionLocalProvider(LocalDensity provides appDensity) {
         Box(modifier = modifier.fillMaxSize()) {
             when {
@@ -160,6 +164,7 @@ fun SakiApp(
                         onUpdateLanguage = viewModel::updateLanguage,
                         onUpdateThemeMode = viewModel::updateThemeMode,
                         onUpdateThemeStyle = viewModel::updateThemeStyle,
+                        onUpdateThemeSeed = viewModel::updateThemeSeed,
                         onUpdateDefaultBrowseTab = viewModel::updateDefaultBrowseTab,
                         onUpdateDefaultAlbumFeed = viewModel::updateDefaultAlbumFeed,
                         onUpdateSongsPageSize = viewModel::updateSongsPageSize,
@@ -266,6 +271,7 @@ private fun RootShell(
     onUpdateLanguage: (org.hdhmc.saki.domain.model.AppLanguage) -> Unit,
     onUpdateThemeMode: (ThemeMode) -> Unit,
     onUpdateThemeStyle: (ThemeStyle) -> Unit,
+    onUpdateThemeSeed: (String) -> Unit,
     onUpdateDefaultBrowseTab: (org.hdhmc.saki.domain.model.DefaultBrowseTab) -> Unit,
     onUpdateDefaultAlbumFeed: (org.hdhmc.saki.domain.model.AlbumListType) -> Unit,
     onUpdateSongsPageSize: (Int) -> Unit,
@@ -359,6 +365,7 @@ private fun RootShell(
                             onUpdateLanguage = onUpdateLanguage,
                             onUpdateThemeMode = onUpdateThemeMode,
                             onUpdateThemeStyle = onUpdateThemeStyle,
+                            onUpdateThemeSeed = onUpdateThemeSeed,
                             onUpdateDefaultBrowseTab = onUpdateDefaultBrowseTab,
                             onUpdateDefaultAlbumFeed = onUpdateDefaultAlbumFeed,
                             onUpdateSongsPageSize = onUpdateSongsPageSize,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -361,6 +361,12 @@ class SakiAppViewModel @Inject constructor(
         }
     }
 
+    fun updateThemeSeed(seedKey: String) {
+        viewModelScope.launch {
+            appPreferencesRepository.updateThemeSeed(seedKey)
+        }
+    }
+
     fun updateAlbumViewMode(mode: AlbumViewMode) {
         viewModelScope.launch {
             appPreferencesRepository.updateAlbumViewMode(mode)

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/Artwork.kt
@@ -39,6 +39,7 @@ import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.allowHardware
 import coil3.toBitmap
+import com.materialkolor.ktx.harmonize
 import androidx.palette.graphics.Palette
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -210,7 +211,7 @@ fun AdaptiveBlurArtwork(
  * Coil at palette resolution.
  */
 @Composable
-fun rememberArtworkAccentColor(model: Any?, fallback: Color): Color {
+fun rememberArtworkAccentColor(model: Any?, fallback: Color, harmonizeTarget: Color = fallback): Color {
     val context = LocalContext.current
     var accent by remember(model) { mutableStateOf(fallback) }
     LaunchedEffect(model) {
@@ -233,7 +234,7 @@ fun rememberArtworkAccentColor(model: Any?, fallback: Color): Color {
                 null
             }
         }
-        if (extracted != null) accent = extracted
+        if (extracted != null) accent = extracted.harmonize(harmonizeTarget)
     }
     return accent
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -254,7 +254,11 @@ fun AlbumDetailScreen(
 
     val artworkModel = resolveArtworkModel(server, album.coverArtId, null)
     val albumAccent = animateColorAsState(
-        rememberArtworkAccentColor(artworkModel, MaterialTheme.colorScheme.primary),
+        rememberArtworkAccentColor(
+            artworkModel,
+            fallback = MaterialTheme.colorScheme.secondaryContainer,
+            harmonizeTarget = MaterialTheme.colorScheme.primary,
+        ),
         label = "albumAccent",
     ).value
     val trackAccent = albumAccent.ensureContrast(
@@ -535,7 +539,7 @@ private fun AlbumTrackRow(
                 modifier = Modifier
                     .padding(start = 8.dp)
                     .size(16.dp),
-                tint = accentColor,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
             isDownloading -> CircularProgressIndicator(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -761,13 +761,9 @@ private fun BrowseSectionChip(
                 ),
             shape = chipShape,
             color = if (selected) {
-                MaterialTheme.colorScheme.secondaryContainer.copy(
-                    alpha = visuals.browseSectionChipSelectedContainerAlpha,
-                )
+                MaterialTheme.colorScheme.secondaryContainer
             } else {
-                MaterialTheme.colorScheme.surfaceContainerHighest.copy(
-                    alpha = visuals.browseSectionChipContainerAlpha,
-                )
+                MaterialTheme.colorScheme.surfaceContainerHighest
             },
             contentColor = if (selected) {
                 MaterialTheme.colorScheme.onSecondaryContainer
@@ -1558,13 +1554,9 @@ private fun AlbumFeedChip(
                 ),
             shape = chipShape,
             color = if (selected) {
-                MaterialTheme.colorScheme.secondaryContainer.copy(
-                    alpha = visuals.browseSectionChipSelectedContainerAlpha,
-                )
+                MaterialTheme.colorScheme.secondaryContainer
             } else {
-                MaterialTheme.colorScheme.surfaceContainerHighest.copy(
-                    alpha = visuals.browseSectionChipContainerAlpha,
-                )
+                MaterialTheme.colorScheme.surfaceContainerHighest
             },
             contentColor = if (selected) {
                 MaterialTheme.colorScheme.onSecondaryContainer

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -601,6 +601,7 @@ fun NowPlayingOverlay(
             Color(android.graphics.Color.HSVToColor(hsv))
         }
         val onPlayButtonColor = if (isDark) Color.White else Color.Black
+        val onArtwork = onPlayButtonColor
         val sliderActiveColor = remember(dominant, isDark) {
             val hsv = FloatArray(3)
             android.graphics.Color.colorToHSV(dominant.toArgb(), hsv)
@@ -742,7 +743,7 @@ fun NowPlayingOverlay(
                 )
             }
 
-            CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
+            CompositionLocalProvider(LocalContentColor provides onArtwork) {
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
@@ -758,13 +759,11 @@ fun NowPlayingOverlay(
                         Text(
                             text = stringResource(R.string.player_now_playing),
                             style = MaterialTheme.typography.titleLarge,
-                            color = MaterialTheme.colorScheme.onBackground,
+                            color = onArtwork,
                         )
                         Surface(
                             shape = MaterialTheme.shapes.large,
-                            color = MaterialTheme.colorScheme.secondaryContainer.copy(
-                                alpha = visuals.nowPlayingStatusContainerAlpha,
-                            ),
+                            color = (if (isDark) Color.Black else Color.White).copy(alpha = 0.28f),
                         ) {
                             Text(
                                 text = when {
@@ -774,7 +773,7 @@ fun NowPlayingOverlay(
                                 } + " • ${localizeQualityLabel(track.qualityLabel)}",
                                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
                                 style = MaterialTheme.typography.labelLarge,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                color = onArtwork,
                             )
                         }
                     }
@@ -897,6 +896,7 @@ fun NowPlayingOverlay(
                                     contentDescription = stringResource(R.string.player_more),
                                     onClick = { showMenu = true },
                                     compact = true,
+                                    tint = LocalContentColor.current,
                                     containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(
                                         alpha = visuals.nowPlayingMoreControlContainerAlpha,
                                     ),
@@ -933,7 +933,7 @@ fun NowPlayingOverlay(
                         Text(
                             text = track.title,
                             style = titleStyle,
-                            color = MaterialTheme.colorScheme.onBackground,
+                            color = onArtwork,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .basicMarquee(iterations = Int.MAX_VALUE),
@@ -943,6 +943,7 @@ fun NowPlayingOverlay(
                         MetadataLinkRow(
                             track = track,
                             textStyle = metadataStyle,
+                            linkColor = sliderActiveColor,
                             canOpenArtist = canOpenArtist,
                             onOpenArtist = onOpenArtist,
                             onOpenAlbum = onOpenAlbum,
@@ -1023,8 +1024,8 @@ fun NowPlayingOverlay(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceBetween,
                         ) {
-                            Text(text = formatDuration(sliderValue.roundToLong()), color = MaterialTheme.colorScheme.onBackground)
-                            Text(text = formatDuration(playbackProgress.durationMs), color = MaterialTheme.colorScheme.onBackground)
+                            Text(text = formatDuration(sliderValue.roundToLong()), color = onArtwork)
+                            Text(text = formatDuration(playbackProgress.durationMs), color = onArtwork)
                         }
                         Row(
                             modifier = Modifier.fillMaxWidth(),
@@ -1375,7 +1376,7 @@ private fun PlayerActionButton(
             contentDescription = label,
             onClick = onClick,
             compact = compact,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            tint = LocalContentColor.current,
             containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(
                 alpha = visuals.nowPlayingSecondaryControlContainerAlpha,
             ),
@@ -1407,14 +1408,10 @@ private fun ToggleIconButton(
             (if (hasSelectedContainer) {
                 MaterialTheme.colorScheme.onSecondaryContainer
             } else {
-                MaterialTheme.colorScheme.onBackground
+                LocalContentColor.current
             }).copy(alpha = visuals.nowPlayingToggleSelectedIconAlpha)
         } else {
-            (if (hasInactiveContainer) {
-                MaterialTheme.colorScheme.onSurfaceVariant
-            } else {
-                MaterialTheme.colorScheme.onBackground
-            }).copy(alpha = visuals.nowPlayingToggleIconAlpha)
+            LocalContentColor.current.copy(alpha = visuals.nowPlayingToggleIconAlpha)
         },
         containerColor = when {
             active -> MaterialTheme.colorScheme.secondaryContainer.copy(
@@ -1513,6 +1510,7 @@ private fun PressScaleIconButton(
 private fun MetadataLinkRow(
     track: PlaybackQueueItem,
     textStyle: TextStyle,
+    linkColor: Color,
     canOpenArtist: (String?) -> Boolean,
     onOpenArtist: (String?) -> Unit,
     onOpenAlbum: () -> Unit,
@@ -1592,7 +1590,7 @@ private fun MetadataLinkRow(
                 MetadataLinkText(
                     text = artist.name,
                     style = textStyle,
-                    color = if (canOpen) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (canOpen) linkColor else MaterialTheme.colorScheme.onSurfaceVariant,
                     enabled = canOpen,
                     onClick = { onOpenArtist(artistId) },
                 )
@@ -1621,7 +1619,7 @@ private fun MetadataLinkRow(
                 MetadataLinkText(
                     text = album,
                     style = textStyle,
-                    color = if (track.albumId != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (track.albumId != null) linkColor else MaterialTheme.colorScheme.onSurfaceVariant,
                     enabled = track.albumId != null,
                     onClick = onOpenAlbum,
                 )

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -3,8 +3,11 @@ package org.hdhmc.saki.presentation.settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
@@ -39,7 +42,10 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -47,6 +53,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -85,6 +92,7 @@ import org.hdhmc.saki.presentation.library.resolveArtworkModel
 import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.ui.theme.SakiChromeIconButton
+import org.hdhmc.saki.ui.theme.SakiThemePresets
 import org.hdhmc.saki.ui.theme.sakiCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiSelectedContainerColor
 import org.hdhmc.saki.ui.theme.sakiTonalContainerColor
@@ -113,6 +121,7 @@ fun SettingsScreen(
     onUpdateLanguage: (AppLanguage) -> Unit,
     onUpdateThemeMode: (ThemeMode) -> Unit,
     onUpdateThemeStyle: (ThemeStyle) -> Unit,
+    onUpdateThemeSeed: (String) -> Unit,
     onUpdateDefaultBrowseTab: (DefaultBrowseTab) -> Unit,
     onUpdateDefaultAlbumFeed: (AlbumListType) -> Unit,
     onUpdateSongsPageSize: (Int) -> Unit,
@@ -485,6 +494,44 @@ fun SettingsScreen(
                         onClick = { onUpdateThemeStyle(ThemeStyle.MATERIAL_EXPRESSIVE) },
                         label = { Text(stringResource(R.string.settings_theme_style_material_expressive)) },
                     )
+                }
+                if (currentThemeStyle == ThemeStyle.MATERIAL_EXPRESSIVE) {
+                    val currentSeedKey = uiState.appPreferences.themeSeedKey
+                    Text(
+                        text = stringResource(R.string.settings_theme_seed_label),
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        SakiThemePresets.forEach { preset ->
+                            val selected = preset.key == currentSeedKey
+                            val presetName = stringResource(preset.nameRes)
+                            Box(
+                                modifier = Modifier
+                                    .size(40.dp)
+                                    .clip(CircleShape)
+                                    .background(preset.seed)
+                                    .border(
+                                        width = if (selected) 3.dp else 1.dp,
+                                        color = if (selected) {
+                                            MaterialTheme.colorScheme.onSurface
+                                        } else {
+                                            MaterialTheme.colorScheme.outlineVariant
+                                        },
+                                        shape = CircleShape,
+                                    )
+                                    .selectable(
+                                        selected = selected,
+                                        role = Role.RadioButton,
+                                        onClick = { onUpdateThemeSeed(preset.key) },
+                                    )
+                                    .semantics { contentDescription = presetName },
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/Color.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/Color.kt
@@ -2,14 +2,5 @@ package org.hdhmc.saki.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+/** Brand seed color. The full Material 3 color scheme is generated from this. */
 val HarborBlue = Color(0xFF005E7A)
-val HarborMist = Color(0xFF4C616C)
-val EmberGold = Color(0xFF8A5200)
-val Foam = Color(0xFFF6FAFC)
-val Ink = Color(0xFF101417)
-
-val MoonlitBlue = Color(0xFF8AD0F4)
-val MoonlitMist = Color(0xFFB1CAD7)
-val EmberGlow = Color(0xFFFFB871)
-val Tide = Color(0xFF172126)
-val Night = Color(0xFF05080A)

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/SakiTheme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/SakiTheme.kt
@@ -80,7 +80,7 @@ internal val MaterialExpressiveSakiVisualTokens = SakiVisualTokens(
     backgroundTertiaryOverlayAlpha = 0.16f,
     cardContainerAlpha = 0.98f,
     subtleCardContainerAlpha = 0.96f,
-    selectedContainerAlpha = 0.86f,
+    selectedContainerAlpha = 0.45f,
     tonalContainerAlpha = 0.72f,
     useExpressiveSurfaceContainers = true,
     chromeIconButtonContainerAlpha = 1f,
@@ -142,21 +142,11 @@ object SakiTheme {
 
 @Composable
 @ReadOnlyComposable
-fun sakiCardContainerColor(): Color =
-    if (SakiTheme.visuals.useExpressiveSurfaceContainers) {
-        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = SakiTheme.visuals.cardContainerAlpha)
-    } else {
-        MaterialTheme.colorScheme.surface.copy(alpha = SakiTheme.visuals.cardContainerAlpha)
-    }
+fun sakiCardContainerColor(): Color = MaterialTheme.colorScheme.surfaceContainerHigh
 
 @Composable
 @ReadOnlyComposable
-fun sakiSubtleCardContainerColor(): Color =
-    if (SakiTheme.visuals.useExpressiveSurfaceContainers) {
-        MaterialTheme.colorScheme.surfaceContainer.copy(alpha = SakiTheme.visuals.subtleCardContainerAlpha)
-    } else {
-        MaterialTheme.colorScheme.surface.copy(alpha = SakiTheme.visuals.subtleCardContainerAlpha)
-    }
+fun sakiSubtleCardContainerColor(): Color = MaterialTheme.colorScheme.surfaceContainer
 
 @Composable
 @ReadOnlyComposable
@@ -165,12 +155,7 @@ fun sakiSelectedContainerColor(): Color =
 
 @Composable
 @ReadOnlyComposable
-fun sakiTonalContainerColor(): Color =
-    if (SakiTheme.visuals.useExpressiveSurfaceContainers) {
-        MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = SakiTheme.visuals.tonalContainerAlpha)
-    } else {
-        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = SakiTheme.visuals.tonalContainerAlpha)
-    }
+fun sakiTonalContainerColor(): Color = MaterialTheme.colorScheme.surfaceContainerHighest
 
 @Composable
 fun SakiChromeIconButton(
@@ -188,9 +173,7 @@ fun SakiChromeIconButton(
         Surface(
             modifier = modifier,
             shape = RoundedCornerShape(visuals.chromeIconButtonCornerRadius),
-            color = MaterialTheme.colorScheme.secondaryContainer.copy(
-                alpha = visuals.chromeIconButtonContainerAlpha,
-            ),
+            color = MaterialTheme.colorScheme.secondaryContainer,
             contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
         ) {
             IconButton(onClick = onClick) {

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
@@ -6,62 +6,20 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MotionScheme
-import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.expressiveLightColorScheme
-import androidx.compose.material3.lightColorScheme
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
+import com.materialkolor.PaletteStyle
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.rememberDynamicColorScheme
 import org.hdhmc.saki.domain.model.ThemeStyle
 
-private val DarkColorScheme = darkColorScheme(
-    primary = MoonlitBlue,
-    onPrimary = Ink,
-    primaryContainer = Color(0xFF1C465A),
-    onPrimaryContainer = Foam,
-    secondary = MoonlitMist,
-    onSecondary = Ink,
-    secondaryContainer = Color(0xFF33454E),
-    onSecondaryContainer = Foam,
-    tertiary = EmberGlow,
-    onTertiary = Ink,
-    tertiaryContainer = Color(0xFF6C4306),
-    onTertiaryContainer = Foam,
-    background = Night,
-    onBackground = Foam,
-    surface = Tide,
-    onSurface = Foam,
-    surfaceVariant = Color(0xFF243239),
-    onSurfaceVariant = Color(0xFFD6E3EA),
-    outline = Color(0xFF89969D),
-    outlineVariant = Color(0xFF425157),
-)
-
-private val LightColorScheme = lightColorScheme(
-    primary = HarborBlue,
-    onPrimary = Color.White,
-    primaryContainer = Color(0xFFB7EAFF),
-    onPrimaryContainer = Ink,
-    secondary = HarborMist,
-    onSecondary = Color.White,
-    secondaryContainer = Color(0xFFCFDDE4),
-    onSecondaryContainer = Ink,
-    tertiary = EmberGold,
-    onTertiary = Color.White,
-    tertiaryContainer = Color(0xFFFFDCC0),
-    onTertiaryContainer = Ink,
-    background = Foam,
-    onBackground = Ink,
-    surface = Color.White,
-    onSurface = Ink,
-    surfaceVariant = Color(0xFFD5E4EB),
-    onSurfaceVariant = Color(0xFF3F4C53),
-    outline = Color(0xFF6E7B82),
-    outlineVariant = Color(0xFFBCCAD1),
-)
+/** Brand seed color; all roles are generated from this so the full M3 role set stays consistent. */
+private val BrandSeedColor = HarborBlue
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -70,6 +28,8 @@ fun SakiAndroidTheme(
     themeStyle: ThemeStyle = ThemeStyle.SAKI,
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
+    // Optional user-selected seed (currently exposed only for the Material Expressive style).
+    seedColor: Color? = null,
     content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(LocalSakiVisualTokens provides sakiVisualTokens(themeStyle)) {
@@ -84,8 +44,25 @@ fun SakiAndroidTheme(
             }
 
             ThemeStyle.MATERIAL_EXPRESSIVE -> {
+                val base = rememberDynamicColorScheme(
+                    seedColor = seedColor ?: BrandSeedColor,
+                    isDark = darkTheme,
+                    style = PaletteStyle.Expressive,
+                    specVersion = ColorSpec.SpecVersion.SPEC_2025,
+                )
+                // In dark mode the Expressive secondary rotates to a heavy maroon that fights the
+                // blue seed; remap the prominent secondary containers onto the primary family so
+                // dark accents stay on-brand. Light keeps its soft pink secondary.
+                val scheme = if (darkTheme) {
+                    base.copy(
+                        secondaryContainer = lerp(base.surfaceContainer, base.primaryContainer, 0.45f),
+                        onSecondaryContainer = base.onSurface,
+                    )
+                } else {
+                    base
+                }
                 MaterialExpressiveTheme(
-                    colorScheme = if (darkTheme) darkColorScheme() else expressiveLightColorScheme(),
+                    colorScheme = scheme,
                     motionScheme = MotionScheme.expressive(),
                     content = content,
                 )
@@ -106,6 +83,5 @@ private fun sakiColorScheme(darkTheme: Boolean, dynamicColor: Boolean) = when {
         if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
     }
 
-    darkTheme -> DarkColorScheme
-    else -> LightColorScheme
+    else -> rememberDynamicColorScheme(seedColor = BrandSeedColor, isDark = darkTheme)
 }

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/ThemePresets.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/ThemePresets.kt
@@ -1,0 +1,38 @@
+package org.hdhmc.saki.ui.theme
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.Color
+import org.hdhmc.saki.R
+
+/**
+ * A selectable seed color for the Material Expressive theme.
+ *
+ * Each seed is fed through `rememberDynamicColorScheme` (Expressive / SPEC_2025) in
+ * [SakiAndroidTheme]. The global tuning we settled on — the dark-mode secondary→primary
+ * remap and the calmer `selectedContainerAlpha` — is applied to the generated scheme
+ * regardless of seed, so every preset inherits the same "calm, on-brand" footing instead
+ * of leaning on whatever raw tones a seed happens to produce.
+ *
+ * [key] is the stable identifier persisted as the `themeSeedKey` preference; [nameRes] is
+ * the localized display label shown by the Settings theme-color picker.
+ */
+data class SakiThemePreset(val key: String, val seed: Color, @StringRes val nameRes: Int)
+
+/**
+ * Curated presets spanning the hue wheel. [HarborBlue] stays first as the brand default.
+ * Seeds are mid-chroma on purpose: the Expressive palette derives better-balanced tonal
+ * ranges from a mid-tone source than from a fully saturated or very dark one.
+ */
+val SakiThemePresets: List<SakiThemePreset> = listOf(
+    SakiThemePreset("harbor_blue", HarborBlue, R.string.settings_theme_seed_harbor_blue),
+    SakiThemePreset("sakura", Color(0xFFB5436E), R.string.settings_theme_seed_sakura),
+    SakiThemePreset("wisteria", Color(0xFF6A4FA3), R.string.settings_theme_seed_wisteria),
+    SakiThemePreset("matcha", Color(0xFF5C7A2E), R.string.settings_theme_seed_matcha),
+    SakiThemePreset("jade", Color(0xFF1E7D6A), R.string.settings_theme_seed_jade),
+    SakiThemePreset("ember", Color(0xFFB5612A), R.string.settings_theme_seed_ember),
+    SakiThemePreset("ruby", Color(0xFFB0364A), R.string.settings_theme_seed_ruby),
+)
+
+/** Resolves a stored preset key to its seed color, falling back to the brand seed. */
+fun seedColorForKey(key: String?): Color =
+    SakiThemePresets.firstOrNull { it.key == key }?.seed ?: HarborBlue

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -65,6 +65,14 @@
     <string name="settings_theme_style_saki">Saki</string>
     <!-- Material 3 Expressive is a product/style name and is intentionally kept in English. -->
     <string name="settings_theme_style_material_expressive">Material 3 Expressive</string>
+    <string name="settings_theme_seed_label">主题颜色</string>
+    <string name="settings_theme_seed_harbor_blue">港湾蓝</string>
+    <string name="settings_theme_seed_sakura">樱花粉</string>
+    <string name="settings_theme_seed_wisteria">紫藤</string>
+    <string name="settings_theme_seed_matcha">抹茶绿</string>
+    <string name="settings_theme_seed_jade">翡翠青</string>
+    <string name="settings_theme_seed_ember">暖橙</string>
+    <string name="settings_theme_seed_ruby">朱红</string>
     <string name="settings_default_browse_title">默认浏览标签</string>
     <string name="settings_default_browse_body">选择应用启动时显示的浏览标签。</string>
     <string name="settings_default_album_feed">默认专辑源</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,10 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,14 @@
     <string name="settings_theme_style_label">Style</string>
     <string name="settings_theme_style_saki">Saki</string>
     <string name="settings_theme_style_material_expressive">Material 3 Expressive</string>
+    <string name="settings_theme_seed_label">Theme color</string>
+    <string name="settings_theme_seed_harbor_blue">Harbor blue</string>
+    <string name="settings_theme_seed_sakura">Sakura</string>
+    <string name="settings_theme_seed_wisteria">Wisteria</string>
+    <string name="settings_theme_seed_matcha">Matcha</string>
+    <string name="settings_theme_seed_jade">Jade</string>
+    <string name="settings_theme_seed_ember">Ember</string>
+    <string name="settings_theme_seed_ruby">Ruby</string>
     <string name="settings_default_browse_title">Default Browse tab</string>
     <string name="settings_default_browse_body">Choose the Browse tab shown when the app starts.</string>
     <string name="settings_default_album_feed">Default album feed</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ moshi = "1.15.2"
 palette = "1.0.0"
 coil = "3.4.0"
 datastore = "1.1.7"
+materialKolor = "4.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -54,6 +55,7 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-palette-ktx = { group = "androidx.palette", name = "palette-ktx", version.ref = "palette" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+material-kolor = { group = "com.materialkolor", name = "material-kolor", version.ref = "materialKolor" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
Closes #271. Part of #251.

## Summary

Derive the whole palette from a single seed through the M3 role system, removing hand-written colors, alpha-faked surfaces, and missing roles — then add a user-selectable theme color (gated to Material Expressive).

## Changes

**Theme generation**
- Both SAKI and Material Expressive schemes are now seed-generated via MaterialKolor; dropped the incomplete hand-written light/dark schemes and the unused template colors (`Color.kt`, `colors.xml`).
- Material Expressive **dark**: remap the heavy maroon `secondaryContainer`/`onSecondaryContainer` onto the primary family (a calm steel-blue blend) so chrome, chips, and buttons stay on-brand; light keeps its soft pink secondary. Calmed the over-bright selected container (`selectedContainerAlpha` 0.86 → 0.45).

**Surfaces**
- Card/container helpers use opaque `surfaceContainer*` roles instead of `copy(alpha = …)`.

**Now Playing**
- Neutral over-artwork text/time/header and a neutral status-chip scrim; control icons inherit the neutral content color.
- Artist/album links and the progress slider use an artwork-derived accent instead of raw `primary`.

**Album detail**
- The artwork accent falls back to the mode's `secondaryContainer` (dark steel-blue / light pink) and harmonizes toward the brand seed; the cached-status (`✓`) icon is now neutral `onSurfaceVariant`.

**Theme color picker**
- Curated seed presets (`ThemePresets.kt`) and a Settings picker shown only under Material Expressive, persisted via DataStore (`themeSeedKey`).

## Testing

- `./gradlew assembleDebug` — passes.
- Installed on device (Android 16); verified in light and dark, Material Expressive:
  - Browse / Settings / Now Playing / Album detail all read on-brand with no maroon spillover in dark and readable contrast.
  - Theme color picker appears only under Material Expressive, re-themes the app live, and persists across relaunch.

## Notes

- The seed-generation path is parameterized by seed, so the picker presets plug in without per-preset color code.
- Some Now Playing neutralization and the album-detail accent fallback apply to both themes (theme-agnostic surfaces); the bright-secondary remap and the picker are scoped to Material Expressive.
