### PR TITLE
fix: disable next-item preload when disk prefetch is active (CUSTOM buffer)

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -204,8 +204,18 @@ class SakiPlaybackService : MediaSessionService() {
             .setWakeMode(C.WAKE_MODE_NETWORK)
             .build()
             .apply {
-                preloadConfiguration =
+                preloadConfiguration = if (
+                    initialPrefs.bufferStrategy == BufferStrategy.CUSTOM &&
+                    initialPrefs.customBufferSeconds * 1_000L > CUSTOM_PLAYER_MAX_BUFFER_MS
+                ) {
+                    // Disk prefetch owns look-ahead in this mode. Next-item preload would hold the
+                    // same stream cache key and starve the prefetch, so the next track never fully
+                    // caches ahead (#292). Disable it; the fully-prefetched next track already gives
+                    // instant transitions from disk. NORMAL / short-CUSTOM keep preload (no prefetch).
+                    ExoPlayer.PreloadConfiguration.DEFAULT
+                } else {
                     ExoPlayer.PreloadConfiguration(10 * C.MICROS_PER_SECOND)
+                }
                 addListener(PlaybackRecoveryListener())
                 addListener(PlayQueueSaveListener())
                 addListener(NotificationMediaButtonListener())
@@ -574,8 +584,13 @@ class SakiPlaybackService : MediaSessionService() {
                 val isSatisfied = isStreamPrefetchSatisfied(request.serverId, request.songId, quality)
                 val isDeferred = isStreamPrefetchDeferred(targetKey, nowMs)
                 val trackEndFromCurrentMs = remainingTrackMs?.let { distanceFromCurrentMs + it }
+                // Only the current item is covered by the player's in-memory buffer. This planner
+                // runs only in the mode where next-item preload is disabled (#292), so upcoming
+                // tracks are NOT player-buffered and must be disk-prefetched even when their end
+                // falls within CUSTOM_PLAYER_MAX_BUFFER_MS.
                 val isHandledByPlayerBuffer =
-                    trackEndFromCurrentMs?.let { it <= CUSTOM_PLAYER_MAX_BUFFER_MS } == true
+                    index == currentIndex &&
+                        trackEndFromCurrentMs?.let { it <= CUSTOM_PLAYER_MAX_BUFFER_MS } == true
                 val targetState = when {
                     isSatisfied -> "done"
                     isDeferred -> "deferred"


### PR DESCRIPTION
Closes #292.

## Problem
With CUSTOM buffer (> 5 min) during **natural** playback, the next track never fully caches ahead — it stays partially cached / oscillates `pending`↔`deferred`. Skipping or seeking masked it (those reset the player's preload), which is why it was hard to reproduce.

## Root cause (device-traced — see #292)
CUSTOM (> 5 min) keeps the player buffer short and fills the look-ahead via disk prefetch (`CacheWriter` → `SimpleCache`). But the player also preloaded the next item (`preloadConfiguration = 10s`), which holds the **same** stream cache key. The prefetch `CacheWriter` then completes having committed ~nothing for that track — `getCachedLength` sees the player's in-flight data, so the writer doesn't actually download/commit it. Net: the next track never fully caches ahead, independent of any retry/deferral tuning. (Verified: an earlier retry/measurement tweak did **not** fix it; disabling preload did.)

## Fix
Disable next-item preload **only when disk prefetch is active** (CUSTOM and `customBufferSeconds * 1000 > CUSTOM_PLAYER_MAX_BUFFER_MS`). The fully-prefetched next track then provides instant transitions from disk. **NORMAL** and **short CUSTOM (≤ 5 min, no disk prefetch)** keep the 10s preload, so their next-track readiness is unchanged (no regression of #15).

## Verification (on device, natural playback, no skips)
With preload disabled in prefetch mode, the next track goes `pending → done` within ~1s and **stays fully cached for the entire 2+ min** of playback; the next-next track also reaches `done`. Before the fix, the next track never reached `done` in 100s+ of natural play.

`./gradlew assembleDebug testDebugUnitTest` green.

Supersedes #293 (the retry-delay approach, which didn't address the root cause).