### PR TITLE
Switch progress bar to buffered style when buffering completes

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -1002,7 +1002,12 @@ fun NowPlayingOverlay(
                         (playbackProgress.bufferedPositionMs.toFloat() / duration).coerceIn(0f, 1f)
                     } else 0f
                     val isCachedTrack = track.isCached || playbackState.isStreamCached
-                    val sliderColors = if (isCachedTrack) {
+                    // Once the buffer overlay reaches the end, switch to the solid "buffered" style
+                    // even if the disk cache isn't yet marked fully cached: the streaming overlay
+                    // (player + cache buffered position) and isStreamCached are different signals.
+                    val showCachedStyle = isCachedTrack ||
+                        (playbackProgress.durationMs > 0 && bufferFraction >= 0.999f)
+                    val sliderColors = if (showCachedStyle) {
                         SliderDefaults.colors(
                             thumbColor = sliderActiveColor,
                             activeTrackColor = sliderActiveColor,
@@ -1030,7 +1035,7 @@ fun NowPlayingOverlay(
                         },
                         valueRange = 0f..duration,
                         colors = sliderColors,
-                        modifier = if (!isCachedTrack) {
+                        modifier = if (!showCachedStyle) {
                             Modifier.drawBehind {
                                 val trackHeight = 4.dp.toPx()
                                 val y = size.height / 2


### PR DESCRIPTION
Closes #290.

The Now Playing slider drove its style off `isStreamCached` (disk snapshot, ~2.5s cadence) while the buffer overlay length came from `bufferedPositionMs` (`maxOf(playerBufferedPositionMs, cacheBufferedPositionMs)`). The overlay could fill to the end — the in-memory player buffer covering the whole track (e.g. CUSTOM long buffer), or disk progress complete — while `isStreamCached` hadn't flipped, leaving the bar stuck in the streaming style (transparent inactive track + gray overlay) instead of the solid "buffered" style.

## Change
In `QueueRow`'s sibling — the Now Playing slider — add `showCachedStyle = isCachedTrack || (durationMs > 0 && bufferFraction >= 0.999f)` and use it for both the slider colors and the buffer-overlay `drawBehind` branch. `isStreamCached` is left untouched, so the "已缓存 / Cached" badge still reflects actual disk cache.

## Related
- #55 (buffer progress + cached indicator)
- #109 (transcoded fully-cached detection)

## Testing
`./gradlew assembleDebug` green; verified on device that a cached track renders the solid buffered style with no regression. The fully-buffered-but-not-yet-disk-cached case is covered at the logic level (hard to stage deterministically on device).