### PR TITLE
Shorten prefetch retry after a no-op write so CUSTOM buffer fills ahead

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -78,7 +78,13 @@ import okhttp3.OkHttpClient
 private const val CUSTOM_PLAYER_MAX_BUFFER_MS = 5 * 60 * 1_000
 private const val STREAM_PREFETCH_LOG_TAG = "SakiStreamPrefetch"
 private const val STREAM_PREFETCH_REEVALUATION_MS = 30_000L
-private const val STREAM_PREFETCH_RETRY_DELAY_MS = 30_000L
+// Backoff after a prefetch attempt cached 0 new bytes. This is only reached when the CacheWriter
+// returned without error but wrote nothing — i.e. the resource is momentarily locked by the player
+// caching the same track (the current item, or the next item being preloaded). Real failures throw
+// and are handled at the job level, so they never hit this path. Keep this short: the lock is held
+// only briefly, so a quick retry lets the prefetch fully cache the next track once it releases. A
+// long delay made the next track stall with just the ~10s preload instead of the configured buffer.
+private const val STREAM_PREFETCH_RETRY_DELAY_MS = 3_000L
 
 private fun Long.coerceKnownDuration(): Long? {
     return takeIf { it != C.TIME_UNSET && it > 0L }


### PR DESCRIPTION
Closes #292.

## Problem
CUSTOM buffer streaming never reached the configured depth — upcoming tracks kept getting parked in the prefetch `deferred` state, well before the stream cache was anywhere near full (so not eviction).

## Root cause (device-traced — see #292)
`prefetchStreamToDisk` frequently returns **0 cached bytes with no exception**. That happens when the `CacheWriter` can't take the cache write-lock because the player is already caching that same track — the current item, or the next item being preloaded by the 10s `preloadConfiguration`. `prefetchTimelineToDisk` treated this harmless no-op as a failure and deferred the target for `STREAM_PREFETCH_RETRY_DELAY_MS` (30s).

Crucially, **real failures `throw`** and are handled by the job-level `runCatching`, so they never reach the deferral branch — the 30s backoff only ever penalized these transient contention no-ops. 30s was long enough to miss the brief window after the player releases the lock, so the next track stayed stuck with just the ~10s preload instead of the configured buffer.

## Fix
Shorten the no-op backoff from 30s to **3s** so the prefetch retries soon and fully caches the upcoming track once the lock releases. (Skipping the next track as a prefetch target was rejected — it would leave it with only the 10s preload.)

## Verification
On device with diagnostic logging: with the short retry, the next track (while still next) prefetches the **full file ahead (~26 MB)** and the plan reaches `done` for current + next, with no redownload churn (single result then quiet). Byte-cap was ruled out separately — the in-memory player buffer already fills the entire current track.

`./gradlew assembleDebug testDebugUnitTest` green.