### PR TITLE
fix: reduce UI recomposition jank

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
@@ -13,6 +13,7 @@ import org.hdhmc.saki.domain.repository.StreamCacheRepository
 import org.hdhmc.saki.playback.ConfigurableLeastRecentlyUsedCacheEvictor
 import org.hdhmc.saki.playback.buildStreamCacheKey
 import org.hdhmc.saki.playback.parseStreamCacheKey
+import dagger.Lazy
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
@@ -33,7 +34,7 @@ import kotlinx.coroutines.withContext
 @Singleton
 @UnstableApi
 class DefaultStreamCacheRepository @Inject constructor(
-    private val streamCache: SimpleCache,
+    private val streamCacheProvider: Lazy<SimpleCache>,
     private val cacheEvictor: ConfigurableLeastRecentlyUsedCacheEvictor,
     private val playbackPreferencesRepository: PlaybackPreferencesRepository,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
@@ -41,6 +42,9 @@ class DefaultStreamCacheRepository @Inject constructor(
     private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
     private val cacheVersion = MutableStateFlow(0L)
     private var lastSnapshot = StreamCacheSnapshot()
+    private var hasAppliedInitialCacheSize = false
+    private val streamCache: SimpleCache
+        get() = streamCacheProvider.get()
 
     init {
         scope.launch {
@@ -49,13 +53,18 @@ class DefaultStreamCacheRepository @Inject constructor(
                 .distinctUntilChanged()
                 .collectLatest { maxBytes ->
                     cacheEvictor.updateMaxBytes(maxBytes)
-                    refreshSnapshot(forceEmit = true)
+                    if (hasAppliedInitialCacheSize) {
+                        refreshSnapshot(forceEmit = true)
+                    } else {
+                        hasAppliedInitialCacheSize = true
+                    }
                 }
         }
         scope.launch {
+            delay(STREAM_CACHE_SNAPSHOT_INITIAL_DELAY_MS)
             refreshSnapshot(forceEmit = true)
             while (isActive) {
-                delay(2_500L)
+                delay(STREAM_CACHE_SNAPSHOT_REFRESH_MS)
                 refreshSnapshot()
             }
         }
@@ -211,6 +220,9 @@ private data class StreamCacheSnapshot(
     val cachedSongIdsByServerAndQuality: Map<Long, Map<String, Set<String>>> = emptyMap(),
     val bytesByServer: Map<Long, Long> = emptyMap(),
 )
+
+private const val STREAM_CACHE_SNAPSHOT_INITIAL_DELAY_MS = 5_000L
+private const val STREAM_CACHE_SNAPSHOT_REFRESH_MS = 30_000L
 
 private fun Collection<Set<String>>.flattenToSet(): Set<String> {
     return mutableSetOf<String>().apply {

--- a/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/DefaultPlaybackManager.kt
@@ -1060,7 +1060,7 @@ class DefaultPlaybackManager @Inject constructor(
     override suspend fun seekTo(positionMs: Long) {
         withController { activeController ->
             activeController.seekTo(positionMs.coerceAtLeast(0L))
-            syncState(activeController)
+            syncProgress(activeController)
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -42,8 +43,6 @@ import org.hdhmc.saki.domain.model.PlaybackProgressState
 import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.SongLyrics
-import org.hdhmc.saki.domain.model.ThemeMode
-import org.hdhmc.saki.domain.model.ThemeStyle
 import org.hdhmc.saki.presentation.library.BrowseScreen
 import org.hdhmc.saki.presentation.library.NowPlayingCapsule
 import org.hdhmc.saki.presentation.library.NowPlayingOverlay
@@ -57,18 +56,17 @@ fun SakiApp(
     modifier: Modifier = Modifier,
     viewModel: SakiAppViewModel = viewModel(),
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val endpointStatus by viewModel.endpointStatus.collectAsStateWithLifecycle()
+    val rootUiState by viewModel.rootUiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
     var showServerManager by rememberSaveable { mutableStateOf(false) }
     var showNowPlaying by rememberSaveable { mutableStateOf(false) }
     var showSettings by rememberSaveable { mutableStateOf(false) }
     val density = LocalDensity.current
-    val appDensity = remember(density, uiState.textScale) {
+    val appDensity = remember(density, rootUiState.textScale) {
         Density(
             density = density.density,
-            fontScale = density.fontScale * uiState.textScale.multiplier,
+            fontScale = density.fontScale * rootUiState.textScale.multiplier,
         )
     }
 
@@ -97,113 +95,38 @@ fun SakiApp(
         }
     }
 
+    LaunchedEffect(showSettings) {
+        if (showSettings) {
+            viewModel.refreshSettingsCacheStorageSummary()
+        }
+    }
+
     SakiAndroidTheme(
-        themeStyle = uiState.appPreferences.themeStyle,
-        seedColor = seedColorForKey(uiState.appPreferences.themeSeedKey),
-        paletteStyle = uiState.appPreferences.paletteStyle,
+        themeStyle = rootUiState.appPreferences.themeStyle,
+        seedColor = seedColorForKey(rootUiState.appPreferences.themeSeedKey),
+        paletteStyle = rootUiState.appPreferences.paletteStyle,
     ) {
         CompositionLocalProvider(LocalDensity provides appDensity) {
         Box(modifier = modifier.fillMaxSize()) {
             when {
-                !uiState.isAppReady -> {
+                !rootUiState.isAppReady -> {
                     Surface(modifier = Modifier.fillMaxSize()) {}
                 }
 
                 else -> {
                     RootShell(
-                        uiState = uiState,
-                        endpointStatus = endpointStatus,
+                        viewModel = viewModel,
                         snackbarHostState = snackbarHostState,
                         showSettings = showSettings,
                         onShowSettingsChange = { showSettings = it },
                         onManageServers = { showServerManager = true },
-                        onOpenNowPlaying = {
-                            if (uiState.playbackState.currentItem != null) {
-                                showNowPlaying = true
-                            }
-                        },
-                        onSelectBrowseSection = viewModel::selectBrowseSection,
-                        onSelectServer = viewModel::selectServer,
-                        onSetSearchActive = viewModel::setSearchActive,
-                        onUpdateSearchQuery = viewModel::updateSearchQuery,
-                        onRemoveRecentSearchQuery = viewModel::removeRecentSearchQuery,
-                        onClearRecentSearchQueries = viewModel::clearRecentSearchQueries,
-                        onRefreshCurrentTab = viewModel::refreshCurrentTab,
-                        onSelectAlbumFeed = viewModel::selectAlbumFeed,
-                        onLoadMoreAlbums = viewModel::loadMoreAlbums,
-                        onLoadPreviousSongs = viewModel::loadPreviousSongs,
-                        onLoadMoreSongs = viewModel::loadMoreSongs,
-                        onUpdateAlbumViewMode = viewModel::updateAlbumViewMode,
-                        onOpenArtist = viewModel::openArtist,
-                        onCloseArtist = viewModel::closeArtist,
-                        onOpenAlbum = viewModel::openAlbum,
-                        onCloseAlbum = viewModel::closeAlbum,
-                        onOpenPlaylist = viewModel::openPlaylist,
-                        onClosePlaylist = viewModel::closePlaylist,
-                        onPlaySongs = viewModel::playSongs,
-                        onPlayLibrarySongs = viewModel::playLibrarySongs,
-                        onQueueSong = viewModel::queueSong,
-                        onPlaySongNext = viewModel::playSongNext,
-                        onOfflineSongUnavailable = viewModel::showOfflineSongUnavailable,
-                        onToggleSongDownload = viewModel::toggleSongDownload,
-                        onPlayCachedSong = viewModel::playCachedSong,
-                        onPlayCachedQueue = viewModel::playCachedQueue,
-                        onDeleteCachedSong = viewModel::deleteCachedSong,
-                        onClearCachedSongs = viewModel::clearCachedSongs,
-                        onUpdateStreamQuality = viewModel::updateStreamQuality,
-                        onUpdateDownloadQuality = viewModel::updateDownloadQuality,
-                        onUpdateAdaptiveQuality = viewModel::updateAdaptiveQuality,
-                        onUpdateWifiStreamQuality = viewModel::updateWifiStreamQuality,
-                        onUpdateMobileStreamQuality = viewModel::updateMobileStreamQuality,
-                        onUpdateSoundBalancing = viewModel::updateSoundBalancing,
-                        onUpdateStreamCacheSizeMb = viewModel::updateStreamCacheSizeMb,
-                        onClearStreamCache = viewModel::clearStreamCache,
-                        onUpdateImageCacheSizeMb = viewModel::updateImageCacheSizeMb,
-                        onClearImageCache = viewModel::clearImageCache,
-                        onUpdateSongMetadata = viewModel::updateAllSongMetadata,
-                        onUpdateTextScale = viewModel::updateTextScale,
-                        onUpdateLanguage = viewModel::updateLanguage,
-                        onUpdateThemeMode = viewModel::updateThemeMode,
-                        onUpdateThemeStyle = viewModel::updateThemeStyle,
-                        onUpdateThemeSeed = viewModel::updateThemeSeed,
-                        onUpdatePaletteStyle = viewModel::updatePaletteStyle,
-                        onUpdateDefaultBrowseTab = viewModel::updateDefaultBrowseTab,
-                        onUpdateDefaultAlbumFeed = viewModel::updateDefaultAlbumFeed,
-                        onUpdateSongsPageSize = viewModel::updateSongsPageSize,
-                        onUpdateBluetoothLyrics = viewModel::updateBluetoothLyrics,
-                        onUpdateBufferStrategy = viewModel::updateBufferStrategy,
-                        onUpdateCustomBufferSeconds = viewModel::updateCustomBufferSeconds,
-                        onExportConfig = viewModel::exportConfig,
-                        onImportConfig = { uri -> viewModel.importConfig(uri) },
-                        onPausePlayback = viewModel::pausePlayback,
-                        onResumePlayback = viewModel::resumePlayback,
-                        onSkipToNext = viewModel::skipToNext,
-                        onSkipToPrevious = viewModel::skipToPrevious,
+                        onOpenNowPlaying = { showNowPlaying = true },
                     )
-                    NowPlayingOverlayHost(
+                    NowPlayingOverlayHostRoute(
                         visible = showNowPlaying,
-                        playbackState = uiState.playbackState,
-                        playbackProgressFlow = viewModel.playbackProgress,
-                        servers = uiState.servers,
-                        selectedServerId = uiState.selectedServerId,
-                        libraryIndexes = uiState.libraryIndexes,
-                        endpointStatus = endpointStatus,
-                        lyrics = uiState.currentLyrics,
+                        viewModel = viewModel,
                         onDismiss = { showNowPlaying = false },
                         onCloseSettings = { showSettings = false },
-                        onOpenArtistFromPlayback = viewModel::openArtistFromPlayback,
-                        onOpenAlbumFromPlayback = viewModel::openAlbumFromPlayback,
-                        onPausePlayback = viewModel::pausePlayback,
-                        onResumePlayback = viewModel::resumePlayback,
-                        onSkipToNext = viewModel::skipToNext,
-                        onSkipToPrevious = viewModel::skipToPrevious,
-                        onSeekTo = viewModel::seekTo,
-                        onCycleRepeatMode = viewModel::cycleRepeatMode,
-                        onToggleShuffle = viewModel::toggleShuffle,
-                        onSkipToQueueItem = viewModel::skipToQueueItem,
-                        onRemoveQueueItem = viewModel::removeQueueItem,
-                        onReprobeEndpoints = viewModel::reprobeEndpoints,
-                        onForceEndpoint = viewModel::forceEndpoint,
                     )
                 }
             }
@@ -223,72 +146,13 @@ fun SakiApp(
 
 @Composable
 private fun RootShell(
-    uiState: SakiAppUiState,
-    endpointStatus: EndpointStatus,
+    viewModel: SakiAppViewModel,
     snackbarHostState: SnackbarHostState,
     showSettings: Boolean,
     onShowSettingsChange: (Boolean) -> Unit,
     onManageServers: () -> Unit,
     onOpenNowPlaying: () -> Unit,
-    onSelectBrowseSection: (BrowseSection) -> Unit,
-    onSelectServer: (Long) -> Unit,
-    onSetSearchActive: (Boolean) -> Unit,
-    onUpdateSearchQuery: (String) -> Unit,
-    onRemoveRecentSearchQuery: (String) -> Unit,
-    onClearRecentSearchQueries: () -> Unit,
-    onRefreshCurrentTab: () -> Unit,
-    onSelectAlbumFeed: (org.hdhmc.saki.domain.model.AlbumListType) -> Unit,
-    onLoadMoreAlbums: () -> Unit,
-    onLoadPreviousSongs: () -> Unit,
-    onLoadMoreSongs: () -> Unit,
-    onUpdateAlbumViewMode: (org.hdhmc.saki.domain.model.AlbumViewMode) -> Unit,
-    onOpenArtist: (String) -> Unit,
-    onCloseArtist: () -> Unit,
-    onOpenAlbum: (String) -> Unit,
-    onCloseAlbum: () -> Unit,
-    onOpenPlaylist: (String) -> Unit,
-    onClosePlaylist: () -> Unit,
-    onPlaySongs: (List<org.hdhmc.saki.domain.model.Song>, Int) -> Unit,
-    onPlayLibrarySongs: (Int) -> Unit,
-    onQueueSong: (org.hdhmc.saki.domain.model.Song) -> Unit,
-    onPlaySongNext: (org.hdhmc.saki.domain.model.Song) -> Unit,
-    onOfflineSongUnavailable: () -> Unit,
-    onToggleSongDownload: (org.hdhmc.saki.domain.model.Song) -> Unit,
-    onPlayCachedSong: (org.hdhmc.saki.domain.model.CachedSong) -> Unit,
-    onPlayCachedQueue: (List<org.hdhmc.saki.domain.model.CachedSong>, Int) -> Unit,
-    onDeleteCachedSong: (String) -> Unit,
-    onClearCachedSongs: () -> Unit,
-    onUpdateStreamQuality: (org.hdhmc.saki.domain.model.StreamQuality) -> Unit,
-    onUpdateDownloadQuality: (org.hdhmc.saki.domain.model.StreamQuality) -> Unit,
-    onUpdateAdaptiveQuality: (Boolean) -> Unit,
-    onUpdateWifiStreamQuality: (org.hdhmc.saki.domain.model.StreamQuality) -> Unit,
-    onUpdateMobileStreamQuality: (org.hdhmc.saki.domain.model.StreamQuality) -> Unit,
-    onUpdateSoundBalancing: (org.hdhmc.saki.domain.model.SoundBalancingMode) -> Unit,
-    onUpdateStreamCacheSizeMb: (Int) -> Unit,
-    onClearStreamCache: () -> Unit,
-    onUpdateImageCacheSizeMb: (Int) -> Unit,
-    onClearImageCache: () -> Unit,
-    onUpdateSongMetadata: () -> Unit,
-    onUpdateTextScale: (org.hdhmc.saki.domain.model.TextScale) -> Unit,
-    onUpdateLanguage: (org.hdhmc.saki.domain.model.AppLanguage) -> Unit,
-    onUpdateThemeMode: (ThemeMode) -> Unit,
-    onUpdateThemeStyle: (ThemeStyle) -> Unit,
-    onUpdateThemeSeed: (String) -> Unit,
-    onUpdatePaletteStyle: (org.hdhmc.saki.domain.model.SakiPaletteStyle) -> Unit,
-    onUpdateDefaultBrowseTab: (org.hdhmc.saki.domain.model.DefaultBrowseTab) -> Unit,
-    onUpdateDefaultAlbumFeed: (org.hdhmc.saki.domain.model.AlbumListType) -> Unit,
-    onUpdateSongsPageSize: (Int) -> Unit,
-    onUpdateBluetoothLyrics: (Boolean) -> Unit,
-    onUpdateBufferStrategy: (org.hdhmc.saki.domain.model.BufferStrategy) -> Unit,
-    onUpdateCustomBufferSeconds: (Int) -> Unit,
-    onExportConfig: (android.net.Uri) -> Unit,
-    onImportConfig: (android.net.Uri) -> Unit,
-    onPausePlayback: () -> Unit,
-    onResumePlayback: () -> Unit,
-    onSkipToNext: () -> Unit,
-    onSkipToPrevious: () -> Unit,
 ) {
-    val currentOrQueuedTrack = uiState.playbackState.currentItem ?: uiState.playbackState.queue.firstOrNull()
     val shellBackgroundBrush = rememberBrowseBackgroundBrush()
     val density = LocalDensity.current
     val defaultCapsuleHeightPx = with(density) { 72.dp.roundToPx() }
@@ -307,37 +171,12 @@ private fun RootShell(
     ) {
         CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
             Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
-                BrowseScreen(
-                    uiState = uiState,
-                    isOfflineDegraded = endpointStatus.isOfflineDegraded,
+                BrowseRoute(
+                    viewModel = viewModel,
                     contentPadding = PaddingValues(),
                     bottomOverlayPadding = capsuleOverlayPadding,
                     onManageServers = onManageServers,
-                    onSelectBrowseSection = onSelectBrowseSection,
-                    onSetSearchActive = onSetSearchActive,
-                    onUpdateSearchQuery = onUpdateSearchQuery,
-                    onRemoveRecentSearchQuery = onRemoveRecentSearchQuery,
-                    onClearRecentSearchQueries = onClearRecentSearchQueries,
-                    onRefreshCurrentTab = onRefreshCurrentTab,
-                    onSelectAlbumFeed = onSelectAlbumFeed,
-                    onLoadMoreAlbums = onLoadMoreAlbums,
-                    onLoadPreviousSongs = onLoadPreviousSongs,
-                    onLoadMoreSongs = onLoadMoreSongs,
-                    onUpdateAlbumViewMode = onUpdateAlbumViewMode,
-                    onOpenArtist = onOpenArtist,
-                    onCloseArtist = onCloseArtist,
-                    onOpenAlbum = onOpenAlbum,
-                    onCloseAlbum = onCloseAlbum,
-                    onOpenPlaylist = onOpenPlaylist,
-                    onClosePlaylist = onClosePlaylist,
-                    onPlaySongs = onPlaySongs,
-                    onPlayLibrarySongs = onPlayLibrarySongs,
-                    onQueueSong = onQueueSong,
-                    onPlaySongNext = onPlaySongNext,
-                    onOfflineSongUnavailable = onOfflineSongUnavailable,
-                    onToggleSongDownload = onToggleSongDownload,
                     onOpenSettings = { onShowSettingsChange(true) },
-                    onImportConfig = onImportConfig,
                 )
 
                 AnimatedVisibility(
@@ -346,42 +185,12 @@ private fun RootShell(
                     exit = fadeOut(spring(stiffness = Spring.StiffnessMediumLow)),
                 ) {
                     Box(modifier = Modifier.fillMaxSize().then(settingsBackModifier)) {
-                        SettingsScreen(
-                            uiState = uiState,
+                        SettingsRoute(
+                            viewModel = viewModel,
                             contentPadding = PaddingValues(),
                             bottomOverlayPadding = capsuleOverlayPadding,
                             onClose = { onShowSettingsChange(false) },
                             onManageServers = onManageServers,
-                            onSelectServer = onSelectServer,
-                            onUpdateStreamQuality = onUpdateStreamQuality,
-                            onUpdateDownloadQuality = onUpdateDownloadQuality,
-                            onUpdateAdaptiveQuality = onUpdateAdaptiveQuality,
-                            onUpdateWifiStreamQuality = onUpdateWifiStreamQuality,
-                            onUpdateMobileStreamQuality = onUpdateMobileStreamQuality,
-                            onUpdateSoundBalancing = onUpdateSoundBalancing,
-                            onUpdateStreamCacheSizeMb = onUpdateStreamCacheSizeMb,
-                            onClearStreamCache = onClearStreamCache,
-                            onUpdateImageCacheSizeMb = onUpdateImageCacheSizeMb,
-                            onClearImageCache = onClearImageCache,
-                            onUpdateSongMetadata = onUpdateSongMetadata,
-                            onUpdateTextScale = onUpdateTextScale,
-                            onUpdateLanguage = onUpdateLanguage,
-                            onUpdateThemeMode = onUpdateThemeMode,
-                            onUpdateThemeStyle = onUpdateThemeStyle,
-                            onUpdateThemeSeed = onUpdateThemeSeed,
-                            onUpdatePaletteStyle = onUpdatePaletteStyle,
-                            onUpdateDefaultBrowseTab = onUpdateDefaultBrowseTab,
-                            onUpdateDefaultAlbumFeed = onUpdateDefaultAlbumFeed,
-                            onUpdateSongsPageSize = onUpdateSongsPageSize,
-                            onUpdateBluetoothLyrics = onUpdateBluetoothLyrics,
-                            onUpdateBufferStrategy = onUpdateBufferStrategy,
-                            onUpdateCustomBufferSeconds = onUpdateCustomBufferSeconds,
-                            onExportConfig = onExportConfig,
-                            onImportConfig = onImportConfig,
-                            onPlayCachedSong = onPlayCachedSong,
-                            onPlayCachedQueue = onPlayCachedQueue,
-                            onDeleteCachedSong = onDeleteCachedSong,
-                            onClearCachedSongs = onClearCachedSongs,
                         )
                     }
                 }
@@ -403,24 +212,166 @@ private fun RootShell(
                             }
                         },
                 ) {
-                    NowPlayingCapsule(
-                        track = currentOrQueuedTrack,
-                        isPlaying = uiState.playbackState.isPlaying,
-                        currentServer = currentOrQueuedTrack?.serverId?.let { sid ->
-                            uiState.servers.firstOrNull { it.id == sid }
-                        },
-                        onExpand = onOpenNowPlaying,
-                        onPlayPause = {
-                            if (uiState.playbackState.isPlaying) onPausePlayback() else onResumePlayback()
-                        },
-                        onSkipToPrevious = onSkipToPrevious,
-                        onSkipToNext = onSkipToNext,
-                        prewarmDynamicColors = rememberVisualEffectsPolicy().useNowPlayingDynamicArtworkColors,
+                    NowPlayingCapsuleRoute(
+                        viewModel = viewModel,
+                        onOpenNowPlaying = onOpenNowPlaying,
                     )
                 }
             }
         }
     }
+}
+
+@Composable
+private fun BrowseRoute(
+    viewModel: SakiAppViewModel,
+    contentPadding: PaddingValues,
+    bottomOverlayPadding: Dp,
+    onManageServers: () -> Unit,
+    onOpenSettings: () -> Unit,
+) {
+    val uiState by viewModel.browseUiState.collectAsStateWithLifecycle()
+    val endpointStatus by viewModel.endpointStatus.collectAsStateWithLifecycle()
+    BrowseScreen(
+        uiState = uiState,
+        playbackUiStateFlow = viewModel.browsePlaybackUiState,
+        availabilityUiStateFlow = viewModel.browseAvailabilityUiState,
+        isOfflineDegraded = endpointStatus.isOfflineDegraded,
+        contentPadding = contentPadding,
+        bottomOverlayPadding = bottomOverlayPadding,
+        onManageServers = onManageServers,
+        onSelectBrowseSection = viewModel::selectBrowseSection,
+        onSetSearchActive = viewModel::setSearchActive,
+        onUpdateSearchQuery = viewModel::updateSearchQuery,
+        onRemoveRecentSearchQuery = viewModel::removeRecentSearchQuery,
+        onClearRecentSearchQueries = viewModel::clearRecentSearchQueries,
+        onRefreshCurrentTab = viewModel::refreshCurrentTab,
+        onSelectAlbumFeed = viewModel::selectAlbumFeed,
+        onLoadMoreAlbums = viewModel::loadMoreAlbums,
+        onLoadPreviousSongs = viewModel::loadPreviousSongs,
+        onLoadMoreSongs = viewModel::loadMoreSongs,
+        onUpdateAlbumViewMode = viewModel::updateAlbumViewMode,
+        onOpenArtist = viewModel::openArtist,
+        onCloseArtist = viewModel::closeArtist,
+        onOpenAlbum = viewModel::openAlbum,
+        onCloseAlbum = viewModel::closeAlbum,
+        onOpenPlaylist = viewModel::openPlaylist,
+        onClosePlaylist = viewModel::closePlaylist,
+        onPlaySongs = viewModel::playSongs,
+        onPlayLibrarySongs = viewModel::playLibrarySongs,
+        onQueueSong = viewModel::queueSong,
+        onPlaySongNext = viewModel::playSongNext,
+        onOfflineSongUnavailable = viewModel::showOfflineSongUnavailable,
+        onToggleSongDownload = viewModel::toggleSongDownload,
+        onOpenSettings = onOpenSettings,
+        onImportConfig = { uri -> viewModel.importConfig(uri) },
+    )
+}
+
+@Composable
+private fun SettingsRoute(
+    viewModel: SakiAppViewModel,
+    contentPadding: PaddingValues,
+    bottomOverlayPadding: Dp,
+    onClose: () -> Unit,
+    onManageServers: () -> Unit,
+) {
+    val uiState by viewModel.settingsUiState.collectAsStateWithLifecycle()
+    SettingsScreen(
+        uiState = uiState,
+        contentPadding = contentPadding,
+        bottomOverlayPadding = bottomOverlayPadding,
+        onClose = onClose,
+        onManageServers = onManageServers,
+        onSelectServer = viewModel::selectServer,
+        onUpdateStreamQuality = viewModel::updateStreamQuality,
+        onUpdateDownloadQuality = viewModel::updateDownloadQuality,
+        onUpdateAdaptiveQuality = viewModel::updateAdaptiveQuality,
+        onUpdateWifiStreamQuality = viewModel::updateWifiStreamQuality,
+        onUpdateMobileStreamQuality = viewModel::updateMobileStreamQuality,
+        onUpdateSoundBalancing = viewModel::updateSoundBalancing,
+        onUpdateStreamCacheSizeMb = viewModel::updateStreamCacheSizeMb,
+        onClearStreamCache = viewModel::clearStreamCache,
+        onUpdateImageCacheSizeMb = viewModel::updateImageCacheSizeMb,
+        onClearImageCache = viewModel::clearImageCache,
+        onUpdateSongMetadata = viewModel::updateAllSongMetadata,
+        onUpdateTextScale = viewModel::updateTextScale,
+        onUpdateLanguage = viewModel::updateLanguage,
+        onUpdateThemeMode = viewModel::updateThemeMode,
+        onUpdateThemeStyle = viewModel::updateThemeStyle,
+        onUpdateThemeSeed = viewModel::updateThemeSeed,
+        onUpdatePaletteStyle = viewModel::updatePaletteStyle,
+        onUpdateDefaultBrowseTab = viewModel::updateDefaultBrowseTab,
+        onUpdateDefaultAlbumFeed = viewModel::updateDefaultAlbumFeed,
+        onUpdateSongsPageSize = viewModel::updateSongsPageSize,
+        onUpdateBluetoothLyrics = viewModel::updateBluetoothLyrics,
+        onUpdateBufferStrategy = viewModel::updateBufferStrategy,
+        onUpdateCustomBufferSeconds = viewModel::updateCustomBufferSeconds,
+        onExportConfig = viewModel::exportConfig,
+        onImportConfig = { uri -> viewModel.importConfig(uri) },
+        onPlayCachedSong = viewModel::playCachedSong,
+        onPlayCachedQueue = viewModel::playCachedQueue,
+        onDeleteCachedSong = viewModel::deleteCachedSong,
+        onClearCachedSongs = viewModel::clearCachedSongs,
+    )
+}
+
+@Composable
+private fun NowPlayingCapsuleRoute(
+    viewModel: SakiAppViewModel,
+    onOpenNowPlaying: () -> Unit,
+) {
+    val uiState by viewModel.capsuleUiState.collectAsStateWithLifecycle()
+    NowPlayingCapsule(
+        track = uiState.track,
+        isPlaying = uiState.isPlaying,
+        currentServer = uiState.currentServer,
+        onExpand = {
+            if (uiState.track != null) onOpenNowPlaying()
+        },
+        onPlayPause = {
+            if (uiState.isPlaying) viewModel.pausePlayback() else viewModel.resumePlayback()
+        },
+        onSkipToPrevious = viewModel::skipToPrevious,
+        onSkipToNext = viewModel::skipToNext,
+        prewarmDynamicColors = rememberVisualEffectsPolicy().useNowPlayingDynamicArtworkColors,
+    )
+}
+
+@Composable
+private fun NowPlayingOverlayHostRoute(
+    visible: Boolean,
+    viewModel: SakiAppViewModel,
+    onDismiss: () -> Unit,
+    onCloseSettings: () -> Unit,
+) {
+    val uiState by viewModel.nowPlayingUiState.collectAsStateWithLifecycle()
+    val endpointStatus by viewModel.endpointStatus.collectAsStateWithLifecycle()
+    NowPlayingOverlayHost(
+        visible = visible,
+        playbackState = uiState.playbackState,
+        playbackProgressFlow = viewModel.playbackProgress,
+        servers = uiState.servers,
+        selectedServerId = uiState.selectedServerId,
+        libraryIndexes = uiState.libraryIndexes,
+        endpointStatus = endpointStatus,
+        lyrics = uiState.currentLyrics,
+        onDismiss = onDismiss,
+        onCloseSettings = onCloseSettings,
+        onOpenArtistFromPlayback = viewModel::openArtistFromPlayback,
+        onOpenAlbumFromPlayback = viewModel::openAlbumFromPlayback,
+        onPausePlayback = viewModel::pausePlayback,
+        onResumePlayback = viewModel::resumePlayback,
+        onSkipToNext = viewModel::skipToNext,
+        onSkipToPrevious = viewModel::skipToPrevious,
+        onSeekTo = viewModel::seekTo,
+        onCycleRepeatMode = viewModel::cycleRepeatMode,
+        onToggleShuffle = viewModel::toggleShuffle,
+        onSkipToQueueItem = viewModel::skipToQueueItem,
+        onRemoveQueueItem = viewModel::removeQueueItem,
+        onReprobeEndpoints = viewModel::reprobeEndpoints,
+        onForceEndpoint = viewModel::forceEndpoint,
+    )
 }
 
 /**
@@ -484,15 +435,10 @@ private fun NowPlayingOverlayHost(
                 artistId in availableArtistIds
             )
     }
-    val progress = if (visible) {
-        playbackProgressFlow.collectAsStateWithLifecycle().value
-    } else {
-        playbackState.toProgressState()
-    }
     NowPlayingOverlay(
         visible = visible,
         playbackState = playbackState,
-        playbackProgress = progress,
+        playbackProgressFlow = playbackProgressFlow,
         track = track,
         onDismiss = onDismiss,
         canOpenArtist = ::canOpenArtist,
@@ -531,13 +477,5 @@ private fun NowPlayingOverlayHost(
         useArtworkMotion = visualEffectsPolicy.useNowPlayingArtworkMotion,
         useArtworkBackdrop = visualEffectsPolicy.useNowPlayingArtworkBackdrop,
         artworkPrewarmRadius = visualEffectsPolicy.nowPlayingArtworkPrewarmRadius,
-    )
-}
-
-private fun PlaybackSessionState.toProgressState(): PlaybackProgressState {
-    return PlaybackProgressState(
-        positionMs = positionMs,
-        durationMs = durationMs,
-        bufferedPositionMs = bufferedPositionMs,
     )
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -28,6 +28,8 @@ import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshot
 import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshotSourceType
 import org.hdhmc.saki.domain.model.regroupByLocale
 import org.hdhmc.saki.domain.model.PlaybackProgressState
+import org.hdhmc.saki.domain.model.PlaybackPreferences
+import org.hdhmc.saki.domain.model.PlaybackQueueItem
 import org.hdhmc.saki.domain.model.PlaybackSessionState
 import org.hdhmc.saki.domain.model.Playlist
 import org.hdhmc.saki.domain.model.PlaylistSummary
@@ -55,9 +57,12 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -65,6 +70,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -73,6 +79,7 @@ private const val PLAYLIST_DETAIL_PREFETCH_LIMIT = 12
 private const val PLAYLIST_DETAIL_PREFETCH_MAX_SONGS = 500
 private const val SONG_METADATA_SYNC_PAGE_SIZE = 500
 private const val SONGS_DISPLAY_WINDOW_SIZE = 5_000
+private const val DEFERRED_STREAM_CACHE_SUMMARY_REFRESH_MS = 5_000L
 
 @HiltViewModel
 @OptIn(FlowPreview::class)
@@ -97,11 +104,40 @@ class SakiAppViewModel @Inject constructor(
     private val searchQueryFlow = MutableStateFlow("")
     private var lastLoadedServerId: Long? = null
     private var appliedDefaultBrowsePreference = false
+    private var deferredStreamCacheSummaryJob: Job? = null
 
     private val mutableEndpointStatus = MutableStateFlow(EndpointStatus())
     val endpointStatus: StateFlow<EndpointStatus> = mutableEndpointStatus.asStateFlow()
 
     val uiState = mutableUiState.asStateFlow()
+    val rootUiState: StateFlow<SakiRootUiState> = mutableUiState
+        .map(SakiAppUiState::toRootUiState)
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, mutableUiState.value.toRootUiState())
+    val browseUiState: StateFlow<SakiBrowseUiState> = mutableUiState
+        .map(SakiAppUiState::toBrowseUiState)
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, mutableUiState.value.toBrowseUiState())
+    val browsePlaybackUiState: StateFlow<SakiBrowsePlaybackUiState> = mutableUiState
+        .map(SakiAppUiState::toBrowsePlaybackUiState)
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, mutableUiState.value.toBrowsePlaybackUiState())
+    val browseAvailabilityUiState: StateFlow<SakiBrowseAvailabilityUiState> = mutableUiState
+        .map(SakiAppUiState::toBrowseAvailabilityUiState)
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, mutableUiState.value.toBrowseAvailabilityUiState())
+    val settingsUiState: StateFlow<SakiSettingsUiState> = mutableUiState
+        .map(SakiAppUiState::toSettingsUiState)
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, mutableUiState.value.toSettingsUiState())
+    val capsuleUiState: StateFlow<SakiCapsuleUiState> = mutableUiState
+        .map(SakiAppUiState::toCapsuleUiState)
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, mutableUiState.value.toCapsuleUiState())
+    val nowPlayingUiState: StateFlow<SakiNowPlayingUiState> = mutableUiState
+        .map(SakiAppUiState::toNowPlayingUiState)
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, mutableUiState.value.toNowPlayingUiState())
     val playbackProgress: StateFlow<PlaybackProgressState> = playbackManager.playbackProgress
     val messages = snackbarMessages.asSharedFlow()
     val openNowPlayingRequests = openNowPlayingRequestsFlow.asSharedFlow()
@@ -171,7 +207,9 @@ class SakiAppViewModel @Inject constructor(
 
         viewModelScope.launch {
             streamCacheRepository.observeCacheVersion().collectLatest {
-                refreshCacheStorageSummary(uiState.value.selectedServerId)
+                if (it > 0L) {
+                    scheduleStreamCacheStorageSummaryRefresh(uiState.value.selectedServerId, delayMs = 500L)
+                }
             }
         }
 
@@ -1196,7 +1234,7 @@ class SakiAppViewModel @Inject constructor(
                         UiText.resource(R.string.message_no_stream_cache_to_clear)
                     }),
                 )
-                refreshCacheStorageSummary(targetServerId)
+                refreshCacheStorageSummary(targetServerId, includeStreamCacheSummary = true)
             }.onFailure { throwable ->
                 snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_clear_stream_cache)))
             }
@@ -1206,17 +1244,27 @@ class SakiAppViewModel @Inject constructor(
     fun clearImageCache() {
         viewModelScope.launch {
             runCatching {
-                kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                withContext(Dispatchers.IO) {
                     val dir = appContext.cacheDir.resolve("image_cache")
                     dir.deleteRecursively()
                     dir.mkdirs()
                 }
             }.onSuccess {
                 snackbarMessages.emit(SnackbarMessage(UiText.resource(R.string.message_cover_art_cache_cleared)))
-                refreshCacheStorageSummary(uiState.value.selectedServerId)
+                refreshCacheStorageSummary(uiState.value.selectedServerId, includeImageCacheBytes = true)
             }.onFailure { throwable ->
                 snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_clear_cover_art_cache)))
             }
+        }
+    }
+
+    fun refreshSettingsCacheStorageSummary() {
+        viewModelScope.launch {
+            refreshCacheStorageSummary(
+                serverId = uiState.value.selectedServerId,
+                includeStreamCacheSummary = true,
+                includeImageCacheBytes = true,
+            )
         }
     }
 
@@ -1434,6 +1482,16 @@ class SakiAppViewModel @Inject constructor(
                 hasLoadedSongsFromNetwork = if (serverChanged) false else state.hasLoadedSongsFromNetwork,
                 isSongsLoadingPrevious = if (serverChanged) false else state.isSongsLoadingPrevious,
                 isSongsLoadingMore = if (serverChanged) false else state.isSongsLoadingMore,
+                cacheStorageSummary = if (serverChanged) {
+                    state.cacheStorageSummary.copy(
+                        streamCachedSongCount = 0,
+                        streamCacheBytes = 0,
+                        hasStreamingCache = false,
+                    )
+                } else {
+                    state.cacheStorageSummary
+                },
+                streamCachedSongIds = if (serverChanged) emptySet() else state.streamCachedSongIds,
             )
         }
         if (serverChanged) {
@@ -1443,6 +1501,7 @@ class SakiAppViewModel @Inject constructor(
         viewModelScope.launch {
             refreshCacheStorageSummary(selectedServerId)
         }
+        scheduleStreamCacheStorageSummaryRefresh(selectedServerId)
 
         if (selectedServerId != null && (serverChanged || lastLoadedServerId != selectedServerId)) {
             // Show cached content immediately, then probe + network refresh
@@ -1476,26 +1535,56 @@ class SakiAppViewModel @Inject constructor(
         }
     }
 
-    private suspend fun refreshCacheStorageSummary(serverId: Long?) {
+    private suspend fun refreshCacheStorageSummary(
+        serverId: Long?,
+        includeStreamCacheSummary: Boolean = false,
+        includeImageCacheBytes: Boolean = false,
+    ) {
         val downloadSummary = cachedSongRepository.getCacheStorageSummary(serverId)
-        val fullStreamSummary = streamCacheRepository.getStreamCacheSummary(serverId)
-        val imageCacheDir = appContext.cacheDir.resolve("image_cache")
-        val imageCacheBytes = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-            imageCacheDir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+        val fullStreamSummary = if (includeStreamCacheSummary) {
+            streamCacheRepository.getStreamCacheSummary(serverId)
+        } else {
+            null
+        }
+        val imageCacheBytes = if (includeImageCacheBytes) {
+            withContext(Dispatchers.IO) {
+                val imageCacheDir = appContext.cacheDir.resolve("image_cache")
+                imageCacheDir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+            }
+        } else {
+            null
         }
         mutableUiState.update { state ->
             if (state.selectedServerId == serverId) {
+                val currentSummary = state.cacheStorageSummary
+                val currentImageCacheBytes = imageCacheBytes ?: state.cacheStorageSummary.imageCacheBytes
                 state.copy(
                     cacheStorageSummary = downloadSummary.copy(
-                        streamCachedSongCount = fullStreamSummary.cachedSongIds.size,
-                        streamCacheBytes = fullStreamSummary.bytes,
-                        hasStreamingCache = true,
-                        imageCacheBytes = imageCacheBytes,
+                        streamCachedSongCount = fullStreamSummary?.cachedSongIds?.size
+                            ?: currentSummary.streamCachedSongCount,
+                        streamCacheBytes = fullStreamSummary?.bytes
+                            ?: currentSummary.streamCacheBytes,
+                        hasStreamingCache = fullStreamSummary != null || currentSummary.hasStreamingCache,
+                        imageCacheBytes = currentImageCacheBytes,
                     ),
-                    streamCachedSongIds = fullStreamSummary.cachedSongIds,
+                    streamCachedSongIds = fullStreamSummary?.cachedSongIds ?: state.streamCachedSongIds,
                 )
             } else {
                 state
+            }
+        }
+    }
+
+    private fun scheduleStreamCacheStorageSummaryRefresh(
+        serverId: Long?,
+        delayMs: Long = DEFERRED_STREAM_CACHE_SUMMARY_REFRESH_MS,
+    ) {
+        deferredStreamCacheSummaryJob?.cancel()
+        if (serverId == null) return
+        deferredStreamCacheSummaryJob = viewModelScope.launch {
+            delay(delayMs)
+            if (uiState.value.selectedServerId == serverId) {
+                refreshCacheStorageSummary(serverId, includeStreamCacheSummary = true)
             }
         }
     }
@@ -2451,6 +2540,201 @@ data class SakiAppUiState(
     val albumsError: UiText?
         get() = selectedAlbumFeedState.error
 }
+
+data class SakiRootUiState(
+    val isAppReady: Boolean = false,
+    val textScale: TextScale = TextScale.DEFAULT,
+    val appPreferences: AppPreferences = AppPreferences(),
+)
+
+data class SakiCapsuleUiState(
+    val track: PlaybackQueueItem? = null,
+    val isPlaying: Boolean = false,
+    val currentServer: ServerConfig? = null,
+)
+
+data class SakiNowPlayingUiState(
+    val playbackState: PlaybackSessionState = PlaybackSessionState(),
+    val servers: List<ServerConfig> = emptyList(),
+    val selectedServerId: Long? = null,
+    val libraryIndexes: LibraryIndexes? = null,
+    val currentLyrics: SongLyrics? = null,
+)
+
+data class SakiBrowsePlaybackUiState(
+    val currentPlaybackSongId: String? = null,
+    val isPlaying: Boolean = false,
+)
+
+data class SakiBrowseAvailabilityUiState(
+    val selectedServerId: Long? = null,
+    val cachedSongs: List<CachedSong> = emptyList(),
+    val streamCachedSongIds: Set<String> = emptySet(),
+    val downloadingSongIds: Set<String> = emptySet(),
+)
+
+data class SakiBrowseUiState(
+    val appPreferences: AppPreferences = AppPreferences(),
+    val selectedBrowseSection: BrowseSection = BrowseSection.ARTISTS,
+    val servers: List<ServerConfig> = emptyList(),
+    val selectedServerId: Long? = null,
+    val selectedAlbumFeed: AlbumListType = AlbumListType.NEWEST,
+    val libraryIndexes: LibraryIndexes? = null,
+    val isArtistsLoading: Boolean = false,
+    val artistsError: UiText? = null,
+    val selectedArtist: Artist? = null,
+    val selectedArtistSongs: List<Song> = emptyList(),
+    val selectedArtistSongsAreTopSongs: Boolean = true,
+    val isArtistLoading: Boolean = false,
+    val artistError: UiText? = null,
+    val albumFeeds: Map<AlbumListType, AlbumFeedState> = emptyAlbumFeedStates(),
+    val selectedAlbum: Album? = null,
+    val isAlbumLoading: Boolean = false,
+    val albumError: UiText? = null,
+    val playlists: List<PlaylistSummary> = emptyList(),
+    val isPlaylistsLoading: Boolean = false,
+    val playlistsError: UiText? = null,
+    val selectedPlaylist: Playlist? = null,
+    val isPlaylistLoading: Boolean = false,
+    val playlistError: UiText? = null,
+    val songs: List<Song> = emptyList(),
+    val songsOffset: Int = 0,
+    val hasPreviousSongs: Boolean = false,
+    val hasMoreSongs: Boolean = true,
+    val isSongsLoading: Boolean = false,
+    val isSongsLoadingPrevious: Boolean = false,
+    val isSongsLoadingMore: Boolean = false,
+    val songsError: UiText? = null,
+    val isSearchActive: Boolean = false,
+    val searchQuery: String = "",
+    val searchResults: SearchResults = SearchResults(),
+    val isSearchLoading: Boolean = false,
+    val searchError: UiText? = null,
+    val recentSearchQueries: List<String> = emptyList(),
+) {
+    fun albumFeedState(type: AlbumListType): AlbumFeedState {
+        return albumFeeds[type] ?: AlbumFeedState(hasMore = type.supportsPagination())
+    }
+
+    val selectedAlbumFeedState: AlbumFeedState
+        get() = albumFeedState(selectedAlbumFeed)
+    val albums: List<AlbumSummary>
+        get() = selectedAlbumFeedState.albums
+    val isAlbumsLoading: Boolean
+        get() = selectedAlbumFeedState.isLoading
+    val hasMoreAlbums: Boolean
+        get() = selectedAlbumFeedState.hasMore
+    val isLoadingMoreAlbums: Boolean
+        get() = selectedAlbumFeedState.isLoadingMore
+    val albumsError: UiText?
+        get() = selectedAlbumFeedState.error
+}
+
+data class SakiSettingsUiState(
+    val appPreferences: AppPreferences = AppPreferences(),
+    val textScale: TextScale = TextScale.DEFAULT,
+    val servers: List<ServerConfig> = emptyList(),
+    val selectedServerId: Long? = null,
+    val cachedSongs: List<CachedSong> = emptyList(),
+    val cacheStorageSummary: CacheStorageSummary = CacheStorageSummary(),
+    val playbackPreferences: PlaybackPreferences = PlaybackPreferences(),
+    val isSongMetadataSyncing: Boolean = false,
+    val songMetadataSyncCount: Int = 0,
+)
+
+private fun SakiAppUiState.toRootUiState(): SakiRootUiState = SakiRootUiState(
+    isAppReady = isAppReady,
+    textScale = textScale,
+    appPreferences = appPreferences,
+)
+
+private fun SakiAppUiState.toCapsuleUiState(): SakiCapsuleUiState {
+    val track = playbackState.currentItem ?: playbackState.queue.firstOrNull()
+    return SakiCapsuleUiState(
+        track = track,
+        isPlaying = playbackState.isPlaying,
+        currentServer = track?.serverId?.let { sid -> servers.firstOrNull { it.id == sid } },
+    )
+}
+
+private fun SakiAppUiState.toNowPlayingUiState(): SakiNowPlayingUiState = SakiNowPlayingUiState(
+    playbackState = playbackState,
+    servers = servers,
+    selectedServerId = selectedServerId,
+    libraryIndexes = libraryIndexes,
+    currentLyrics = currentLyrics,
+)
+
+private fun SakiAppUiState.toBrowsePlaybackUiState(): SakiBrowsePlaybackUiState {
+    val currentPlaybackSongId = playbackState.currentItem?.songId
+        ?: playbackState.queue.getOrNull(playbackState.currentIndex)?.songId
+    return SakiBrowsePlaybackUiState(
+        currentPlaybackSongId = currentPlaybackSongId,
+        isPlaying = playbackState.isPlaying,
+    )
+}
+
+private fun SakiAppUiState.toBrowseAvailabilityUiState(): SakiBrowseAvailabilityUiState =
+    SakiBrowseAvailabilityUiState(
+        selectedServerId = selectedServerId,
+        cachedSongs = cachedSongs,
+        streamCachedSongIds = streamCachedSongIds,
+        downloadingSongIds = downloadingSongIds,
+    )
+
+private fun SakiAppUiState.toBrowseUiState(): SakiBrowseUiState {
+    return SakiBrowseUiState(
+        appPreferences = appPreferences,
+        selectedBrowseSection = selectedBrowseSection,
+        servers = servers,
+        selectedServerId = selectedServerId,
+        selectedAlbumFeed = selectedAlbumFeed,
+        libraryIndexes = libraryIndexes,
+        isArtistsLoading = isArtistsLoading,
+        artistsError = artistsError,
+        selectedArtist = selectedArtist,
+        selectedArtistSongs = selectedArtistSongs,
+        selectedArtistSongsAreTopSongs = selectedArtistSongsAreTopSongs,
+        isArtistLoading = isArtistLoading,
+        artistError = artistError,
+        albumFeeds = albumFeeds,
+        selectedAlbum = selectedAlbum,
+        isAlbumLoading = isAlbumLoading,
+        albumError = albumError,
+        playlists = playlists,
+        isPlaylistsLoading = isPlaylistsLoading,
+        playlistsError = playlistsError,
+        selectedPlaylist = selectedPlaylist,
+        isPlaylistLoading = isPlaylistLoading,
+        playlistError = playlistError,
+        songs = songs,
+        songsOffset = songsOffset,
+        hasPreviousSongs = hasPreviousSongs,
+        hasMoreSongs = hasMoreSongs,
+        isSongsLoading = isSongsLoading,
+        isSongsLoadingPrevious = isSongsLoadingPrevious,
+        isSongsLoadingMore = isSongsLoadingMore,
+        songsError = songsError,
+        isSearchActive = isSearchActive,
+        searchQuery = searchQuery,
+        searchResults = searchResults,
+        isSearchLoading = isSearchLoading,
+        searchError = searchError,
+        recentSearchQueries = appPreferences.recentSearchQueries,
+    )
+}
+
+private fun SakiAppUiState.toSettingsUiState(): SakiSettingsUiState = SakiSettingsUiState(
+    appPreferences = appPreferences,
+    textScale = textScale,
+    servers = servers,
+    selectedServerId = selectedServerId,
+    cachedSongs = cachedSongs,
+    cacheStorageSummary = cacheStorageSummary,
+    playbackPreferences = playbackState.preferences,
+    isSongMetadataSyncing = isSongMetadataSyncing,
+    songMetadataSyncCount = songMetadataSyncCount,
+)
 
 private fun SakiAppUiState.findArtistSummary(artistId: String): ArtistSummary? {
     val indexes = libraryIndexes ?: return null

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -102,10 +102,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlin.math.abs
 import org.hdhmc.saki.R
+import org.hdhmc.saki.domain.model.Album
 import org.hdhmc.saki.domain.model.AlbumListType
 import org.hdhmc.saki.domain.model.AlbumSummary
 import org.hdhmc.saki.domain.model.AlbumViewMode
+import org.hdhmc.saki.domain.model.Artist
 import org.hdhmc.saki.domain.model.CachedSong
+import org.hdhmc.saki.domain.model.Playlist
 import org.hdhmc.saki.domain.model.SearchResults
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.Song
@@ -114,10 +117,14 @@ import org.hdhmc.saki.presentation.AlbumFeedState
 import org.hdhmc.saki.presentation.labelRes
 import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
-import org.hdhmc.saki.presentation.SakiAppUiState
+import org.hdhmc.saki.presentation.SakiBrowseAvailabilityUiState
+import org.hdhmc.saki.presentation.SakiBrowsePlaybackUiState
+import org.hdhmc.saki.presentation.SakiBrowseUiState
 import org.hdhmc.saki.presentation.asString
 import org.hdhmc.saki.ui.theme.SakiChromeIconButton
 import org.hdhmc.saki.ui.theme.SakiTheme
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.filter
@@ -126,7 +133,9 @@ import kotlinx.coroutines.flow.map
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun BrowseScreen(
-    uiState: SakiAppUiState,
+    uiState: SakiBrowseUiState,
+    playbackUiStateFlow: StateFlow<SakiBrowsePlaybackUiState>,
+    availabilityUiStateFlow: StateFlow<SakiBrowseAvailabilityUiState>,
     isOfflineDegraded: Boolean,
     contentPadding: PaddingValues,
     bottomOverlayPadding: Dp = 0.dp,
@@ -159,23 +168,16 @@ fun BrowseScreen(
 ) {
     val background = rememberBrowseBackgroundBrush()
     val currentServer = uiState.servers.firstOrNull { it.id == uiState.selectedServerId }
-    val currentPlaybackSongId = uiState.playbackState.currentItem?.songId
-        ?: uiState.playbackState.queue.getOrNull(uiState.playbackState.currentIndex)?.songId
-    val cachedSongsBySongId = remember(uiState.cachedSongs, uiState.selectedServerId) {
-        uiState.cachedSongs
-            .asSequence()
-            .filter { cachedSong -> cachedSong.serverId == uiState.selectedServerId }
-            .associateBy(CachedSong::songId)
-    }
     var actionSong by remember { mutableStateOf<Song?>(null) }
     var detailSong by remember { mutableStateOf<Song?>(null) }
     val offlineAwarePlaySongs: (List<Song>, Int) -> Unit = { songs, startIndex ->
+        val availability = availabilityUiStateFlow.value
         playOfflineAwareSongs(
             songs = songs,
             startIndex = startIndex,
             isOfflineDegraded = isOfflineDegraded,
-            cachedSongsBySongId = cachedSongsBySongId,
-            streamCachedSongIds = uiState.streamCachedSongIds,
+            cachedSongsBySongId = availability.cachedSongsBySongId(),
+            streamCachedSongIds = availability.streamCachedSongIds,
             onPlaySongs = onPlaySongs,
             onUnavailable = onOfflineSongUnavailable,
         )
@@ -240,32 +242,29 @@ fun BrowseScreen(
                 label = "browseTarget",
             ) { target ->
                 when {
-                    target.hasAlbum && uiState.selectedAlbum != null -> AlbumDetailScreen(
+                    target.hasAlbum && uiState.selectedAlbum != null -> AlbumDetailRoute(
                         server = currentServer,
                         album = uiState.selectedAlbum,
-                        cachedSongsBySongId = cachedSongsBySongId,
-                        streamCachedSongIds = uiState.streamCachedSongIds,
-                        downloadingSongIds = uiState.downloadingSongIds,
+                        playbackUiStateFlow = playbackUiStateFlow,
+                        availabilityUiStateFlow = availabilityUiStateFlow,
                         isLoading = uiState.isAlbumLoading,
                         error = uiState.albumError?.asString(),
                         bottomOverlayPadding = bottomOverlayPadding,
                         isOfflineDegraded = isOfflineDegraded,
                         onOfflineSongUnavailable = onOfflineSongUnavailable,
-                        currentPlaybackSongId = currentPlaybackSongId,
-                        isPlaying = uiState.playbackState.isPlaying,
+
                         onPlaySongs = offlineAwarePlaySongs,
                         onShowActions = { actionSong = it },
                         onBack = onCloseAlbum,
                     )
 
-                    target.hasArtist && uiState.selectedArtist != null -> ArtistDetailScreen(
+                    target.hasArtist && uiState.selectedArtist != null -> ArtistDetailRoute(
                         server = currentServer,
                         artist = uiState.selectedArtist,
                         songs = uiState.selectedArtistSongs,
                         songsAreTopSongs = uiState.selectedArtistSongsAreTopSongs,
-                        cachedSongsBySongId = cachedSongsBySongId,
-                        streamCachedSongIds = uiState.streamCachedSongIds,
-                        downloadingSongIds = uiState.downloadingSongIds,
+                        playbackUiStateFlow = playbackUiStateFlow,
+                        availabilityUiStateFlow = availabilityUiStateFlow,
                         isLoading = uiState.isArtistLoading,
                         error = uiState.artistError?.asString(),
                         bottomOverlayPadding = bottomOverlayPadding,
@@ -273,17 +272,15 @@ fun BrowseScreen(
                         onOpenAlbum = onOpenAlbum,
                         onPlaySongs = offlineAwarePlaySongs,
                         onShowActions = { actionSong = it },
-                        currentPlaybackSongId = currentPlaybackSongId,
-                        isPlaying = uiState.playbackState.isPlaying,
+
                         onBack = onCloseArtist,
                     )
 
-                    target.hasPlaylist && uiState.selectedPlaylist != null -> PlaylistDetailScreen(
+                    target.hasPlaylist && uiState.selectedPlaylist != null -> PlaylistDetailRoute(
                         server = currentServer,
                         playlist = uiState.selectedPlaylist,
-                        cachedSongsBySongId = cachedSongsBySongId,
-                        streamCachedSongIds = uiState.streamCachedSongIds,
-                        downloadingSongIds = uiState.downloadingSongIds,
+                        playbackUiStateFlow = playbackUiStateFlow,
+                        availabilityUiStateFlow = availabilityUiStateFlow,
                         isLoading = uiState.isPlaylistLoading,
                         error = uiState.playlistError?.asString(),
                         bottomOverlayPadding = bottomOverlayPadding,
@@ -291,8 +288,7 @@ fun BrowseScreen(
                         onOfflineSongUnavailable = onOfflineSongUnavailable,
                         onPlaySongs = offlineAwarePlaySongs,
                         onShowActions = { actionSong = it },
-                        currentPlaybackSongId = currentPlaybackSongId,
-                        isPlaying = uiState.playbackState.isPlaying,
+
                         onBack = onClosePlaylist,
                     )
 
@@ -301,7 +297,8 @@ fun BrowseScreen(
                         uiState = uiState,
                         currentServer = currentServer,
                         scrollState = scrollState,
-                        cachedSongsBySongId = cachedSongsBySongId,
+                        playbackUiStateFlow = playbackUiStateFlow,
+                        availabilityUiStateFlow = availabilityUiStateFlow,
                         isOfflineDegraded = isOfflineDegraded,
                         bottomOverlayPadding = bottomOverlayPadding,
                         onSelectBrowseSection = onSelectBrowseSection,
@@ -330,30 +327,18 @@ fun BrowseScreen(
     }
 
     actionSong?.let { song ->
-        val isDownloaded = cachedSongsBySongId.containsKey(song.id)
-        val isOfflinePlayable = song.isOfflinePlayable(
-            cachedSongsBySongId = cachedSongsBySongId,
-            streamCachedSongIds = uiState.streamCachedSongIds,
-        )
-        SongActionsSheet(
+        SongActionsSheetRoute(
             song = song,
-            isDownloaded = isDownloaded,
-            isDownloading = song.id in uiState.downloadingSongIds,
+            availabilityUiStateFlow = availabilityUiStateFlow,
+            isOfflineDegraded = isOfflineDegraded,
+            onOfflineSongUnavailable = onOfflineSongUnavailable,
             onDismiss = { actionSong = null },
             onPlayNext = {
-                if (isOfflineDegraded && !isOfflinePlayable) {
-                    onOfflineSongUnavailable()
-                } else {
-                    onPlaySongNext(song)
-                }
+                onPlaySongNext(song)
                 actionSong = null
             },
             onToggleDownload = {
-                if (isOfflineDegraded && !isDownloaded) {
-                    onOfflineSongUnavailable()
-                } else {
-                    onToggleSongDownload(song)
-                }
+                onToggleSongDownload(song)
                 actionSong = null
             },
             onDetails = {
@@ -361,11 +346,7 @@ fun BrowseScreen(
                 actionSong = null
             },
             onQueueSong = {
-                if (isOfflineDegraded && !isOfflinePlayable) {
-                    onOfflineSongUnavailable()
-                } else {
-                    onQueueSong(song)
-                }
+                onQueueSong(song)
                 actionSong = null
             },
         )
@@ -381,6 +362,189 @@ private data class BrowseDetailTarget(
     val hasAlbum: Boolean,
     val hasPlaylist: Boolean,
 )
+
+@Composable
+private fun AlbumDetailRoute(
+    server: ServerConfig,
+    album: Album,
+    playbackUiStateFlow: StateFlow<SakiBrowsePlaybackUiState>,
+    availabilityUiStateFlow: StateFlow<SakiBrowseAvailabilityUiState>,
+    isLoading: Boolean,
+    error: String?,
+    bottomOverlayPadding: Dp,
+    isOfflineDegraded: Boolean,
+    onOfflineSongUnavailable: () -> Unit,
+    onPlaySongs: (List<Song>, Int) -> Unit,
+    onShowActions: (Song) -> Unit,
+    onBack: () -> Unit,
+) {
+    val playbackUiState by playbackUiStateFlow.collectAsStateWithLifecycle()
+    val availabilityUiState by availabilityUiStateFlow.collectAsStateWithLifecycle()
+    val cachedSongsBySongId = rememberCachedSongsBySongId(availabilityUiState)
+    AlbumDetailScreen(
+        server = server,
+        album = album,
+        cachedSongsBySongId = cachedSongsBySongId,
+        streamCachedSongIds = availabilityUiState.streamCachedSongIds,
+        downloadingSongIds = availabilityUiState.downloadingSongIds,
+        isLoading = isLoading,
+        error = error,
+        bottomOverlayPadding = bottomOverlayPadding,
+        isOfflineDegraded = isOfflineDegraded,
+        onOfflineSongUnavailable = onOfflineSongUnavailable,
+        currentPlaybackSongId = playbackUiState.currentPlaybackSongId,
+        isPlaying = playbackUiState.isPlaying,
+        onPlaySongs = onPlaySongs,
+        onShowActions = onShowActions,
+        onBack = onBack,
+    )
+}
+
+@Composable
+private fun ArtistDetailRoute(
+    server: ServerConfig,
+    artist: Artist,
+    songs: List<Song>,
+    songsAreTopSongs: Boolean,
+    playbackUiStateFlow: StateFlow<SakiBrowsePlaybackUiState>,
+    availabilityUiStateFlow: StateFlow<SakiBrowseAvailabilityUiState>,
+    isLoading: Boolean,
+    error: String?,
+    bottomOverlayPadding: Dp,
+    isOfflineDegraded: Boolean,
+    onOpenAlbum: (String) -> Unit,
+    onPlaySongs: (List<Song>, Int) -> Unit,
+    onShowActions: (Song) -> Unit,
+    onBack: () -> Unit,
+) {
+    val playbackUiState by playbackUiStateFlow.collectAsStateWithLifecycle()
+    val availabilityUiState by availabilityUiStateFlow.collectAsStateWithLifecycle()
+    val cachedSongsBySongId = rememberCachedSongsBySongId(availabilityUiState)
+    ArtistDetailScreen(
+        server = server,
+        artist = artist,
+        songs = songs,
+        songsAreTopSongs = songsAreTopSongs,
+        cachedSongsBySongId = cachedSongsBySongId,
+        streamCachedSongIds = availabilityUiState.streamCachedSongIds,
+        downloadingSongIds = availabilityUiState.downloadingSongIds,
+        isLoading = isLoading,
+        error = error,
+        bottomOverlayPadding = bottomOverlayPadding,
+        isOfflineDegraded = isOfflineDegraded,
+        onOpenAlbum = onOpenAlbum,
+        onPlaySongs = onPlaySongs,
+        onShowActions = onShowActions,
+        currentPlaybackSongId = playbackUiState.currentPlaybackSongId,
+        isPlaying = playbackUiState.isPlaying,
+        onBack = onBack,
+    )
+}
+
+@Composable
+private fun PlaylistDetailRoute(
+    server: ServerConfig,
+    playlist: Playlist,
+    playbackUiStateFlow: StateFlow<SakiBrowsePlaybackUiState>,
+    availabilityUiStateFlow: StateFlow<SakiBrowseAvailabilityUiState>,
+    isLoading: Boolean,
+    error: String?,
+    bottomOverlayPadding: Dp,
+    isOfflineDegraded: Boolean,
+    onOfflineSongUnavailable: () -> Unit,
+    onPlaySongs: (List<Song>, Int) -> Unit,
+    onShowActions: (Song) -> Unit,
+    onBack: () -> Unit,
+) {
+    val playbackUiState by playbackUiStateFlow.collectAsStateWithLifecycle()
+    val availabilityUiState by availabilityUiStateFlow.collectAsStateWithLifecycle()
+    val cachedSongsBySongId = rememberCachedSongsBySongId(availabilityUiState)
+    PlaylistDetailScreen(
+        server = server,
+        playlist = playlist,
+        cachedSongsBySongId = cachedSongsBySongId,
+        streamCachedSongIds = availabilityUiState.streamCachedSongIds,
+        downloadingSongIds = availabilityUiState.downloadingSongIds,
+        isLoading = isLoading,
+        error = error,
+        bottomOverlayPadding = bottomOverlayPadding,
+        isOfflineDegraded = isOfflineDegraded,
+        onOfflineSongUnavailable = onOfflineSongUnavailable,
+        onPlaySongs = onPlaySongs,
+        onShowActions = onShowActions,
+        currentPlaybackSongId = playbackUiState.currentPlaybackSongId,
+        isPlaying = playbackUiState.isPlaying,
+        onBack = onBack,
+    )
+}
+
+@Composable
+private fun SongActionsSheetRoute(
+    song: Song,
+    availabilityUiStateFlow: StateFlow<SakiBrowseAvailabilityUiState>,
+    isOfflineDegraded: Boolean,
+    onOfflineSongUnavailable: () -> Unit,
+    onDismiss: () -> Unit,
+    onPlayNext: () -> Unit,
+    onToggleDownload: () -> Unit,
+    onDetails: () -> Unit,
+    onQueueSong: () -> Unit,
+) {
+    val availabilityUiState by availabilityUiStateFlow.collectAsStateWithLifecycle()
+    val cachedSongsBySongId = rememberCachedSongsBySongId(availabilityUiState)
+    val isDownloaded = cachedSongsBySongId.containsKey(song.id)
+    val isOfflinePlayable = song.isOfflinePlayable(
+        cachedSongsBySongId = cachedSongsBySongId,
+        streamCachedSongIds = availabilityUiState.streamCachedSongIds,
+    )
+    SongActionsSheet(
+        song = song,
+        isDownloaded = isDownloaded,
+        isDownloading = song.id in availabilityUiState.downloadingSongIds,
+        onDismiss = onDismiss,
+        onPlayNext = {
+            if (isOfflineDegraded && !isOfflinePlayable) {
+                onOfflineSongUnavailable()
+                onDismiss()
+            } else {
+                onPlayNext()
+            }
+        },
+        onToggleDownload = {
+            if (isOfflineDegraded && !isDownloaded) {
+                onOfflineSongUnavailable()
+                onDismiss()
+            } else {
+                onToggleDownload()
+            }
+        },
+        onDetails = onDetails,
+        onQueueSong = {
+            if (isOfflineDegraded && !isOfflinePlayable) {
+                onOfflineSongUnavailable()
+                onDismiss()
+            } else {
+                onQueueSong()
+            }
+        },
+    )
+}
+
+@Composable
+private fun rememberCachedSongsBySongId(
+    availabilityUiState: SakiBrowseAvailabilityUiState,
+): Map<String, CachedSong> {
+    return remember(availabilityUiState.cachedSongs, availabilityUiState.selectedServerId) {
+        availabilityUiState.cachedSongsBySongId()
+    }
+}
+
+private fun SakiBrowseAvailabilityUiState.cachedSongsBySongId(): Map<String, CachedSong> {
+    return cachedSongs
+        .asSequence()
+        .filter { cachedSong -> cachedSong.serverId == selectedServerId }
+        .associateBy(CachedSong::songId)
+}
 
 private class BrowseScrollState(
     val searchResultsPosition: LazyListScrollPosition = LazyListScrollPosition(),
@@ -468,10 +632,11 @@ private fun OfflineModeBanner(modifier: Modifier = Modifier) {
 @Composable
 private fun BrowsePager(
     modifier: Modifier,
-    uiState: SakiAppUiState,
+    uiState: SakiBrowseUiState,
     currentServer: ServerConfig,
     scrollState: BrowseScrollState,
-    cachedSongsBySongId: Map<String, CachedSong>,
+    playbackUiStateFlow: StateFlow<SakiBrowsePlaybackUiState>,
+    availabilityUiStateFlow: StateFlow<SakiBrowseAvailabilityUiState>,
     isOfflineDegraded: Boolean,
     bottomOverlayPadding: Dp,
     onSelectBrowseSection: (BrowseSection) -> Unit,
@@ -529,17 +694,15 @@ private fun BrowsePager(
             onOpenSettings = onOpenSettings,
         )
         if (uiState.isSearchActive) {
-            SearchResultsPage(
+            SearchResultsRoute(
                 modifier = Modifier.weight(1f),
                 currentServer = currentServer,
                 query = uiState.searchQuery,
                 results = uiState.searchResults,
                 isLoading = uiState.isSearchLoading,
                 error = uiState.searchError?.asString(),
-                recentSearchQueries = uiState.appPreferences.recentSearchQueries,
-                cachedSongsBySongId = cachedSongsBySongId,
-                streamCachedSongIds = uiState.streamCachedSongIds,
-                downloadingSongIds = uiState.downloadingSongIds,
+                recentSearchQueries = uiState.recentSearchQueries,
+                availabilityUiStateFlow = availabilityUiStateFlow,
                 isOfflineDegraded = isOfflineDegraded,
                 bottomOverlayPadding = bottomOverlayPadding,
                 resultsPosition = scrollState.searchResultsPosition,
@@ -642,15 +805,14 @@ private fun BrowsePager(
                                 onOpenPlaylist = onOpenPlaylist,
                             )
 
-                            BrowseSection.SONGS -> SongsPage(
+                            BrowseSection.SONGS -> SongsPageRoute(
                                 songs = uiState.songs,
                                 songsOffset = uiState.songsOffset,
                                 hasPrevious = uiState.hasPreviousSongs,
                                 hasMore = uiState.hasMoreSongs,
                                 server = currentServer,
-                                cachedSongsBySongId = cachedSongsBySongId,
-                                streamCachedSongIds = uiState.streamCachedSongIds,
-                                downloadingSongIds = uiState.downloadingSongIds,
+                                playbackUiStateFlow = playbackUiStateFlow,
+                                availabilityUiStateFlow = availabilityUiStateFlow,
                                 isOfflineDegraded = isOfflineDegraded,
                                 isLoading = uiState.isSongsLoading,
                                 isLoadingPrevious = uiState.isSongsLoadingPrevious,
@@ -658,9 +820,6 @@ private fun BrowsePager(
                                 error = uiState.songsError?.asString(),
                                 bottomOverlayPadding = bottomOverlayPadding,
                                 scrollPosition = scrollState.songsPosition,
-                                currentPlaybackSongId = uiState.playbackState.currentItem?.songId
-                                    ?: uiState.playbackState.queue.getOrNull(uiState.playbackState.currentIndex)?.songId,
-                                isPlaying = uiState.playbackState.isPlaying,
                                 onLoadPrevious = onLoadPreviousSongs,
                                 onLoadMore = onLoadMoreSongs,
                                 onPlaySongs = onPlaySongs,
@@ -798,6 +957,57 @@ private fun BrowseSectionChip(
             )
         }
     }
+}
+
+@Composable
+private fun SearchResultsRoute(
+    modifier: Modifier,
+    currentServer: ServerConfig,
+    query: String,
+    results: SearchResults,
+    isLoading: Boolean,
+    error: String?,
+    recentSearchQueries: List<String>,
+    availabilityUiStateFlow: StateFlow<SakiBrowseAvailabilityUiState>,
+    isOfflineDegraded: Boolean,
+    bottomOverlayPadding: Dp,
+    resultsPosition: LazyListScrollPosition,
+    recentSearchesPosition: LazyListScrollPosition,
+    onSearchQuery: (String) -> Unit,
+    onRemoveRecentSearchQuery: (String) -> Unit,
+    onClearRecentSearchQueries: () -> Unit,
+    onOpenArtist: (String) -> Unit,
+    onOpenAlbum: (String) -> Unit,
+    onPlaySongs: (List<Song>, Int) -> Unit,
+    onOfflineSongUnavailable: () -> Unit,
+    onShowSongActions: (Song) -> Unit,
+) {
+    val availabilityUiState by availabilityUiStateFlow.collectAsStateWithLifecycle()
+    val cachedSongsBySongId = rememberCachedSongsBySongId(availabilityUiState)
+    SearchResultsPage(
+        modifier = modifier,
+        currentServer = currentServer,
+        query = query,
+        results = results,
+        isLoading = isLoading,
+        error = error,
+        recentSearchQueries = recentSearchQueries,
+        cachedSongsBySongId = cachedSongsBySongId,
+        streamCachedSongIds = availabilityUiState.streamCachedSongIds,
+        downloadingSongIds = availabilityUiState.downloadingSongIds,
+        isOfflineDegraded = isOfflineDegraded,
+        bottomOverlayPadding = bottomOverlayPadding,
+        resultsPosition = resultsPosition,
+        recentSearchesPosition = recentSearchesPosition,
+        onSearchQuery = onSearchQuery,
+        onRemoveRecentSearchQuery = onRemoveRecentSearchQuery,
+        onClearRecentSearchQueries = onClearRecentSearchQueries,
+        onOpenArtist = onOpenArtist,
+        onOpenAlbum = onOpenAlbum,
+        onPlaySongs = onPlaySongs,
+        onOfflineSongUnavailable = onOfflineSongUnavailable,
+        onShowSongActions = onShowSongActions,
+    )
 }
 
 @Composable
@@ -1629,6 +1839,59 @@ private fun PlaylistsPage(
             PlaylistCard(playlist = playlist, server = server, onOpenPlaylist = onOpenPlaylist)
         }
     }
+}
+
+@Composable
+private fun SongsPageRoute(
+    songs: List<Song>,
+    songsOffset: Int,
+    hasPrevious: Boolean,
+    hasMore: Boolean,
+    server: ServerConfig,
+    playbackUiStateFlow: StateFlow<SakiBrowsePlaybackUiState>,
+    availabilityUiStateFlow: StateFlow<SakiBrowseAvailabilityUiState>,
+    isOfflineDegraded: Boolean,
+    isLoading: Boolean,
+    isLoadingPrevious: Boolean,
+    isLoadingMore: Boolean,
+    error: String?,
+    bottomOverlayPadding: Dp,
+    scrollPosition: LazyListScrollPosition,
+    onLoadPrevious: () -> Unit,
+    onLoadMore: () -> Unit,
+    onPlaySongs: (List<Song>, Int) -> Unit,
+    onPlayLibrarySongs: (Int) -> Unit,
+    onOfflineSongUnavailable: () -> Unit,
+    onShowSongActions: (Song) -> Unit,
+) {
+    val playbackUiState by playbackUiStateFlow.collectAsStateWithLifecycle()
+    val availabilityUiState by availabilityUiStateFlow.collectAsStateWithLifecycle()
+    val cachedSongsBySongId = rememberCachedSongsBySongId(availabilityUiState)
+    SongsPage(
+        songs = songs,
+        songsOffset = songsOffset,
+        hasPrevious = hasPrevious,
+        hasMore = hasMore,
+        server = server,
+        cachedSongsBySongId = cachedSongsBySongId,
+        streamCachedSongIds = availabilityUiState.streamCachedSongIds,
+        downloadingSongIds = availabilityUiState.downloadingSongIds,
+        isOfflineDegraded = isOfflineDegraded,
+        isLoading = isLoading,
+        isLoadingPrevious = isLoadingPrevious,
+        isLoadingMore = isLoadingMore,
+        error = error,
+        bottomOverlayPadding = bottomOverlayPadding,
+        scrollPosition = scrollPosition,
+        currentPlaybackSongId = playbackUiState.currentPlaybackSongId,
+        isPlaying = playbackUiState.isPlaying,
+        onLoadPrevious = onLoadPrevious,
+        onLoadMore = onLoadMore,
+        onPlaySongs = onPlaySongs,
+        onPlayLibrarySongs = onPlayLibrarySongs,
+        onOfflineSongUnavailable = onOfflineSongUnavailable,
+        onShowSongActions = onShowSongActions,
+    )
 }
 
 @Composable

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -94,8 +94,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
@@ -137,6 +137,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.palette.graphics.Palette
 import com.materialkolor.hct.Hct
 import com.materialkolor.quantize.QuantizerCelebi
@@ -173,6 +174,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -426,7 +428,7 @@ private fun MiniPlayerIconButton(
 fun NowPlayingOverlay(
     visible: Boolean,
     playbackState: PlaybackSessionState,
-    playbackProgress: PlaybackProgressState,
+    playbackProgressFlow: StateFlow<PlaybackProgressState>,
     track: PlaybackQueueItem,
     onDismiss: () -> Unit,
     canOpenArtist: (String?) -> Boolean,
@@ -659,17 +661,6 @@ fun NowPlayingOverlay(
         } else {
             sliderActiveColor.copy(alpha = 0.25f)
         }
-        var sliderValue by remember(track.songId) {
-            mutableFloatStateOf(playbackProgress.positionMs.toFloat())
-        }
-        var isDragging by remember(track.songId) { mutableStateOf(false) }
-
-        LaunchedEffect(playbackProgress.positionMs, track.songId) {
-            if (!isDragging) {
-                sliderValue = playbackProgress.positionMs.toFloat()
-            }
-        }
-
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
@@ -866,7 +857,7 @@ fun NowPlayingOverlay(
                                 if (lyrics != null && lyrics.lines.isNotEmpty()) {
                                     SyncedLyricsView(
                                         lyrics = lyrics,
-                                        positionMs = playbackProgress.positionMs,
+                                        playbackProgressFlow = playbackProgressFlow,
                                         isPlaying = playbackState.isPlaying,
                                         onSeekTo = onSeekTo,
                                         modifier = Modifier
@@ -999,75 +990,16 @@ fun NowPlayingOverlay(
                             onOpenAlbum = onOpenAlbum,
                         )
                     }
-                    val duration = playbackProgress.durationMs.coerceAtLeast(1L).toFloat()
-                    val bufferFraction = if (playbackProgress.durationMs > 0) {
-                        (playbackProgress.bufferedPositionMs.toFloat() / duration).coerceIn(0f, 1f)
-                    } else 0f
                     val isCachedTrack = track.isCached || playbackState.isStreamCached
-                    // Once the buffer overlay reaches the end, switch to the solid "buffered" style
-                    // even if the disk cache isn't yet marked fully cached: the streaming overlay
-                    // (player + cache buffered position) and isStreamCached are different signals.
-                    val showCachedStyle = isCachedTrack ||
-                        (playbackProgress.durationMs > 0 && bufferFraction >= 0.999f)
-                    val sliderColors = if (showCachedStyle) {
-                        SliderDefaults.colors(
-                            thumbColor = sliderActiveColor,
-                            activeTrackColor = sliderActiveColor,
-                            inactiveTrackColor = sliderInactiveColor,
-                        )
-                    } else {
-                        SliderDefaults.colors(
-                            thumbColor = sliderActiveColor,
-                            activeTrackColor = sliderActiveColor,
-                            inactiveTrackColor = Color.Transparent,
-                        )
-                    }
-                    val bufferColor = sliderActiveColor.copy(alpha = 0.3f)
-                    val trackBgColor = MaterialTheme.colorScheme.surfaceContainerHighest
-                    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
-                    Slider(
-                        value = sliderValue.coerceIn(0f, duration),
-                        onValueChange = {
-                            isDragging = true
-                            sliderValue = it
-                        },
-                        onValueChangeFinished = {
-                            isDragging = false
-                            onSeekTo(sliderValue.roundToLong())
-                        },
-                        valueRange = 0f..duration,
-                        colors = sliderColors,
-                        modifier = if (!showCachedStyle) {
-                            Modifier.drawBehind {
-                                val trackHeight = 4.dp.toPx()
-                                val y = size.height / 2
-                                val padding = 6.dp.toPx()
-                                val trackWidth = size.width - padding * 2
-                                val start = if (isRtl) size.width - padding else padding
-                                val end = if (isRtl) padding else size.width - padding
-                                drawLine(
-                                    color = trackBgColor,
-                                    start = Offset(start, y),
-                                    end = Offset(end, y),
-                                    strokeWidth = trackHeight,
-                                    cap = StrokeCap.Round,
-                                )
-                                if (bufferFraction > 0f) {
-                                    val bufferEnd = if (isRtl) {
-                                        start - trackWidth * bufferFraction
-                                    } else {
-                                        start + trackWidth * bufferFraction
-                                    }
-                                    drawLine(
-                                        color = bufferColor,
-                                        start = Offset(start, y),
-                                        end = Offset(bufferEnd, y),
-                                        strokeWidth = trackHeight,
-                                        cap = StrokeCap.Round,
-                                    )
-                                }
-                            }
-                        } else Modifier,
+                    NowPlayingProgressSection(
+                        playbackProgressFlow = playbackProgressFlow,
+                        trackId = track.songId,
+                        isCachedTrack = isCachedTrack,
+                        sliderActiveColor = sliderActiveColor,
+                        sliderInactiveColor = sliderInactiveColor,
+                        onArtwork = onArtwork,
+                        verticalSpacing = verticalSpacing,
+                        onSeekTo = onSeekTo,
                     )
                     Column(
                         modifier = Modifier
@@ -1075,13 +1007,6 @@ fun NowPlayingOverlay(
                             .then(queueSwipeModifier),
                         verticalArrangement = Arrangement.spacedBy(verticalSpacing),
                     ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                        ) {
-                            Text(text = formatDuration(sliderValue.roundToLong()), color = onArtwork)
-                            Text(text = formatDuration(playbackProgress.durationMs), color = onArtwork)
-                        }
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.Center,
@@ -1407,6 +1332,113 @@ fun NowPlayingOverlay(
                 }
             },
         )
+    }
+}
+
+@Composable
+private fun NowPlayingProgressSection(
+    playbackProgressFlow: StateFlow<PlaybackProgressState>,
+    trackId: String,
+    isCachedTrack: Boolean,
+    sliderActiveColor: Color,
+    sliderInactiveColor: Color,
+    onArtwork: Color,
+    verticalSpacing: Dp,
+    onSeekTo: (Long) -> Unit,
+) {
+    val playbackProgress by playbackProgressFlow.collectAsStateWithLifecycle()
+    val duration = playbackProgress.durationMs.coerceAtLeast(1L).toFloat()
+    val bufferFraction = if (playbackProgress.durationMs > 0) {
+        (playbackProgress.bufferedPositionMs.toFloat() / duration).coerceIn(0f, 1f)
+    } else {
+        0f
+    }
+    // Once the buffer overlay reaches the end, switch to the solid "buffered" style
+    // even if the disk cache isn't yet marked fully cached: the streaming overlay
+    // (player + cache buffered position) and isStreamCached are different signals.
+    val showCachedStyle = isCachedTrack ||
+        (playbackProgress.durationMs > 0 && bufferFraction >= 0.999f)
+    val sliderColors = if (showCachedStyle) {
+        SliderDefaults.colors(
+            thumbColor = sliderActiveColor,
+            activeTrackColor = sliderActiveColor,
+            inactiveTrackColor = sliderInactiveColor,
+        )
+    } else {
+        SliderDefaults.colors(
+            thumbColor = sliderActiveColor,
+            activeTrackColor = sliderActiveColor,
+            inactiveTrackColor = Color.Transparent,
+        )
+    }
+    val bufferColor = sliderActiveColor.copy(alpha = 0.3f)
+    val trackBgColor = MaterialTheme.colorScheme.surfaceContainerHighest
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    var sliderValue by remember(trackId) {
+        mutableFloatStateOf(playbackProgress.positionMs.toFloat())
+    }
+    var isDragging by remember(trackId) { mutableStateOf(false) }
+
+    LaunchedEffect(playbackProgress.positionMs, trackId) {
+        if (!isDragging) {
+            sliderValue = playbackProgress.positionMs.toFloat()
+        }
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(verticalSpacing)) {
+        Slider(
+            value = sliderValue.coerceIn(0f, duration),
+            onValueChange = {
+                isDragging = true
+                sliderValue = it
+            },
+            onValueChangeFinished = {
+                isDragging = false
+                onSeekTo(sliderValue.roundToLong())
+            },
+            valueRange = 0f..duration,
+            colors = sliderColors,
+            modifier = if (!showCachedStyle) {
+                Modifier.drawBehind {
+                    val trackHeight = 4.dp.toPx()
+                    val y = size.height / 2
+                    val padding = 6.dp.toPx()
+                    val trackWidth = size.width - padding * 2
+                    val start = if (isRtl) size.width - padding else padding
+                    val end = if (isRtl) padding else size.width - padding
+                    drawLine(
+                        color = trackBgColor,
+                        start = Offset(start, y),
+                        end = Offset(end, y),
+                        strokeWidth = trackHeight,
+                        cap = StrokeCap.Round,
+                    )
+                    if (bufferFraction > 0f) {
+                        val bufferEnd = if (isRtl) {
+                            start - trackWidth * bufferFraction
+                        } else {
+                            start + trackWidth * bufferFraction
+                        }
+                        drawLine(
+                            color = bufferColor,
+                            start = Offset(start, y),
+                            end = Offset(bufferEnd, y),
+                            strokeWidth = trackHeight,
+                            cap = StrokeCap.Round,
+                        )
+                    }
+                }
+            } else {
+                Modifier
+            },
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(text = formatDuration(sliderValue.roundToLong()), color = onArtwork)
+            Text(text = formatDuration(playbackProgress.durationMs), color = onArtwork)
+        }
     }
 }
 
@@ -2442,6 +2474,7 @@ private const val ARTWORK_BUTTON_SKIP_CONFIRM_TIMEOUT_MS = 900L
 private const val ARTWORK_BUTTON_SKIP_INITIAL_VELOCITY_PAGES = 3.5f
 private const val COMPACT_TECH_INFO_SETTLE_MS = 700L
 private const val COMPACT_TECH_INFO_FADE_MS = 700
+private const val KARAOKE_PROGRESS_CORRECTION_THRESHOLD_MS = 1_200L
 private const val METADATA_LINK_SCROLL_EDGE_PAUSE_MS = 1_200L
 private const val METADATA_LINK_SCROLL_MIN_DURATION_MS = 350
 private const val METADATA_LINK_SCROLL_SPEED_DP_PER_SECOND = 32f
@@ -2780,49 +2813,60 @@ private fun formatSampleRate(sampleRate: Int): String = "$sampleRate Hz"
 @Composable
 private fun SyncedLyricsView(
     lyrics: SongLyrics,
-    positionMs: Long,
+    playbackProgressFlow: StateFlow<PlaybackProgressState>,
     isPlaying: Boolean,
     onSeekTo: (Long) -> Unit,
     modifier: Modifier = Modifier,
     textColor: Color = MaterialTheme.colorScheme.onBackground,
 ) {
+    val playbackProgress by playbackProgressFlow.collectAsStateWithLifecycle()
+    val positionMs = playbackProgress.positionMs
     val lines = lyrics.lines
     val hasWordLevelTiming = lyrics.synced && lines.any { it.words != null }
+    var lyricPositionMs by remember(lyrics) { mutableLongStateOf(positionMs) }
 
-    // High-frequency position: interpolate between 500ms global updates (only for karaoke)
-    val smoothPositionMs by produceState(
-        initialValue = positionMs,
-        key1 = positionMs,
-        key2 = isPlaying,
-        key3 = hasWordLevelTiming,
-    ) {
-        value = positionMs
-        if (!isPlaying || !hasWordLevelTiming) return@produceState
-        var lastFrame = withFrameNanos { it }
-        while (true) {
-            val now = withFrameNanos { it }
-            val delta = (now - lastFrame) / 1_000_000
-            lastFrame = now
-            value += delta
+    LaunchedEffect(positionMs, isPlaying, lyrics) {
+        val deltaFromLyricPosition = positionMs - lyricPositionMs
+        lyricPositionMs = when {
+            !isPlaying -> positionMs
+            deltaFromLyricPosition > KARAOKE_PROGRESS_CORRECTION_THRESHOLD_MS -> positionMs
+            deltaFromLyricPosition < -KARAOKE_PROGRESS_CORRECTION_THRESHOLD_MS -> positionMs
+            else -> maxOf(lyricPositionMs, positionMs)
         }
     }
 
     val activeIndex = if (lyrics.synced) {
-        lines.indexOfLast { it.startMs <= positionMs }.coerceAtLeast(0)
+        lines.activeLyricLineIndex(lyricPositionMs)
     } else {
         -1
     }
 
-    val lyricsListState = rememberLazyListState()
+    val initialActiveIndex = remember(lyrics) {
+        if (lyrics.synced) {
+            lines.activeLyricLineIndex(lyricPositionMs).coerceAtLeast(0)
+        } else {
+            0
+        }
+    }
+    val lyricsListState = rememberLazyListState(initialFirstVisibleItemIndex = initialActiveIndex)
+    var hasPositionedInitialLine by remember(lyrics) { mutableStateOf(false) }
     val density = LocalDensity.current
 
-    if (lyrics.synced && activeIndex >= 0 && isPlaying) {
-        LaunchedEffect(activeIndex) {
+    if (lyrics.synced && activeIndex >= 0) {
+        LaunchedEffect(activeIndex, isPlaying) {
             val offsetPx = with(density) { 80.dp.roundToPx() }
-            lyricsListState.animateScrollToItem(
-                index = activeIndex,
-                scrollOffset = -offsetPx,
-            )
+            when {
+                !hasPositionedInitialLine -> {
+                    hasPositionedInitialLine = true
+                    lyricsListState.scrollToItem(activeIndex, -offsetPx)
+                }
+                isPlaying -> {
+                    lyricsListState.animateScrollToItem(
+                        index = activeIndex,
+                        scrollOffset = -offsetPx,
+                    )
+                }
+            }
         }
     }
 
@@ -2845,29 +2889,23 @@ private fun SyncedLyricsView(
                 val lineEndMs = lines.getOrNull(index + 1)?.startMs ?: (line.words.last().startMs + 1000)
                 val lineDurationMs = lineEndMs - line.startMs
                 if (lineDurationMs > 0) {
-                    val progress = ((smoothPositionMs - line.startMs).toFloat() / lineDurationMs.toFloat()).coerceIn(0f, 1f)
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .then(
-                                if (lyrics.synced && line.startMs >= 0) {
-                                    Modifier.clickable { onSeekTo(line.startMs) }
-                                } else {
-                                    Modifier
-                                },
-                            )
-                            .padding(vertical = 4.dp),
-                    ) {
-                        Text(text = line.text, style = style, color = dimColor)
-                        Text(
-                            text = line.text,
-                            style = style,
-                            color = textColor,
-                            modifier = Modifier.drawWithContent {
-                                clipRect(right = size.width * progress) { this@drawWithContent.drawContent() }
-                            },
-                        )
-                    }
+                    KaraokeLyricLine(
+                        text = line.text,
+                        lineStartMs = line.startMs,
+                        lineDurationMs = lineDurationMs,
+                        positionMs = positionMs,
+                        isPlaying = isPlaying && hasWordLevelTiming,
+                        style = style,
+                        textColor = textColor,
+                        dimColor = dimColor,
+                        onClick = if (lyrics.synced && line.startMs >= 0) {
+                            {
+                                onSeekTo(line.startMs)
+                            }
+                        } else {
+                            null
+                        },
+                    )
                 } else {
                     Text(
                         text = line.text.ifBlank { "♪" },
@@ -2877,7 +2915,9 @@ private fun SyncedLyricsView(
                             .fillMaxWidth()
                             .then(
                                 if (lyrics.synced && line.startMs >= 0) {
-                                    Modifier.clickable { onSeekTo(line.startMs) }
+                                    Modifier.clickable {
+                                        onSeekTo(line.startMs)
+                                    }
                                 } else {
                                     Modifier
                                 },
@@ -2894,7 +2934,9 @@ private fun SyncedLyricsView(
                         .fillMaxWidth()
                         .then(
                             if (lyrics.synced && line.startMs >= 0) {
-                                Modifier.clickable { onSeekTo(line.startMs) }
+                                Modifier.clickable {
+                                    onSeekTo(line.startMs)
+                                }
                             } else {
                                 Modifier
                             },
@@ -2904,4 +2946,87 @@ private fun SyncedLyricsView(
             }
         }
     }
+}
+
+@Composable
+private fun KaraokeLyricLine(
+    text: String,
+    lineStartMs: Long,
+    lineDurationMs: Long,
+    positionMs: Long,
+    isPlaying: Boolean,
+    style: TextStyle,
+    textColor: Color,
+    dimColor: Color,
+    onClick: (() -> Unit)?,
+) {
+    // Keep per-frame karaoke interpolation scoped to the active row. Do not key the
+    // interpolator by every player progress tick: those ticks are only sampled every
+    // ~500ms and can arrive behind the locally interpolated value, which makes the
+    // highlight visibly jump backward. Normal playback stays monotonic; large
+    // discontinuities still snap to the player position for seek/track changes.
+    var smoothPositionMs by remember(lineStartMs) { mutableLongStateOf(positionMs) }
+    val latestPositionMs = rememberUpdatedState(positionMs)
+
+    LaunchedEffect(positionMs, isPlaying, lineStartMs) {
+        val deltaFromSmooth = positionMs - smoothPositionMs
+        when {
+            !isPlaying -> smoothPositionMs = positionMs
+            deltaFromSmooth > KARAOKE_PROGRESS_CORRECTION_THRESHOLD_MS -> smoothPositionMs = positionMs
+            deltaFromSmooth < -KARAOKE_PROGRESS_CORRECTION_THRESHOLD_MS -> smoothPositionMs = positionMs
+            positionMs > smoothPositionMs -> smoothPositionMs = positionMs
+        }
+    }
+
+    LaunchedEffect(isPlaying, lineStartMs) {
+        if (!isPlaying) return@LaunchedEffect
+        var lastFrame = withFrameNanos { it }
+        while (true) {
+            val now = withFrameNanos { it }
+            val delta = (now - lastFrame) / 1_000_000
+            lastFrame = now
+            val playerPositionMs = latestPositionMs.value
+            val predictedPositionMs = smoothPositionMs + delta
+            smoothPositionMs = when {
+                playerPositionMs > predictedPositionMs + KARAOKE_PROGRESS_CORRECTION_THRESHOLD_MS -> playerPositionMs
+                playerPositionMs < smoothPositionMs - KARAOKE_PROGRESS_CORRECTION_THRESHOLD_MS -> playerPositionMs
+                else -> maxOf(predictedPositionMs, playerPositionMs)
+            }
+        }
+    }
+
+    val progress = ((smoothPositionMs - lineStartMs).toFloat() / lineDurationMs.toFloat()).coerceIn(0f, 1f)
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(vertical = 4.dp),
+    ) {
+        Text(text = text, style = style, color = dimColor)
+        Text(
+            text = text,
+            style = style,
+            color = textColor,
+            modifier = Modifier.drawWithContent {
+                clipRect(right = size.width * progress) { this@drawWithContent.drawContent() }
+            },
+        )
+    }
+}
+
+private fun List<org.hdhmc.saki.domain.model.LyricLine>.activeLyricLineIndex(positionMs: Long): Int {
+    if (isEmpty()) return -1
+    var low = 0
+    var high = lastIndex
+    var result = -1
+    while (low <= high) {
+        val mid = (low + high) ushr 1
+        if (this[mid].startMs <= positionMs) {
+            result = mid
+            low = mid + 1
+        } else {
+            high = mid - 1
+        }
+    }
+    return result.coerceAtLeast(0)
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -87,7 +89,7 @@ import org.hdhmc.saki.domain.model.SoundBalancingMode
 import org.hdhmc.saki.domain.model.STREAM_CACHE_SIZE_STEP_MB
 import org.hdhmc.saki.domain.model.StreamQuality
 import org.hdhmc.saki.domain.model.TextScale
-import org.hdhmc.saki.presentation.SakiAppUiState
+import org.hdhmc.saki.presentation.SakiSettingsUiState
 import org.hdhmc.saki.presentation.labelRes
 import org.hdhmc.saki.presentation.library.ArtworkCard
 import org.hdhmc.saki.presentation.library.THUMBNAIL_COVER_ART_SIZE_PX
@@ -96,16 +98,16 @@ import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.ui.theme.SakiChromeIconButton
 import org.hdhmc.saki.ui.theme.SakiThemePresets
-import org.hdhmc.saki.ui.theme.rememberSakiExpressiveColorScheme
 import org.hdhmc.saki.ui.theme.sakiCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiSelectedContainerColor
 import org.hdhmc.saki.ui.theme.sakiTonalContainerColor
+import com.materialkolor.hct.Hct
 import java.util.Locale
 import kotlin.math.roundToInt
 
 @Composable
 fun SettingsScreen(
-    uiState: SakiAppUiState,
+    uiState: SakiSettingsUiState,
     contentPadding: PaddingValues,
     bottomOverlayPadding: Dp = 0.dp,
     onClose: () -> Unit,
@@ -143,15 +145,17 @@ fun SettingsScreen(
 ) {
     val background = rememberBrowseBackgroundBrush()
     val selectedServer = uiState.servers.firstOrNull { it.id == uiState.selectedServerId }
-    val visibleCachedSongs = uiState.cachedSongs.filter { song ->
-        uiState.selectedServerId == null || song.serverId == uiState.selectedServerId
+    val visibleCachedSongs = remember(uiState.cachedSongs, uiState.selectedServerId) {
+        uiState.cachedSongs.filter { song ->
+            uiState.selectedServerId == null || song.serverId == uiState.selectedServerId
+        }
     }
     val storageSummary = uiState.cacheStorageSummary
-    val configuredStreamCacheSizeMb = uiState.playbackState.preferences.streamCacheSizeMb
+    val configuredStreamCacheSizeMb = uiState.playbackPreferences.streamCacheSizeMb
     var streamCacheSliderValue by remember(configuredStreamCacheSizeMb) {
         mutableFloatStateOf(configuredStreamCacheSizeMb.toFloat())
     }
-    val configuredImageCacheSizeMb = uiState.playbackState.preferences.imageCacheSizeMb
+    val configuredImageCacheSizeMb = uiState.playbackPreferences.imageCacheSizeMb
     var imageCacheSliderValue by remember(configuredImageCacheSizeMb) {
         mutableFloatStateOf(configuredImageCacheSizeMb.toFloat())
     }
@@ -232,7 +236,7 @@ fun SettingsScreen(
         }
 
         item {
-            val prefs = uiState.playbackState.preferences
+            val prefs = uiState.playbackPreferences
             SettingsSectionCard(
                 title = stringResource(R.string.settings_stream_quality_title),
                 body = stringResource(R.string.settings_stream_quality_body),
@@ -305,7 +309,7 @@ fun SettingsScreen(
                 ) {
                     SoundBalancingMode.entries.forEach { mode ->
                         FilterChip(
-                            selected = uiState.playbackState.preferences.soundBalancingMode == mode,
+                            selected = uiState.playbackPreferences.soundBalancingMode == mode,
                             onClick = { onUpdateSoundBalancing(mode) },
                             label = { Text(mode.localizedLabel()) },
                         )
@@ -315,7 +319,7 @@ fun SettingsScreen(
         }
 
         item {
-            val prefs = uiState.playbackState.preferences
+            val prefs = uiState.playbackPreferences
             val configuredSeconds = prefs.customBufferSeconds
             var bufferSliderValue by remember(configuredSeconds) {
                 mutableFloatStateOf(configuredSeconds.toFloat())
@@ -531,6 +535,15 @@ fun SettingsScreen(
                     // Preview follows the current light/dark mode and uses the container roles, so the
                     // swatches stay pleasant pastels in light and deep tones in dark (KSU-style).
                     val previewDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
+                    val swatchColors = remember(previewDark, currentPaletteStyle) {
+                        SakiThemePresets.associate { preset ->
+                            preset.key to themeSeedSwatchColors(
+                                seed = preset.seed,
+                                isDark = previewDark,
+                                paletteStyle = currentPaletteStyle,
+                            )
+                        }
+                    }
                     Text(
                         text = stringResource(R.string.settings_theme_seed_label),
                         style = MaterialTheme.typography.labelLarge,
@@ -543,18 +556,7 @@ fun SettingsScreen(
                         SakiThemePresets.forEach { preset ->
                             val selected = preset.key == currentSeedKey
                             val presetName = stringResource(preset.nameRes)
-                            // Preview the actual generated pairing (top = primary, bottom = secondary)
-                            // under the active palette style, so the theme's two tones read at a glance.
-                            val previewScheme = rememberSakiExpressiveColorScheme(
-                                seedColor = preset.seed,
-                                isDark = previewDark,
-                                paletteStyle = currentPaletteStyle,
-                            )
-                            // Pick tonally balanced roles per mode so both halves read as similar
-                            // lightness (containers are pale + balanced in light; in dark the accent
-                            // pair stays balanced whereas SPEC_2025 Expressive containers go extreme).
-                            val topColor = if (previewDark) previewScheme.primary else previewScheme.primaryContainer
-                            val bottomColor = if (previewDark) previewScheme.secondary else previewScheme.secondaryContainer
+                            val colors = swatchColors.getValue(preset.key)
                             Box(
                                 modifier = Modifier
                                     .size(44.dp)
@@ -576,8 +578,8 @@ fun SettingsScreen(
                                     .semantics { contentDescription = presetName },
                             ) {
                                 Canvas(modifier = Modifier.fillMaxSize()) {
-                                    drawArc(color = topColor, startAngle = 180f, sweepAngle = 180f, useCenter = true)
-                                    drawArc(color = bottomColor, startAngle = 0f, sweepAngle = 180f, useCenter = true)
+                                    drawArc(color = colors.top, startAngle = 180f, sweepAngle = 180f, useCenter = true)
+                                    drawArc(color = colors.bottom, startAngle = 0f, sweepAngle = 180f, useCenter = true)
                                 }
                             }
                         }
@@ -878,7 +880,7 @@ fun SettingsScreen(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    val currentDownloadQuality = uiState.playbackState.preferences.downloadQuality
+                    val currentDownloadQuality = uiState.playbackPreferences.downloadQuality
                     StreamQuality.entries.forEach { quality ->
                         FilterChip(
                             selected = currentDownloadQuality == quality,
@@ -933,7 +935,7 @@ fun SettingsScreen(
                 body = stringResource(R.string.settings_experimental_body),
                 action = null,
             ) {
-                val checked = uiState.playbackState.preferences.bluetoothLyricsEnabled
+                val checked = uiState.playbackPreferences.bluetoothLyricsEnabled
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -1202,6 +1204,36 @@ private fun formatStorageSize(bytes: Long): String {
     } else {
         String.format(Locale.getDefault(), "%.1f %s", value, units[unitIndex])
     }
+}
+
+private data class ThemeSeedSwatchColors(
+    val top: Color,
+    val bottom: Color,
+)
+
+private fun themeSeedSwatchColors(
+    seed: Color,
+    isDark: Boolean,
+    paletteStyle: SakiPaletteStyle,
+): ThemeSeedSwatchColors {
+    val hct = Hct.fromInt(seed.toArgb())
+    val hueShift = when (paletteStyle) {
+        SakiPaletteStyle.TONAL_SPOT -> 24.0
+        SakiPaletteStyle.VIBRANT -> 36.0
+        SakiPaletteStyle.EXPRESSIVE -> 58.0
+    }
+    val primaryTone = if (isDark) 70.0 else 88.0
+    val secondaryTone = if (isDark) 62.0 else 92.0
+    val primaryChroma = (hct.chroma * 0.70).coerceIn(18.0, if (isDark) 42.0 else 32.0)
+    val secondaryChroma = (hct.chroma * when (paletteStyle) {
+        SakiPaletteStyle.TONAL_SPOT -> 0.42
+        SakiPaletteStyle.VIBRANT -> 0.58
+        SakiPaletteStyle.EXPRESSIVE -> 0.70
+    }).coerceIn(12.0, if (isDark) 34.0 else 26.0)
+    return ThemeSeedSwatchColors(
+        top = Color(Hct.from(hct.hue, primaryChroma, primaryTone).toInt()),
+        bottom = Color(Hct.from((hct.hue + hueShift) % 360.0, secondaryChroma, secondaryTone).toInt()),
+    )
 }
 
 private const val STREAM_CACHE_SLIDER_STEPS =


### PR DESCRIPTION
## Summary
- Split the root Compose UI state into route-specific state flows so playback/cache ticks do not recompose the entire app shell.
- Keep Now Playing progress and lyrics progress collection scoped to the local UI subtree.
- Delay expensive stream/image cache summary work and avoid full playback state sync on lyric seeks.
- Stabilize karaoke lyric highlighting so sampled player progress does not make line progress jump backward.

## Validation
- `/usr/bin/git diff --check`
- `./gradlew assembleDebug -q`

## Notes
- This targets the observed low-power-mode/UI jank around settings scrolling, lyric panel interactions, and frequent playback progress updates.