### PR TITLE
Refine M3 Expressive color: palette-style switcher, global desaturation, two-tone swatches

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/ConfigBackupManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/ConfigBackupManager.kt
@@ -154,6 +154,9 @@ class ConfigBackupManager @Inject constructor(
                         DataStoreAppPreferencesRepository.KEY_THEME_SEED.name -> {
                             ds[DataStoreAppPreferencesRepository.KEY_THEME_SEED] = value; settingsApplied = true
                         }
+                        DataStoreAppPreferencesRepository.KEY_PALETTE_STYLE.name -> {
+                            ds[DataStoreAppPreferencesRepository.KEY_PALETTE_STYLE] = value; settingsApplied = true
+                        }
                         DataStoreAppPreferencesRepository.KEY_SONGS_PAGE_SIZE.name -> {
                             ds[DataStoreAppPreferencesRepository.KEY_SONGS_PAGE_SIZE] =
                                 value.toIntOrNull()?.normalizeSongsPageSize() ?: return@forEach

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
@@ -14,6 +14,7 @@ import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.DEFAULT_SONGS_PAGE_SIZE
 import org.hdhmc.saki.domain.model.DEFAULT_THEME_SEED_KEY
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
+import org.hdhmc.saki.domain.model.SakiPaletteStyle
 import org.hdhmc.saki.domain.model.TextScale
 import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.domain.model.ThemeStyle
@@ -64,6 +65,10 @@ class DataStoreAppPreferencesRepository @Inject constructor(
 
     override suspend fun updateThemeSeed(seedKey: String) {
         dataStore.edit { it[KEY_THEME_SEED] = seedKey }
+    }
+
+    override suspend fun updatePaletteStyle(style: SakiPaletteStyle) {
+        dataStore.edit { it[KEY_PALETTE_STYLE] = style.storageKey }
     }
 
     override suspend fun updateAlbumViewMode(mode: AlbumViewMode) {
@@ -133,6 +138,7 @@ class DataStoreAppPreferencesRepository @Inject constructor(
         val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
         val KEY_THEME_STYLE = stringPreferencesKey("theme_style")
         val KEY_THEME_SEED = stringPreferencesKey("theme_seed")
+        val KEY_PALETTE_STYLE = stringPreferencesKey("palette_style")
         val KEY_ALBUM_VIEW_MODE = stringPreferencesKey("album_view_mode")
         val KEY_DEFAULT_BROWSE_TAB = stringPreferencesKey("default_browse_tab")
         val KEY_DEFAULT_ALBUM_FEED = stringPreferencesKey("default_album_feed")
@@ -148,6 +154,7 @@ private fun Preferences.toAppPreferences() = AppPreferences(
     themeMode = ThemeMode.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_THEME_MODE]),
     themeStyle = ThemeStyle.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_THEME_STYLE]),
     themeSeedKey = this[DataStoreAppPreferencesRepository.KEY_THEME_SEED] ?: DEFAULT_THEME_SEED_KEY,
+    paletteStyle = SakiPaletteStyle.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_PALETTE_STYLE]),
     albumViewMode = AlbumViewMode.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_ALBUM_VIEW_MODE]),
     defaultBrowseTab = DefaultBrowseTab.fromStorageKey(this[DataStoreAppPreferencesRepository.KEY_DEFAULT_BROWSE_TAB]),
     defaultAlbumFeed = AlbumListType.fromApiValue(

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
@@ -10,6 +10,7 @@ import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
 import org.hdhmc.saki.domain.model.TextScale
 import org.hdhmc.saki.domain.model.ThemeMode
+import org.hdhmc.saki.domain.model.SakiPaletteStyle
 import org.hdhmc.saki.domain.model.ThemeStyle
 import org.hdhmc.saki.domain.repository.AppPreferencesRepository
 import javax.inject.Inject
@@ -53,6 +54,10 @@ class DefaultAppPreferencesRepository @Inject constructor(
     }
 
     override suspend fun updateThemeSeed(seedKey: String) {
+        // Theme preference is only supported via DataStore; no-op here
+    }
+
+    override suspend fun updatePaletteStyle(style: SakiPaletteStyle) {
         // Theme preference is only supported via DataStore; no-op here
     }
 

--- a/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
@@ -44,6 +44,7 @@ data class AppPreferences(
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val themeStyle: ThemeStyle = ThemeStyle.SAKI,
     val themeSeedKey: String = DEFAULT_THEME_SEED_KEY,
+    val paletteStyle: SakiPaletteStyle = SakiPaletteStyle.TONAL_SPOT,
     val albumViewMode: AlbumViewMode = AlbumViewMode.GRID,
     val defaultBrowseTab: DefaultBrowseTab = DefaultBrowseTab.ARTISTS,
     val defaultAlbumFeed: AlbumListType = AlbumListType.NEWEST,
@@ -109,6 +110,22 @@ enum class ThemeStyle(val storageKey: String) {
     companion object {
         fun fromStorageKey(storageKey: String?): ThemeStyle =
             entries.firstOrNull { it.storageKey == storageKey } ?: SAKI
+    }
+}
+
+/**
+ * Palette style for the Material Expressive theme. Maps to MaterialKolor's `PaletteStyle`
+ * in the theme layer. TonalSpot = calm/analogous, Vibrant = vivid but harmonious,
+ * Expressive = high-vibrancy with unexpected (often complementary) accents.
+ */
+enum class SakiPaletteStyle(val storageKey: String) {
+    TONAL_SPOT("tonal_spot"),
+    VIBRANT("vibrant"),
+    EXPRESSIVE("expressive");
+
+    companion object {
+        fun fromStorageKey(storageKey: String?): SakiPaletteStyle =
+            entries.firstOrNull { it.storageKey == storageKey } ?: TONAL_SPOT
     }
 }
 

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
@@ -5,6 +5,7 @@ import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.AlbumListType
 import org.hdhmc.saki.domain.model.AlbumViewMode
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
+import org.hdhmc.saki.domain.model.SakiPaletteStyle
 import org.hdhmc.saki.domain.model.TextScale
 import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.domain.model.ThemeStyle
@@ -24,6 +25,8 @@ interface AppPreferencesRepository {
     suspend fun updateThemeStyle(themeStyle: ThemeStyle)
 
     suspend fun updateThemeSeed(seedKey: String)
+
+    suspend fun updatePaletteStyle(style: SakiPaletteStyle)
 
     suspend fun updateAlbumViewMode(mode: AlbumViewMode)
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -100,6 +100,7 @@ fun SakiApp(
     SakiAndroidTheme(
         themeStyle = uiState.appPreferences.themeStyle,
         seedColor = seedColorForKey(uiState.appPreferences.themeSeedKey),
+        paletteStyle = uiState.appPreferences.paletteStyle,
     ) {
         CompositionLocalProvider(LocalDensity provides appDensity) {
         Box(modifier = modifier.fillMaxSize()) {
@@ -165,6 +166,7 @@ fun SakiApp(
                         onUpdateThemeMode = viewModel::updateThemeMode,
                         onUpdateThemeStyle = viewModel::updateThemeStyle,
                         onUpdateThemeSeed = viewModel::updateThemeSeed,
+                        onUpdatePaletteStyle = viewModel::updatePaletteStyle,
                         onUpdateDefaultBrowseTab = viewModel::updateDefaultBrowseTab,
                         onUpdateDefaultAlbumFeed = viewModel::updateDefaultAlbumFeed,
                         onUpdateSongsPageSize = viewModel::updateSongsPageSize,
@@ -272,6 +274,7 @@ private fun RootShell(
     onUpdateThemeMode: (ThemeMode) -> Unit,
     onUpdateThemeStyle: (ThemeStyle) -> Unit,
     onUpdateThemeSeed: (String) -> Unit,
+    onUpdatePaletteStyle: (org.hdhmc.saki.domain.model.SakiPaletteStyle) -> Unit,
     onUpdateDefaultBrowseTab: (org.hdhmc.saki.domain.model.DefaultBrowseTab) -> Unit,
     onUpdateDefaultAlbumFeed: (org.hdhmc.saki.domain.model.AlbumListType) -> Unit,
     onUpdateSongsPageSize: (Int) -> Unit,
@@ -366,6 +369,7 @@ private fun RootShell(
                             onUpdateThemeMode = onUpdateThemeMode,
                             onUpdateThemeStyle = onUpdateThemeStyle,
                             onUpdateThemeSeed = onUpdateThemeSeed,
+                            onUpdatePaletteStyle = onUpdatePaletteStyle,
                             onUpdateDefaultBrowseTab = onUpdateDefaultBrowseTab,
                             onUpdateDefaultAlbumFeed = onUpdateDefaultAlbumFeed,
                             onUpdateSongsPageSize = onUpdateSongsPageSize,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -13,6 +13,7 @@ import org.hdhmc.saki.domain.model.AlbumViewMode
 import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.AppPreferences
 import org.hdhmc.saki.domain.model.ThemeMode
+import org.hdhmc.saki.domain.model.SakiPaletteStyle
 import org.hdhmc.saki.domain.model.ThemeStyle
 import org.hdhmc.saki.domain.model.AlbumSummary
 import org.hdhmc.saki.domain.model.Artist
@@ -364,6 +365,12 @@ class SakiAppViewModel @Inject constructor(
     fun updateThemeSeed(seedKey: String) {
         viewModelScope.launch {
             appPreferencesRepository.updateThemeSeed(seedKey)
+        }
+    }
+
+    fun updatePaletteStyle(style: SakiPaletteStyle) {
+        viewModelScope.launch {
+            appPreferencesRepository.updatePaletteStyle(style)
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -3,9 +3,11 @@ package org.hdhmc.saki.presentation.settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -66,6 +68,7 @@ import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.CachedSong
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
 import org.hdhmc.saki.domain.model.ThemeMode
+import org.hdhmc.saki.domain.model.SakiPaletteStyle
 import org.hdhmc.saki.domain.model.ThemeStyle
 import org.hdhmc.saki.domain.model.MAX_STREAM_CACHE_SIZE_MB
 import org.hdhmc.saki.domain.model.MIN_STREAM_CACHE_SIZE_MB
@@ -93,6 +96,7 @@ import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.ui.theme.SakiChromeIconButton
 import org.hdhmc.saki.ui.theme.SakiThemePresets
+import org.hdhmc.saki.ui.theme.rememberSakiExpressiveColorScheme
 import org.hdhmc.saki.ui.theme.sakiCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiSelectedContainerColor
 import org.hdhmc.saki.ui.theme.sakiTonalContainerColor
@@ -122,6 +126,7 @@ fun SettingsScreen(
     onUpdateThemeMode: (ThemeMode) -> Unit,
     onUpdateThemeStyle: (ThemeStyle) -> Unit,
     onUpdateThemeSeed: (String) -> Unit,
+    onUpdatePaletteStyle: (SakiPaletteStyle) -> Unit,
     onUpdateDefaultBrowseTab: (DefaultBrowseTab) -> Unit,
     onUpdateDefaultAlbumFeed: (AlbumListType) -> Unit,
     onUpdateSongsPageSize: (Int) -> Unit,
@@ -496,7 +501,36 @@ fun SettingsScreen(
                     )
                 }
                 if (currentThemeStyle == ThemeStyle.MATERIAL_EXPRESSIVE) {
+                    val currentPaletteStyle = uiState.appPreferences.paletteStyle
+                    Text(
+                        text = stringResource(R.string.settings_palette_style_label),
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        FilterChip(
+                            selected = currentPaletteStyle == SakiPaletteStyle.TONAL_SPOT,
+                            onClick = { onUpdatePaletteStyle(SakiPaletteStyle.TONAL_SPOT) },
+                            label = { Text(stringResource(R.string.settings_palette_style_tonal_spot)) },
+                        )
+                        FilterChip(
+                            selected = currentPaletteStyle == SakiPaletteStyle.VIBRANT,
+                            onClick = { onUpdatePaletteStyle(SakiPaletteStyle.VIBRANT) },
+                            label = { Text(stringResource(R.string.settings_palette_style_vibrant)) },
+                        )
+                        FilterChip(
+                            selected = currentPaletteStyle == SakiPaletteStyle.EXPRESSIVE,
+                            onClick = { onUpdatePaletteStyle(SakiPaletteStyle.EXPRESSIVE) },
+                            label = { Text(stringResource(R.string.settings_palette_style_expressive)) },
+                        )
+                    }
                     val currentSeedKey = uiState.appPreferences.themeSeedKey
+                    // Preview follows the current light/dark mode and uses the container roles, so the
+                    // swatches stay pleasant pastels in light and deep tones in dark (KSU-style).
+                    val previewDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
                     Text(
                         text = stringResource(R.string.settings_theme_seed_label),
                         style = MaterialTheme.typography.labelLarge,
@@ -509,11 +543,22 @@ fun SettingsScreen(
                         SakiThemePresets.forEach { preset ->
                             val selected = preset.key == currentSeedKey
                             val presetName = stringResource(preset.nameRes)
+                            // Preview the actual generated pairing (top = primary, bottom = secondary)
+                            // under the active palette style, so the theme's two tones read at a glance.
+                            val previewScheme = rememberSakiExpressiveColorScheme(
+                                seedColor = preset.seed,
+                                isDark = previewDark,
+                                paletteStyle = currentPaletteStyle,
+                            )
+                            // Pick tonally balanced roles per mode so both halves read as similar
+                            // lightness (containers are pale + balanced in light; in dark the accent
+                            // pair stays balanced whereas SPEC_2025 Expressive containers go extreme).
+                            val topColor = if (previewDark) previewScheme.primary else previewScheme.primaryContainer
+                            val bottomColor = if (previewDark) previewScheme.secondary else previewScheme.secondaryContainer
                             Box(
                                 modifier = Modifier
-                                    .size(40.dp)
+                                    .size(44.dp)
                                     .clip(CircleShape)
-                                    .background(preset.seed)
                                     .border(
                                         width = if (selected) 3.dp else 1.dp,
                                         color = if (selected) {
@@ -529,7 +574,12 @@ fun SettingsScreen(
                                         onClick = { onUpdateThemeSeed(preset.key) },
                                     )
                                     .semantics { contentDescription = presetName },
-                            )
+                            ) {
+                                Canvas(modifier = Modifier.fillMaxSize()) {
+                                    drawArc(color = topColor, startAngle = 180f, sweepAngle = 180f, useCenter = true)
+                                    drawArc(color = bottomColor, startAngle = 0f, sweepAngle = 180f, useCenter = true)
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/SakiTheme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/SakiTheme.kt
@@ -76,14 +76,14 @@ data class SakiVisualTokens(
 internal val DefaultSakiVisualTokens = SakiVisualTokens()
 
 internal val MaterialExpressiveSakiVisualTokens = SakiVisualTokens(
-    backgroundPrimaryOverlayAlpha = 0.12f,
-    backgroundTertiaryOverlayAlpha = 0.16f,
+    backgroundPrimaryOverlayAlpha = 0.05f,
+    backgroundTertiaryOverlayAlpha = 0.07f,
     cardContainerAlpha = 0.98f,
     subtleCardContainerAlpha = 0.96f,
     selectedContainerAlpha = 0.45f,
     tonalContainerAlpha = 0.72f,
     useExpressiveSurfaceContainers = true,
-    chromeIconButtonContainerAlpha = 1f,
+    chromeIconButtonContainerAlpha = 0f,
     chromeIconButtonCornerRadius = 24.dp,
     chromeIconButtonIconSize = 24.dp,
     browseSectionChipContainerAlpha = 1f,

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
@@ -6,16 +6,19 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MotionScheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.hct.Hct
 import com.materialkolor.rememberDynamicColorScheme
+import org.hdhmc.saki.domain.model.SakiPaletteStyle
 import org.hdhmc.saki.domain.model.ThemeStyle
 
 /** Brand seed color; all roles are generated from this so the full M3 role set stays consistent. */
@@ -30,6 +33,8 @@ fun SakiAndroidTheme(
     dynamicColor: Boolean = true,
     // Optional user-selected seed (currently exposed only for the Material Expressive style).
     seedColor: Color? = null,
+    // Palette style for the Material Expressive theme.
+    paletteStyle: SakiPaletteStyle = SakiPaletteStyle.TONAL_SPOT,
     content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(LocalSakiVisualTokens provides sakiVisualTokens(themeStyle)) {
@@ -44,23 +49,11 @@ fun SakiAndroidTheme(
             }
 
             ThemeStyle.MATERIAL_EXPRESSIVE -> {
-                val base = rememberDynamicColorScheme(
+                val scheme = rememberSakiExpressiveColorScheme(
                     seedColor = seedColor ?: BrandSeedColor,
                     isDark = darkTheme,
-                    style = PaletteStyle.Expressive,
-                    specVersion = ColorSpec.SpecVersion.SPEC_2025,
+                    paletteStyle = paletteStyle,
                 )
-                // In dark mode the Expressive secondary rotates to a heavy maroon that fights the
-                // blue seed; remap the prominent secondary containers onto the primary family so
-                // dark accents stay on-brand. Light keeps its soft pink secondary.
-                val scheme = if (darkTheme) {
-                    base.copy(
-                        secondaryContainer = lerp(base.surfaceContainer, base.primaryContainer, 0.45f),
-                        onSecondaryContainer = base.onSurface,
-                    )
-                } else {
-                    base
-                }
                 MaterialExpressiveTheme(
                     colorScheme = scheme,
                     motionScheme = MotionScheme.expressive(),
@@ -84,4 +77,68 @@ private fun sakiColorScheme(darkTheme: Boolean, dynamicColor: Boolean) = when {
     }
 
     else -> rememberDynamicColorScheme(seedColor = BrandSeedColor, isDark = darkTheme)
+}
+
+/** Maps the persisted palette-style preference to MaterialKolor's [PaletteStyle]. */
+private fun SakiPaletteStyle.toMaterialKolor(): PaletteStyle = when (this) {
+    SakiPaletteStyle.TONAL_SPOT -> PaletteStyle.TonalSpot
+    SakiPaletteStyle.VIBRANT -> PaletteStyle.Vibrant
+    SakiPaletteStyle.EXPRESSIVE -> PaletteStyle.Expressive
+}
+
+/**
+ * The Material Expressive color scheme exactly as the app renders it (selected palette style,
+ * SPEC_2025, global chroma dial). Exposed so the Settings color picker can preview each seed's
+ * primary/secondary pairing faithfully.
+ */
+@Composable
+fun rememberSakiExpressiveColorScheme(
+    seedColor: Color,
+    isDark: Boolean,
+    paletteStyle: SakiPaletteStyle,
+): ColorScheme = rememberDynamicColorScheme(
+    seedColor = seedColor,
+    isDark = isDark,
+    style = paletteStyle.toMaterialKolor(),
+    specVersion = ColorSpec.SpecVersion.SPEC_2025,
+).desaturate(SchemeChromaScale)
+
+/**
+ * Global saturation dial applied on top of whichever palette style is active. MaterialKolor's
+ * styles run a bit hot for our taste (our calmest style sits near other apps' "vibrant"), so we
+ * scale the HCT chroma of every visible role down. Hue and tone are left untouched, so tonal
+ * contrast — notably card vs background legibility — is fully preserved.
+ */
+private const val SchemeChromaScale = 0.7
+
+private fun ColorScheme.desaturate(scale: Double): ColorScheme {
+    if (scale >= 1.0) return this
+    return copy(
+        primary = primary.scaleChroma(scale),
+        primaryContainer = primaryContainer.scaleChroma(scale),
+        inversePrimary = inversePrimary.scaleChroma(scale),
+        secondary = secondary.scaleChroma(scale),
+        secondaryContainer = secondaryContainer.scaleChroma(scale),
+        tertiary = tertiary.scaleChroma(scale),
+        tertiaryContainer = tertiaryContainer.scaleChroma(scale),
+        background = background.scaleChroma(scale),
+        surface = surface.scaleChroma(scale),
+        surfaceDim = surfaceDim.scaleChroma(scale),
+        surfaceBright = surfaceBright.scaleChroma(scale),
+        surfaceContainerLowest = surfaceContainerLowest.scaleChroma(scale),
+        surfaceContainerLow = surfaceContainerLow.scaleChroma(scale),
+        surfaceContainer = surfaceContainer.scaleChroma(scale),
+        surfaceContainerHigh = surfaceContainerHigh.scaleChroma(scale),
+        surfaceContainerHighest = surfaceContainerHighest.scaleChroma(scale),
+        surfaceVariant = surfaceVariant.scaleChroma(scale),
+        surfaceTint = surfaceTint.scaleChroma(scale),
+        outline = outline.scaleChroma(scale),
+        outlineVariant = outlineVariant.scaleChroma(scale),
+    )
+}
+
+/** Scales a color's HCT chroma by [scale], keeping its hue and tone. */
+private fun Color.scaleChroma(scale: Double): Color {
+    val hct = Hct.fromInt(toArgb())
+    return Color(Hct.from(hct.hue, hct.chroma * scale, hct.tone).toInt())
 }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -65,6 +65,10 @@
     <string name="settings_theme_style_saki">Saki</string>
     <!-- Material 3 Expressive is a product/style name and is intentionally kept in English. -->
     <string name="settings_theme_style_material_expressive">Material 3 Expressive</string>
+    <string name="settings_palette_style_label">配色风格</string>
+    <string name="settings_palette_style_tonal_spot">柔和</string>
+    <string name="settings_palette_style_vibrant">鲜艳</string>
+    <string name="settings_palette_style_expressive">张扬</string>
     <string name="settings_theme_seed_label">主题颜色</string>
     <string name="settings_theme_seed_harbor_blue">港湾蓝</string>
     <string name="settings_theme_seed_sakura">樱花粉</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,10 @@
     <string name="settings_theme_style_label">Style</string>
     <string name="settings_theme_style_saki">Saki</string>
     <string name="settings_theme_style_material_expressive">Material 3 Expressive</string>
+    <string name="settings_palette_style_label">Palette style</string>
+    <string name="settings_palette_style_tonal_spot">Tonal</string>
+    <string name="settings_palette_style_vibrant">Vibrant</string>
+    <string name="settings_palette_style_expressive">Expressive</string>
     <string name="settings_theme_seed_label">Theme color</string>
     <string name="settings_theme_seed_harbor_blue">Harbor blue</string>
     <string name="settings_theme_seed_sakura">Sakura</string>


### PR DESCRIPTION
Closes #273.

Follow-up to #272: the Material 3 Expressive theme ran too saturated (tinted cards, omnipresent accent, clashing complementary secondary, no user control). This calms it down and adds control.

## Changes
- **Palette-style setting** under `视觉风格 = Material 3 Expressive`: **TonalSpot / Vibrant / Expressive**, default **TonalSpot**. Persisted (DataStore), backed up/restored (ConfigBackupManager), localized en/zh. `colorSpec` stays fixed at `SPEC_2025` (2021 rotates the Expressive primary off the seed hue).
- **Global saturation dial**: scale every visible role's HCT chroma by `0.7`, keeping hue + tone so card↔background contrast and legibility are preserved. Sits on top of whichever style is active.
- **Neutral chrome**: search/settings icon buttons drop the filled accent container.
- **Calmer background gradient**: lower the primary/tertiary overlay alphas.
- **Two-tone theme-color swatches**: each preset previews its actual generated primary/secondary pairing as a split circle, adapting per light/dark mode (pale containers in light, balanced accents in dark) so the theme's two tones read at a glance. Backed by a shared `rememberSakiExpressiveColorScheme` so the swatch matches the real rendering.
- **Removed** the dark-mode secondary→primary remap hack; each palette style now renders natively.

## Testing
- `./gradlew assembleDebug testDebugUnitTest` — green.
- Verified on device across light/dark modes, all 7 presets, and all three palette styles.

## Notes
- Picking **Expressive** intentionally restores the high-vibrancy, hue-rotated accents (it's now an explicit user choice, not the default).