### PR TITLE
ui: queue row insets and chevron nav icon

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -32,7 +32,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
-import androidx.compose.material.icons.automirrored.rounded.ArrowForward
+import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.Album
 import androidx.compose.material.icons.rounded.CloudDownload
@@ -1525,7 +1525,7 @@ private fun RowCard(
                 }
             }
             Icon(
-                imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
+                imageVector = Icons.Rounded.ChevronRight,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = visuals.browseRowNavigationIconAlpha),
             )

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -1173,7 +1173,7 @@ fun NowPlayingOverlay(
                     LazyColumn(
                         modifier = Modifier.fillMaxWidth(),
                         state = queueListState,
-                        contentPadding = PaddingValues(bottom = 28.dp),
+                        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 28.dp),
                         verticalArrangement = Arrangement.spacedBy(verticalSpacing),
                     ) {
                         itemsIndexed(playbackState.queue) { index, item ->


### PR DESCRIPTION
Closes #68.

Completes the last two remaining items of the UI consistency pass; the other items were already addressed in earlier work.

## Changes
- **Queue rows touching edges (item 6)**: the Now Playing queue `LazyColumn` now has horizontal content padding (`start/end = 16.dp`), so the rounded `QueueRow` cards are inset from the screen edges instead of bleeding to them.
- **Disclosure icon (item 1)**: artist/playlist browse rows now use `Icons.Rounded.ChevronRight` (the `›` disclosure chevron) instead of `ArrowForward` (`→`), matching the standard list-navigation affordance.

## Already done previously (no change needed)
- Song/queue thumbnails are rounded rectangles everywhere (no circle thumbnails).
- Now Playing secondary controls use a unified `ToggleIconButton` / `PressScaleIconButton` with shared shape tokens.
- Mini-player buttons support container backgrounds via visual tokens.
- Placeholder artwork is a `LibraryMusic` note on a tonal gradient (no blue vinyl).

## Testing
`./gradlew assembleDebug testDebugUnitTest` — green; verified on device (queue rows inset; chevron on browse rows).