### PR TITLE
Model Browse detail navigation as a route stack with predictive back polish

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
@@ -3,10 +3,11 @@ package org.hdhmc.saki.presentation
 import android.view.animation.PathInterpolator
 import androidx.activity.BackEventCompat
 import androidx.activity.compose.PredictiveBackHandler
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -16,7 +17,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
 
 private val PredictiveBackInterpolator = PathInterpolator(0.1f, 0.1f, 0f, 1f)
 
@@ -24,51 +27,64 @@ private val PredictiveBackInterpolator = PathInterpolator(0.1f, 0.1f, 0f, 1f)
 fun Modifier.predictiveBackMotion(
     enabled: Boolean,
     onBack: () -> Unit,
+    maxScaleReduction: Float = 0.1f,
+    maxHorizontalShiftFraction: Float = 1f / 20f,
+    horizontalShiftInset: Dp = 8.dp,
+    maxVerticalShiftFraction: Float = 1f / 20f,
+    verticalShiftInset: Dp = 8.dp,
+    maxCornerRadius: Dp = 28.dp,
+    targetAlpha: Float = 1f,
 ): Modifier {
-    var progress by remember { mutableFloatStateOf(0f) }
+    val progress = remember { Animatable(0f) }
     var swipeEdge by remember { mutableIntStateOf(BackEventCompat.EDGE_LEFT) }
     var touchY by remember { mutableFloatStateOf(0f) }
-    // Only animate on cancel (progress -> 0), snap during gesture
-    val animatedProgress by animateFloatAsState(
-        targetValue = progress,
-        animationSpec = spring(stiffness = 400f),
-    )
     val latestOnBack by rememberUpdatedState(onBack)
+    LaunchedEffect(enabled) {
+        if (enabled) {
+            progress.snapTo(0f)
+        }
+    }
     PredictiveBackHandler(enabled = enabled) { backEvents ->
+        var completed = false
         try {
             backEvents.collect { event ->
-                progress = event.progress
+                progress.snapTo(event.progress)
                 swipeEdge = event.swipeEdge
                 touchY = event.touchY
             }
+            completed = true
+            progress.animateTo(1f, animationSpec = spring(stiffness = 400f))
             latestOnBack()
-        } catch (_: kotlinx.coroutines.CancellationException) {
-            // User cancelled — animatedProgress springs back to 0
-        } finally {
-            progress = 0f
+        } catch (_: CancellationException) {
+            if (!completed) {
+                // User cancelled — animate back from the exact gesture position.
+                progress.animateTo(0f, animationSpec = spring(stiffness = 400f))
+            }
         }
     }
 
-    // Use raw progress during gesture, animated on cancel
-    val displayProgress = if (progress > 0f) progress else animatedProgress
+    val displayProgress = progress.value
     val interpolated = if (displayProgress <= 0f) 0f
     else PredictiveBackInterpolator.getInterpolation(displayProgress.coerceIn(0f, 1f))
-    val margin8dp = with(LocalDensity.current) { 8.dp.toPx() }
+    val density = LocalDensity.current
+    val horizontalShiftInsetPx = with(density) { horizontalShiftInset.toPx() }
+    val verticalShiftInsetPx = with(density) { verticalShiftInset.toPx() }
     val currentSwipeEdge = swipeEdge
     val currentTouchY = touchY
 
     return if (interpolated <= 0f) this
     else this.graphicsLayer {
-        val scale = 1f - (interpolated * 0.1f)
+        val scale = 1f - (interpolated * maxScaleReduction)
         scaleX = scale
         scaleY = scale
-        val maxShiftX = (size.width / 20f - margin8dp).coerceAtLeast(0f)
+        alpha = 1f - (interpolated * (1f - targetAlpha))
+        val maxShiftX = (size.width * maxHorizontalShiftFraction - horizontalShiftInsetPx).coerceAtLeast(0f)
         translationX = interpolated * maxShiftX * if (currentSwipeEdge == BackEventCompat.EDGE_LEFT) 1f else -1f
         val centerY = size.height / 2f
-        val maxShiftY = (size.height / 20f - margin8dp).coerceAtLeast(0f)
+        val maxShiftY = (size.height * maxVerticalShiftFraction - verticalShiftInsetPx).coerceAtLeast(0f)
         val yOffset = if (centerY > 0f) (currentTouchY - centerY) / centerY else 0f
         translationY = interpolated * maxShiftY * yOffset
-        shape = RoundedCornerShape((interpolated * 28f).dp)
+        shape = RoundedCornerShape((interpolated * maxCornerRadius.value).dp)
         clip = true
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -162,6 +162,7 @@ private fun RootShell(
     val settingsBackModifier = Modifier.predictiveBackMotion(
         enabled = showSettings,
         onBack = { onShowSettingsChange(false) },
+        targetAlpha = 0.35f,
     )
 
     Box(
@@ -252,11 +253,9 @@ private fun BrowseRoute(
         onLoadMoreSongs = viewModel::loadMoreSongs,
         onUpdateAlbumViewMode = viewModel::updateAlbumViewMode,
         onOpenArtist = viewModel::openArtist,
-        onCloseArtist = viewModel::closeArtist,
         onOpenAlbum = viewModel::openAlbum,
-        onCloseAlbum = viewModel::closeAlbum,
         onOpenPlaylist = viewModel::openPlaylist,
-        onClosePlaylist = viewModel::closePlaylist,
+        onPopDetail = viewModel::popBrowseRoute,
         onPlaySongs = viewModel::playSongs,
         onPlayLibrarySongs = viewModel::playLibrarySongs,
         onQueueSong = viewModel::queueSong,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -7,6 +7,7 @@ import org.hdhmc.saki.R
 import org.hdhmc.saki.data.remote.EndpointSelector
 import org.hdhmc.saki.data.repository.ConfigBackupManager
 import org.hdhmc.saki.data.repository.ImportResult
+import org.hdhmc.saki.presentation.library.BrowseNavRoute
 import org.hdhmc.saki.domain.model.Album
 import org.hdhmc.saki.domain.model.AlbumListType
 import org.hdhmc.saki.domain.model.AlbumViewMode
@@ -445,6 +446,7 @@ class SakiAppViewModel @Inject constructor(
         if (uiState.value.selectedServerId != serverId) {
             selectServer(serverId)
         }
+        mutableUiState.update { it.copy(browseStack = listOf(BrowseNavRoute.Root)) }
         openArtist(artistId)
     }
 
@@ -457,6 +459,7 @@ class SakiAppViewModel @Inject constructor(
         if (uiState.value.selectedServerId != serverId) {
             selectServer(serverId)
         }
+        mutableUiState.update { it.copy(browseStack = listOf(BrowseNavRoute.Root)) }
         openAlbum(albumId)
     }
 
@@ -469,6 +472,7 @@ class SakiAppViewModel @Inject constructor(
         mutableUiState.update { state ->
             state.copy(
                 selectedServerId = serverId,
+                browseStack = listOf(BrowseNavRoute.Root),
                 selectedArtist = null,
                 selectedArtistSongs = emptyList(),
                 selectedArtistSongsAreTopSongs = true,
@@ -803,6 +807,7 @@ class SakiAppViewModel @Inject constructor(
                 isArtistLoading = true,
                 artistError = null,
                 selectedAlbum = null,
+                browseStack = state.browseStack.pushed(BrowseNavRoute.ArtistDetail(artistId)),
             )
         }
 
@@ -881,16 +886,36 @@ class SakiAppViewModel @Inject constructor(
         }
     }
 
-    fun closeArtist() {
+    private fun List<BrowseNavRoute>.pushed(route: BrowseNavRoute): List<BrowseNavRoute> =
+        if (lastOrNull() == route) this else this + route
+
+    /** Pops the top Browse route and clears that page's detail data. No-op at the root. */
+    fun popBrowseRoute() {
         mutableUiState.update { state ->
-            state.copy(
-                selectedArtist = null,
-                selectedArtistSongs = emptyList(),
-                selectedArtistSongsAreTopSongs = true,
-                selectedAlbum = null,
-                artistError = null,
-                albumError = null,
-            )
+            if (state.browseStack.size <= 1) return@update state
+            val newStack = state.browseStack.dropLast(1)
+            when (state.browseStack.last()) {
+                is BrowseNavRoute.AlbumDetail -> state.copy(
+                    browseStack = newStack,
+                    selectedAlbum = null,
+                    albumError = null,
+                )
+                is BrowseNavRoute.ArtistDetail -> state.copy(
+                    browseStack = newStack,
+                    selectedArtist = null,
+                    selectedArtistSongs = emptyList(),
+                    selectedArtistSongsAreTopSongs = true,
+                    selectedAlbum = null,
+                    artistError = null,
+                    albumError = null,
+                )
+                is BrowseNavRoute.PlaylistDetail -> state.copy(
+                    browseStack = newStack,
+                    selectedPlaylist = null,
+                    playlistError = null,
+                )
+                BrowseNavRoute.Root -> state.copy(browseStack = newStack)
+            }
         }
     }
 
@@ -902,6 +927,7 @@ class SakiAppViewModel @Inject constructor(
                 selectedAlbum = fallbackAlbum,
                 isAlbumLoading = true,
                 albumError = null,
+                browseStack = state.browseStack.pushed(BrowseNavRoute.AlbumDetail(albumId)),
             )
         }
 
@@ -959,15 +985,6 @@ class SakiAppViewModel @Inject constructor(
         }
     }
 
-    fun closeAlbum() {
-        mutableUiState.update { state ->
-            state.copy(
-                selectedAlbum = null,
-                albumError = null,
-            )
-        }
-    }
-
     fun openPlaylist(playlistId: String) {
         val serverId = uiState.value.selectedServerId ?: return
         val fallbackPlaylist = uiState.value.findPlaylistSummary(playlistId)?.toPlaylist()
@@ -976,6 +993,7 @@ class SakiAppViewModel @Inject constructor(
                 selectedPlaylist = fallbackPlaylist,
                 isPlaylistLoading = true,
                 playlistError = null,
+                browseStack = state.browseStack.pushed(BrowseNavRoute.PlaylistDetail(playlistId)),
             )
         }
 
@@ -1030,15 +1048,6 @@ class SakiAppViewModel @Inject constructor(
                     }
                 }
             }
-        }
-    }
-
-    fun closePlaylist() {
-        mutableUiState.update { state ->
-            state.copy(
-                selectedPlaylist = null,
-                playlistError = null,
-            )
         }
     }
 
@@ -1468,6 +1477,7 @@ class SakiAppViewModel @Inject constructor(
             state.copy(
                 servers = servers,
                 selectedServerId = selectedServerId,
+                browseStack = if (serverChanged) listOf(BrowseNavRoute.Root) else state.browseStack,
                 selectedArtist = if (serverChanged) null else state.selectedArtist,
                 selectedArtistSongs = if (serverChanged) emptyList() else state.selectedArtistSongs,
                 selectedArtistSongsAreTopSongs = if (serverChanged) true else state.selectedArtistSongsAreTopSongs,
@@ -2478,6 +2488,7 @@ data class SakiAppUiState(
     val textScale: TextScale = TextScale.DEFAULT,
     val appPreferences: AppPreferences = AppPreferences(),
     val selectedBrowseSection: BrowseSection = BrowseSection.ARTISTS,
+    val browseStack: List<BrowseNavRoute> = listOf(BrowseNavRoute.Root),
     val servers: List<ServerConfig> = emptyList(),
     val selectedServerId: Long? = null,
     val selectedAlbumFeed: AlbumListType = AlbumListType.NEWEST,
@@ -2576,6 +2587,7 @@ data class SakiBrowseAvailabilityUiState(
 data class SakiBrowseUiState(
     val appPreferences: AppPreferences = AppPreferences(),
     val selectedBrowseSection: BrowseSection = BrowseSection.ARTISTS,
+    val browseStack: List<BrowseNavRoute> = listOf(BrowseNavRoute.Root),
     val servers: List<ServerConfig> = emptyList(),
     val selectedServerId: Long? = null,
     val selectedAlbumFeed: AlbumListType = AlbumListType.NEWEST,
@@ -2686,6 +2698,7 @@ private fun SakiAppUiState.toBrowseUiState(): SakiBrowseUiState {
     return SakiBrowseUiState(
         appPreferences = appPreferences,
         selectedBrowseSection = selectedBrowseSection,
+        browseStack = browseStack,
         servers = servers,
         selectedServerId = selectedServerId,
         selectedAlbumFeed = selectedAlbumFeed,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseNavRoute.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseNavRoute.kt
@@ -1,0 +1,13 @@
+package org.hdhmc.saki.presentation.library
+
+/**
+ * Browse-internal navigation entry. The route stack is the source of truth for
+ * which Browse detail page is shown, so each detail page can be rendered as an
+ * opaque page over its real previous page.
+ */
+sealed interface BrowseNavRoute {
+    data object Root : BrowseNavRoute
+    data class AlbumDetail(val albumId: String) : BrowseNavRoute
+    data class ArtistDetail(val artistId: String) : BrowseNavRoute
+    data class PlaylistDetail(val playlistId: String) : BrowseNavRoute
+}

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -4,10 +4,6 @@ import android.view.ViewConfiguration
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.togetherWith
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -75,6 +71,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -116,6 +113,7 @@ import org.hdhmc.saki.presentation.BrowseSection
 import org.hdhmc.saki.presentation.AlbumFeedState
 import org.hdhmc.saki.presentation.labelRes
 import org.hdhmc.saki.presentation.bottomContentPadding
+import org.hdhmc.saki.presentation.predictiveBackMotion
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.presentation.SakiBrowseAvailabilityUiState
 import org.hdhmc.saki.presentation.SakiBrowsePlaybackUiState
@@ -152,11 +150,9 @@ fun BrowseScreen(
     onLoadMoreSongs: () -> Unit,
     onUpdateAlbumViewMode: (AlbumViewMode) -> Unit,
     onOpenArtist: (String) -> Unit,
-    onCloseArtist: () -> Unit,
     onOpenAlbum: (String) -> Unit,
-    onCloseAlbum: () -> Unit,
     onOpenPlaylist: (String) -> Unit,
-    onClosePlaylist: () -> Unit,
+    onPopDetail: () -> Unit,
     onPlaySongs: (List<Song>, Int) -> Unit,
     onPlayLibrarySongs: (Int) -> Unit,
     onQueueSong: (Song) -> Unit,
@@ -184,18 +180,11 @@ fun BrowseScreen(
     }
     val scrollState = rememberBrowseScrollState(uiState.selectedServerId)
 
-    BackHandler(
-        enabled = uiState.selectedArtist != null ||
-            uiState.selectedAlbum != null ||
-            uiState.selectedPlaylist != null ||
-            uiState.isSearchActive,
-    ) {
-        when {
-            uiState.selectedAlbum != null -> onCloseAlbum()
-            uiState.selectedArtist != null -> onCloseArtist()
-            uiState.selectedPlaylist != null -> onClosePlaylist()
-            uiState.isSearchActive -> onSetSearchActive(false)
-        }
+    BackHandler(enabled = uiState.browseStack.size > 1) {
+        onPopDetail()
+    }
+    BackHandler(enabled = uiState.browseStack.size <= 1 && uiState.isSearchActive) {
+        onSetSearchActive(false)
     }
 
     Column(
@@ -219,108 +208,148 @@ fun BrowseScreen(
             if (isOfflineDegraded) {
                 OfflineModeBanner(modifier = Modifier.padding(top = 10.dp, bottom = 2.dp))
             }
-            AnimatedContent(
-                targetState = BrowseDetailTarget(
-                    hasArtist = uiState.selectedArtist != null,
-                    hasAlbum = uiState.selectedAlbum != null,
-                    hasPlaylist = uiState.selectedPlaylist != null,
-                ),
-                modifier = Modifier.weight(1f),
-                transitionSpec = {
-                    androidx.compose.animation.fadeIn(
-                        animationSpec = spring(
-                            dampingRatio = Spring.DampingRatioNoBouncy,
-                            stiffness = Spring.StiffnessLow,
-                        ),
-                    ) togetherWith androidx.compose.animation.fadeOut(
-                        animationSpec = spring(
-                            dampingRatio = Spring.DampingRatioNoBouncy,
-                            stiffness = Spring.StiffnessMediumLow,
-                        ),
-                    )
-                },
-                label = "browseTarget",
-            ) { target ->
-                when {
-                    target.hasAlbum && uiState.selectedAlbum != null -> AlbumDetailRoute(
-                        server = currentServer,
-                        album = uiState.selectedAlbum,
-                        playbackUiStateFlow = playbackUiStateFlow,
-                        availabilityUiStateFlow = availabilityUiStateFlow,
-                        isLoading = uiState.isAlbumLoading,
-                        error = uiState.albumError?.asString(),
-                        bottomOverlayPadding = bottomOverlayPadding,
-                        isOfflineDegraded = isOfflineDegraded,
-                        onOfflineSongUnavailable = onOfflineSongUnavailable,
+            Box(modifier = Modifier.weight(1f)) {
+                val stack = uiState.browseStack.ifEmpty { listOf(BrowseNavRoute.Root) }
+                val top = stack.last()
+                val below = stack.getOrNull(stack.size - 2)
 
-                        onPlaySongs = offlineAwarePlaySongs,
-                        onShowActions = { actionSong = it },
-                        onBack = onCloseAlbum,
-                    )
+                @Composable
+                fun BrowsePage(route: BrowseNavRoute, pageModifier: Modifier) {
+                    Box(modifier = pageModifier) {
+                        when (route) {
+                            BrowseNavRoute.Root -> BrowsePager(
+                                modifier = Modifier.fillMaxSize(),
+                                uiState = uiState,
+                                currentServer = currentServer,
+                                scrollState = scrollState,
+                                playbackUiStateFlow = playbackUiStateFlow,
+                                availabilityUiStateFlow = availabilityUiStateFlow,
+                                isOfflineDegraded = isOfflineDegraded,
+                                bottomOverlayPadding = bottomOverlayPadding,
+                                onSelectBrowseSection = onSelectBrowseSection,
+                                onSetSearchActive = onSetSearchActive,
+                                onUpdateSearchQuery = onUpdateSearchQuery,
+                                onRemoveRecentSearchQuery = onRemoveRecentSearchQuery,
+                                onClearRecentSearchQueries = onClearRecentSearchQueries,
+                                onRefreshCurrentTab = onRefreshCurrentTab,
+                                onSelectAlbumFeed = onSelectAlbumFeed,
+                                onLoadMoreAlbums = onLoadMoreAlbums,
+                                onLoadPreviousSongs = onLoadPreviousSongs,
+                                onLoadMoreSongs = onLoadMoreSongs,
+                                onUpdateAlbumViewMode = onUpdateAlbumViewMode,
+                                onOpenArtist = onOpenArtist,
+                                onOpenAlbum = onOpenAlbum,
+                                onOpenPlaylist = onOpenPlaylist,
+                                onPlaySongs = onPlaySongs,
+                                onPlayLibrarySongs = onPlayLibrarySongs,
+                                onOfflineSongUnavailable = onOfflineSongUnavailable,
+                                onShowSongActions = { actionSong = it },
+                                onOpenSettings = onOpenSettings,
+                            )
 
-                    target.hasArtist && uiState.selectedArtist != null -> ArtistDetailRoute(
-                        server = currentServer,
-                        artist = uiState.selectedArtist,
-                        songs = uiState.selectedArtistSongs,
-                        songsAreTopSongs = uiState.selectedArtistSongsAreTopSongs,
-                        playbackUiStateFlow = playbackUiStateFlow,
-                        availabilityUiStateFlow = availabilityUiStateFlow,
-                        isLoading = uiState.isArtistLoading,
-                        error = uiState.artistError?.asString(),
-                        bottomOverlayPadding = bottomOverlayPadding,
-                        isOfflineDegraded = isOfflineDegraded,
-                        onOpenAlbum = onOpenAlbum,
-                        onPlaySongs = offlineAwarePlaySongs,
-                        onShowActions = { actionSong = it },
+                            is BrowseNavRoute.AlbumDetail -> {
+                                val album = uiState.selectedAlbum
+                                if (album != null) {
+                                    AlbumDetailRoute(
+                                        server = currentServer,
+                                        album = album,
+                                        playbackUiStateFlow = playbackUiStateFlow,
+                                        availabilityUiStateFlow = availabilityUiStateFlow,
+                                        isLoading = uiState.isAlbumLoading,
+                                        error = uiState.albumError?.asString(),
+                                        bottomOverlayPadding = bottomOverlayPadding,
+                                        isOfflineDegraded = isOfflineDegraded,
+                                        onOfflineSongUnavailable = onOfflineSongUnavailable,
+                                        onPlaySongs = offlineAwarePlaySongs,
+                                        onShowActions = { actionSong = it },
+                                        onBack = onPopDetail,
+                                    )
+                                } else {
+                                    BrowseDetailPlaceholder(
+                                        loadingLabel = stringResource(R.string.library_loading_album),
+                                        error = uiState.albumError?.asString(),
+                                        bottomOverlayPadding = bottomOverlayPadding,
+                                    )
+                                }
+                            }
 
-                        onBack = onCloseArtist,
-                    )
+                            is BrowseNavRoute.ArtistDetail -> {
+                                val artist = uiState.selectedArtist
+                                if (artist != null) {
+                                    ArtistDetailRoute(
+                                        server = currentServer,
+                                        artist = artist,
+                                        songs = uiState.selectedArtistSongs,
+                                        songsAreTopSongs = uiState.selectedArtistSongsAreTopSongs,
+                                        playbackUiStateFlow = playbackUiStateFlow,
+                                        availabilityUiStateFlow = availabilityUiStateFlow,
+                                        isLoading = uiState.isArtistLoading,
+                                        error = uiState.artistError?.asString(),
+                                        bottomOverlayPadding = bottomOverlayPadding,
+                                        isOfflineDegraded = isOfflineDegraded,
+                                        onOpenAlbum = onOpenAlbum,
+                                        onPlaySongs = offlineAwarePlaySongs,
+                                        onShowActions = { actionSong = it },
+                                        onBack = onPopDetail,
+                                    )
+                                } else {
+                                    BrowseDetailPlaceholder(
+                                        loadingLabel = stringResource(R.string.library_loading_artist),
+                                        error = uiState.artistError?.asString(),
+                                        bottomOverlayPadding = bottomOverlayPadding,
+                                    )
+                                }
+                            }
 
-                    target.hasPlaylist && uiState.selectedPlaylist != null -> PlaylistDetailRoute(
-                        server = currentServer,
-                        playlist = uiState.selectedPlaylist,
-                        playbackUiStateFlow = playbackUiStateFlow,
-                        availabilityUiStateFlow = availabilityUiStateFlow,
-                        isLoading = uiState.isPlaylistLoading,
-                        error = uiState.playlistError?.asString(),
-                        bottomOverlayPadding = bottomOverlayPadding,
-                        isOfflineDegraded = isOfflineDegraded,
-                        onOfflineSongUnavailable = onOfflineSongUnavailable,
-                        onPlaySongs = offlineAwarePlaySongs,
-                        onShowActions = { actionSong = it },
+                            is BrowseNavRoute.PlaylistDetail -> {
+                                val playlist = uiState.selectedPlaylist
+                                if (playlist != null) {
+                                    PlaylistDetailRoute(
+                                        server = currentServer,
+                                        playlist = playlist,
+                                        playbackUiStateFlow = playbackUiStateFlow,
+                                        availabilityUiStateFlow = availabilityUiStateFlow,
+                                        isLoading = uiState.isPlaylistLoading,
+                                        error = uiState.playlistError?.asString(),
+                                        bottomOverlayPadding = bottomOverlayPadding,
+                                        isOfflineDegraded = isOfflineDegraded,
+                                        onOfflineSongUnavailable = onOfflineSongUnavailable,
+                                        onPlaySongs = offlineAwarePlaySongs,
+                                        onShowActions = { actionSong = it },
+                                        onBack = onPopDetail,
+                                    )
+                                } else {
+                                    BrowseDetailPlaceholder(
+                                        loadingLabel = stringResource(R.string.library_loading_playlist),
+                                        error = uiState.playlistError?.asString(),
+                                        bottomOverlayPadding = bottomOverlayPadding,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
 
-                        onBack = onClosePlaylist,
-                    )
-
-                    else -> BrowsePager(
-                        modifier = Modifier.fillMaxSize(),
-                        uiState = uiState,
-                        currentServer = currentServer,
-                        scrollState = scrollState,
-                        playbackUiStateFlow = playbackUiStateFlow,
-                        availabilityUiStateFlow = availabilityUiStateFlow,
-                        isOfflineDegraded = isOfflineDegraded,
-                        bottomOverlayPadding = bottomOverlayPadding,
-                        onSelectBrowseSection = onSelectBrowseSection,
-                        onSetSearchActive = onSetSearchActive,
-                        onUpdateSearchQuery = onUpdateSearchQuery,
-                        onRemoveRecentSearchQuery = onRemoveRecentSearchQuery,
-                        onClearRecentSearchQueries = onClearRecentSearchQueries,
-                        onRefreshCurrentTab = onRefreshCurrentTab,
-                        onSelectAlbumFeed = onSelectAlbumFeed,
-                        onLoadMoreAlbums = onLoadMoreAlbums,
-                        onLoadPreviousSongs = onLoadPreviousSongs,
-                        onLoadMoreSongs = onLoadMoreSongs,
-                        onUpdateAlbumViewMode = onUpdateAlbumViewMode,
-                        onOpenArtist = onOpenArtist,
-                        onOpenAlbum = onOpenAlbum,
-                        onOpenPlaylist = onOpenPlaylist,
-                        onPlaySongs = onPlaySongs,
-                        onPlayLibrarySongs = onPlayLibrarySongs,
-                        onOfflineSongUnavailable = onOfflineSongUnavailable,
-                        onShowSongActions = { actionSong = it },
-                        onOpenSettings = onOpenSettings,
-                    )
+                val pages = listOfNotNull(below, top)
+                pages.forEachIndexed { index, route ->
+                    val isTop = index == pages.lastIndex
+                    key(route) {
+                        val pageModifier = when {
+                            !isTop && route !is BrowseNavRoute.Root -> Modifier
+                                .fillMaxSize()
+                                .background(background)
+                            !isTop -> Modifier.fillMaxSize()
+                            route is BrowseNavRoute.Root -> Modifier.fillMaxSize()
+                            else -> Modifier
+                                .fillMaxSize()
+                                .predictiveBackMotion(
+                                    enabled = true,
+                                    onBack = onPopDetail,
+                                )
+                                .background(background)
+                        }
+                        BrowsePage(route, pageModifier)
+                    }
                 }
             }
         }
@@ -357,11 +386,27 @@ fun BrowseScreen(
     }
 }
 
-private data class BrowseDetailTarget(
-    val hasArtist: Boolean,
-    val hasAlbum: Boolean,
-    val hasPlaylist: Boolean,
-)
+@Composable
+private fun BrowseDetailPlaceholder(
+    loadingLabel: String,
+    error: String?,
+    bottomOverlayPadding: Dp,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = bottomContentPadding(bottomOverlayPadding),
+    ) {
+        item {
+            Box(modifier = Modifier.padding(top = 8.dp)) {
+                if (error != null) {
+                    ErrorStateCard(error)
+                } else {
+                    LoadingStateCard(loadingLabel)
+                }
+            }
+        }
+    }
+}
 
 @Composable
 private fun AlbumDetailRoute(
@@ -659,6 +704,7 @@ private fun BrowsePager(
     onShowSongActions: (Song) -> Unit,
     onOpenSettings: () -> Unit,
 ) {
+    val background = rememberBrowseBackgroundBrush()
     val sections = BrowseSection.entries
     val selectedSectionState = rememberUpdatedState(uiState.selectedBrowseSection)
     val pagerState = rememberPagerState(
@@ -684,152 +730,181 @@ private fun BrowsePager(
             .collect { onSelectBrowseSection(it) }
     }
 
-    Column(modifier = modifier) {
-        BrowseHeroCard(
-            currentServer = currentServer,
-            isSearchActive = uiState.isSearchActive,
-            searchQuery = uiState.searchQuery,
-            onSearchActiveChange = onSetSearchActive,
-            onSearchQueryChange = onUpdateSearchQuery,
-            onOpenSettings = onOpenSettings,
-        )
-        if (uiState.isSearchActive) {
-            SearchResultsRoute(
-                modifier = Modifier.weight(1f),
+    Box(modifier = modifier) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            BrowseHeroCard(
                 currentServer = currentServer,
-                query = uiState.searchQuery,
-                results = uiState.searchResults,
-                isLoading = uiState.isSearchLoading,
-                error = uiState.searchError?.asString(),
-                recentSearchQueries = uiState.recentSearchQueries,
-                availabilityUiStateFlow = availabilityUiStateFlow,
-                isOfflineDegraded = isOfflineDegraded,
-                bottomOverlayPadding = bottomOverlayPadding,
-                resultsPosition = scrollState.searchResultsPosition,
-                recentSearchesPosition = scrollState.recentSearchesPosition,
-                onSearchQuery = onUpdateSearchQuery,
-                onRemoveRecentSearchQuery = onRemoveRecentSearchQuery,
-                onClearRecentSearchQueries = onClearRecentSearchQueries,
-                onOpenArtist = onOpenArtist,
-                onOpenAlbum = onOpenAlbum,
-                onPlaySongs = onPlaySongs,
-                onOfflineSongUnavailable = onOfflineSongUnavailable,
-                onShowSongActions = onShowSongActions,
+                isSearchActive = false,
+                searchQuery = "",
+                onSearchActiveChange = onSetSearchActive,
+                onSearchQueryChange = onUpdateSearchQuery,
+                onOpenSettings = onOpenSettings,
             )
-        } else {
-            val isRefreshing = uiState.isArtistsLoading || uiState.isAlbumsLoading ||
-                uiState.isPlaylistsLoading || uiState.isSongsLoading
-            val pullState = rememberPullToRefreshState()
-            val haptic = LocalHapticFeedback.current
-            val isOverThreshold = !isRefreshing && pullState.distanceFraction >= 1f
-            LaunchedEffect(isOverThreshold) {
-                if (isOverThreshold) {
-                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+            Box(modifier = Modifier.weight(1f)) {
+                val isRefreshing = uiState.isArtistsLoading || uiState.isAlbumsLoading ||
+                    uiState.isPlaylistsLoading || uiState.isSongsLoading
+                val pullState = rememberPullToRefreshState()
+                val haptic = LocalHapticFeedback.current
+                val isOverThreshold = !isRefreshing && pullState.distanceFraction >= 1f
+                LaunchedEffect(isOverThreshold) {
+                    if (isOverThreshold) {
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    }
+                }
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = onRefreshCurrentTab,
+                    modifier = Modifier.fillMaxSize(),
+                    state = pullState,
+                    indicator = {
+                        if (SakiTheme.visuals.useExpressiveLoadingIndicator) {
+                            PullToRefreshDefaults.LoadingIndicator(
+                                state = pullState,
+                                isRefreshing = isRefreshing,
+                                modifier = Modifier
+                                    .align(Alignment.TopCenter)
+                                    .size(SakiTheme.visuals.pullRefreshLoadingIndicatorSize),
+                            )
+                        } else {
+                            PullToRefreshDefaults.Indicator(
+                                state = pullState,
+                                isRefreshing = isRefreshing,
+                                modifier = Modifier.align(Alignment.TopCenter),
+                            )
+                        }
+                    },
+                ) {
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        LazyRow(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(sections) { section ->
+                                BrowseSectionChip(
+                                    section = section,
+                                    selected = uiState.selectedBrowseSection == section,
+                                    onClick = { onSelectBrowseSection(section) },
+                                )
+                            }
+                        }
+                        HorizontalPager(
+                            state = pagerState,
+                            modifier = Modifier.weight(1f),
+                            flingBehavior = pagerFlingBehavior,
+                        ) { page ->
+                            when (sections[page]) {
+                                BrowseSection.ARTISTS -> ArtistsPage(
+                                    indexes = uiState.libraryIndexes,
+                                    server = currentServer,
+                                    isLoading = uiState.isArtistsLoading,
+                                    error = uiState.artistsError?.asString(),
+                                    bottomOverlayPadding = bottomOverlayPadding,
+                                    scrollPosition = scrollState.artistsPosition,
+                                    onOpenArtist = onOpenArtist,
+                                )
+
+                                BrowseSection.ALBUMS -> AlbumsPage(
+                                    albumFeeds = uiState.albumFeeds,
+                                    browsePagerState = pagerState,
+                                    server = currentServer,
+                                    selectedFeed = uiState.selectedAlbumFeed,
+                                    viewMode = uiState.appPreferences.albumViewMode,
+                                    scrollPositions = scrollState.albumFeedPositions,
+                                    onSelectFeed = onSelectAlbumFeed,
+                                    onLoadMore = onLoadMoreAlbums,
+                                    onUpdateViewMode = onUpdateAlbumViewMode,
+                                    onOpenAlbum = onOpenAlbum,
+                                    bottomOverlayPadding = bottomOverlayPadding,
+                                )
+
+                                BrowseSection.PLAYLISTS -> PlaylistsPage(
+                                    playlists = uiState.playlists,
+                                    server = currentServer,
+                                    isLoading = uiState.isPlaylistsLoading,
+                                    error = uiState.playlistsError?.asString(),
+                                    bottomOverlayPadding = bottomOverlayPadding,
+                                    scrollPosition = scrollState.playlistsPosition,
+                                    onOpenPlaylist = onOpenPlaylist,
+                                )
+
+                                BrowseSection.SONGS -> SongsPageRoute(
+                                    songs = uiState.songs,
+                                    songsOffset = uiState.songsOffset,
+                                    hasPrevious = uiState.hasPreviousSongs,
+                                    hasMore = uiState.hasMoreSongs,
+                                    server = currentServer,
+                                    playbackUiStateFlow = playbackUiStateFlow,
+                                    availabilityUiStateFlow = availabilityUiStateFlow,
+                                    isOfflineDegraded = isOfflineDegraded,
+                                    isLoading = uiState.isSongsLoading,
+                                    isLoadingPrevious = uiState.isSongsLoadingPrevious,
+                                    isLoadingMore = uiState.isSongsLoadingMore,
+                                    error = uiState.songsError?.asString(),
+                                    bottomOverlayPadding = bottomOverlayPadding,
+                                    scrollPosition = scrollState.songsPosition,
+                                    onLoadPrevious = onLoadPreviousSongs,
+                                    onLoadMore = onLoadMoreSongs,
+                                    onPlaySongs = onPlaySongs,
+                                    onPlayLibrarySongs = onPlayLibrarySongs,
+                                    onOfflineSongUnavailable = onOfflineSongUnavailable,
+                                    onShowSongActions = onShowSongActions,
+                                )
+                            }
+                        }
+                    }
                 }
             }
-            PullToRefreshBox(
-                isRefreshing = isRefreshing,
-                onRefresh = onRefreshCurrentTab,
-                modifier = Modifier.weight(1f),
-                state = pullState,
-                indicator = {
-                    if (SakiTheme.visuals.useExpressiveLoadingIndicator) {
-                        PullToRefreshDefaults.LoadingIndicator(
-                            state = pullState,
-                            isRefreshing = isRefreshing,
-                            modifier = Modifier
-                                .align(Alignment.TopCenter)
-                                .size(SakiTheme.visuals.pullRefreshLoadingIndicatorSize),
-                        )
-                    } else {
-                        PullToRefreshDefaults.Indicator(
-                            state = pullState,
-                            isRefreshing = isRefreshing,
-                            modifier = Modifier.align(Alignment.TopCenter),
-                        )
-                    }
-                },
+        }
+
+        if (uiState.isSearchActive) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .predictiveBackMotion(
+                        enabled = true,
+                        onBack = { onSetSearchActive(false) },
+                        maxScaleReduction = 0.02f,
+                        maxHorizontalShiftFraction = 0.12f,
+                        horizontalShiftInset = 0.dp,
+                        maxVerticalShiftFraction = 0f,
+                        verticalShiftInset = 0.dp,
+                        maxCornerRadius = 18.dp,
+                        targetAlpha = 0f,
+                    )
+                    .background(background),
             ) {
-                Column(modifier = Modifier.fillMaxSize()) {
-                    LazyRow(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 12.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        items(sections) { section ->
-                            BrowseSectionChip(
-                                section = section,
-                                selected = uiState.selectedBrowseSection == section,
-                                onClick = { onSelectBrowseSection(section) },
-                            )
-                        }
-                    }
-                    HorizontalPager(
-                        state = pagerState,
-                        modifier = Modifier.weight(1f),
-                        flingBehavior = pagerFlingBehavior,
-                    ) { page ->
-                        when (sections[page]) {
-                            BrowseSection.ARTISTS -> ArtistsPage(
-                                indexes = uiState.libraryIndexes,
-                                server = currentServer,
-                                isLoading = uiState.isArtistsLoading,
-                                error = uiState.artistsError?.asString(),
-                                bottomOverlayPadding = bottomOverlayPadding,
-                                scrollPosition = scrollState.artistsPosition,
-                                onOpenArtist = onOpenArtist,
-                            )
-
-                            BrowseSection.ALBUMS -> AlbumsPage(
-                                albumFeeds = uiState.albumFeeds,
-                                browsePagerState = pagerState,
-                                server = currentServer,
-                                selectedFeed = uiState.selectedAlbumFeed,
-                                viewMode = uiState.appPreferences.albumViewMode,
-                                scrollPositions = scrollState.albumFeedPositions,
-                                onSelectFeed = onSelectAlbumFeed,
-                                onLoadMore = onLoadMoreAlbums,
-                                onUpdateViewMode = onUpdateAlbumViewMode,
-                                onOpenAlbum = onOpenAlbum,
-                                bottomOverlayPadding = bottomOverlayPadding,
-                            )
-
-                            BrowseSection.PLAYLISTS -> PlaylistsPage(
-                                playlists = uiState.playlists,
-                                server = currentServer,
-                                isLoading = uiState.isPlaylistsLoading,
-                                error = uiState.playlistsError?.asString(),
-                                bottomOverlayPadding = bottomOverlayPadding,
-                                scrollPosition = scrollState.playlistsPosition,
-                                onOpenPlaylist = onOpenPlaylist,
-                            )
-
-                            BrowseSection.SONGS -> SongsPageRoute(
-                                songs = uiState.songs,
-                                songsOffset = uiState.songsOffset,
-                                hasPrevious = uiState.hasPreviousSongs,
-                                hasMore = uiState.hasMoreSongs,
-                                server = currentServer,
-                                playbackUiStateFlow = playbackUiStateFlow,
-                                availabilityUiStateFlow = availabilityUiStateFlow,
-                                isOfflineDegraded = isOfflineDegraded,
-                                isLoading = uiState.isSongsLoading,
-                                isLoadingPrevious = uiState.isSongsLoadingPrevious,
-                                isLoadingMore = uiState.isSongsLoadingMore,
-                                error = uiState.songsError?.asString(),
-                                bottomOverlayPadding = bottomOverlayPadding,
-                                scrollPosition = scrollState.songsPosition,
-                                onLoadPrevious = onLoadPreviousSongs,
-                                onLoadMore = onLoadMoreSongs,
-                                onPlaySongs = onPlaySongs,
-                                onPlayLibrarySongs = onPlayLibrarySongs,
-                                onOfflineSongUnavailable = onOfflineSongUnavailable,
-                                onShowSongActions = onShowSongActions,
-                            )
-                        }
-                    }
-                }
+                BrowseHeroCard(
+                    currentServer = currentServer,
+                    isSearchActive = true,
+                    searchQuery = uiState.searchQuery,
+                    onSearchActiveChange = onSetSearchActive,
+                    onSearchQueryChange = onUpdateSearchQuery,
+                    onOpenSettings = onOpenSettings,
+                )
+                SearchResultsRoute(
+                    modifier = Modifier.weight(1f),
+                    currentServer = currentServer,
+                    query = uiState.searchQuery,
+                    results = uiState.searchResults,
+                    isLoading = uiState.isSearchLoading,
+                    error = uiState.searchError?.asString(),
+                    recentSearchQueries = uiState.recentSearchQueries,
+                    availabilityUiStateFlow = availabilityUiStateFlow,
+                    isOfflineDegraded = isOfflineDegraded,
+                    bottomOverlayPadding = bottomOverlayPadding,
+                    resultsPosition = scrollState.searchResultsPosition,
+                    recentSearchesPosition = scrollState.recentSearchesPosition,
+                    onSearchQuery = onUpdateSearchQuery,
+                    onRemoveRecentSearchQuery = onRemoveRecentSearchQuery,
+                    onClearRecentSearchQueries = onClearRecentSearchQueries,
+                    onOpenArtist = onOpenArtist,
+                    onOpenAlbum = onOpenAlbum,
+                    onPlaySongs = onPlaySongs,
+                    onOfflineSongUnavailable = onOfflineSongUnavailable,
+                    onShowSongActions = onShowSongActions,
+                )
             }
         }
     }


### PR DESCRIPTION
Closes #296.

## What
Reworks Browse detail navigation around an explicit `BrowseNavRoute` stack, then applies the same predictive-back state machine to Browse details, Settings, and Search so each dismissible surface has a real lower layer and stable cancel/commit behavior.

This updates the original PR onto current `master` after #301.

## Changes
- Add `BrowseNavRoute`: `Root`, `AlbumDetail`, `ArtistDetail`, and `PlaylistDetail`.
- Add `browseStack` to `SakiAppUiState` and `SakiBrowseUiState`.
- `openArtist` / `openAlbum` / `openPlaylist` push routes; server changes and playback deep links reset to root first.
- Replace per-detail `close*` callbacks with a single `popBrowseRoute()`.
- Render Browse as layered below + top pages; top detail pages use predictive back over an opaque clipped background so the real previous page is visible.
- Convert predictive back motion to an `Animatable`-driven state machine:
  - snap to gesture progress while dragging
  - animate back on cancel
  - animate to completion before invoking close
  - reset on next enable/open instead of during the closing frame
- Apply predictive-back polish to Settings dismiss, including alpha fade on completion.
- Render Search as a temporary overlay over the current tab so it has its own predictive-back dismiss animation and a real tab layer underneath.
- Keep loading/error placeholders when a route exists before its detail data is available.

## Design notes
- Browse detail pages are navigation-stack surfaces.
- Settings is a modal/full-screen overlay, so it fades while shrinking instead of behaving exactly like a stack page.
- Search is a transient Browse mode, not a route stack entry; it overlays the current tab and fades/slides out on back.
- The existing single `selectedArtist` / `selectedAlbum` / `selectedPlaylist` fields are still sufficient for this phase because the current forward detail nesting is shallow.

## Deferred
- Destination-page participation in the predictive-back animation.
- Deeper route/depth modeling if Browse gains longer detail chains.
- Server manager/editor predictive-back treatment.

## Validation
- `./gradlew assembleDebug --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon`
- `git diff --check`
- Manual device smoke test: detail, Settings, and Search predictive-back cancel/commit behavior