### PR TITLE
fix: restore shuffle for library-sourced queues

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -345,6 +345,19 @@ class DefaultPlaybackManager @Inject constructor(
         positionMs: Long,
     ) {
         if (songs.isEmpty()) return
+        // If a shuffle order was persisted, the queue was effectively concrete (enabling shuffle
+        // cancels virtual windowing), so restore it as a plain queue to re-apply the saved shuffle
+        // instead of dropping it and wiping the saved state.
+        if (playbackPreferencesRepository.getShuffleState() != null) {
+            val safeOffset = libraryOffset.coerceAtLeast(0)
+            restoreQueue(
+                serverId = serverId,
+                songs = songs,
+                startIndex = (currentLibraryIndex.coerceAtLeast(0) - safeOffset).coerceIn(songs.indices),
+                positionMs = positionMs.coerceAtLeast(0L),
+            )
+            return
+        }
         startLibraryQueue(
             serverId = serverId,
             seedSongs = songs,


### PR DESCRIPTION
Closes #284.

`restoreLibraryQueue` went through `startLibraryQueue`, which unconditionally did `shuffleModeEnabled = false` + `persistShuffleState()` with a null display order — i.e. it disabled shuffle **and wiped the persisted seed/anchor**. So a shuffled library queue came back unshuffled after a restart, while plain queues (via `restoreQueue`) restore shuffle correctly.

## Change
Enabling shuffle already calls `cancelVirtualQueue()`, so a shuffled library queue is effectively a concrete queue. In `restoreLibraryQueue`, when a shuffle order is persisted (`getShuffleState() != null`), restore via `restoreQueue` — which re-applies the saved seed/anchor over the saved song set (identical to save-time order, so the shuffle reproduces) — instead of rebuilding a virtual window. Non-shuffled library queues keep going through `startLibraryQueue` unchanged.

## Testing
`./gradlew assembleDebug testDebugUnitTest` green. (Behavioral; manual repro: play a library list → shuffle on → kill process → reopen → shuffle is preserved.)