### PR TITLE
fix: invisible subtitle on the current queue row

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -1765,13 +1765,22 @@ private fun QueueRow(
                 Text(
                     text = item.title,
                     style = MaterialTheme.typography.titleMedium,
+                    color = if (isCurrent) {
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
                 Text(
                     text = listOfNotNull(item.artist, item.album).joinToString(" • "),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (isCurrent) {
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )


### PR DESCRIPTION
Closes #288.

The current queue row paints its container with `primaryContainer`, but the subtitle was hard-coded to `onSurfaceVariant` and the title fell back to `onSurface` (`Surface` can't derive a content color from an alpha-modified container). On the light `primaryContainer` those have almost no contrast, so the current row's `artist • album` line was effectively invisible (and the title was low-contrast).

## Change
In `QueueRow`, drive the current row's title and subtitle off `onPrimaryContainer`; non-current rows keep `onSurface` / `onSurfaceVariant` on `surfaceVariant`.

## Testing
`./gradlew assembleDebug` green; verified on device — the current row's title and subtitle are now legible on the selected container, other rows unchanged.