### PR TITLE
ci: add release build configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    env:
+      HAS_RELEASE_SIGNING: ${{ secrets.SAKI_RELEASE_KEYSTORE_BASE64 != '' && secrets.SAKI_RELEASE_STORE_PASSWORD != '' && secrets.SAKI_RELEASE_KEY_ALIAS != '' && secrets.SAKI_RELEASE_KEY_PASSWORD != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +51,21 @@ jobs:
       - name: Build debug
         run: ./gradlew assembleDebug --no-daemon
 
+      - name: Prepare release signing
+        if: env.HAS_RELEASE_SIGNING == 'true'
+        env:
+          SAKI_RELEASE_KEYSTORE_BASE64: ${{ secrets.SAKI_RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          printf '%s' "$SAKI_RELEASE_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/saki-release.jks"
+
+      - name: Build release
+        env:
+          SAKI_RELEASE_STORE_FILE: ${{ runner.temp }}/saki-release.jks
+          SAKI_RELEASE_STORE_PASSWORD: ${{ secrets.SAKI_RELEASE_STORE_PASSWORD }}
+          SAKI_RELEASE_KEY_ALIAS: ${{ secrets.SAKI_RELEASE_KEY_ALIAS }}
+          SAKI_RELEASE_KEY_PASSWORD: ${{ secrets.SAKI_RELEASE_KEY_PASSWORD }}
+        run: ./gradlew assembleRelease --no-daemon
+
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest --no-daemon
 
@@ -58,5 +75,14 @@ jobs:
         with:
           name: app-debug
           path: app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload release APK
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: app/build/outputs/apk/release/*.apk
           if-no-files-found: error
           retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ local.properties
 scripts/setup-env.sh
 scripts/deploy.sh
 deploy.sh
+*.jks
 
 # Kiro AI workspace config
 .kiro/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,58 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.room)
+}
+
+val localProperties = Properties().apply {
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.isFile) {
+        localPropertiesFile.inputStream().use(::load)
+    }
+}
+
+fun localProperty(name: String): String? =
+    localProperties.getProperty(name)?.takeIf { it.isNotBlank() }
+
+fun releaseProperty(localName: String, environmentName: String): String? =
+    localProperty(localName) ?: providers.environmentVariable(environmentName).orNull
+        ?.takeIf { it.isNotBlank() }
+
+val releaseStoreFile = releaseProperty("releaseStoreFile", "SAKI_RELEASE_STORE_FILE")
+val releaseStorePassword = releaseProperty("releaseStorePassword", "SAKI_RELEASE_STORE_PASSWORD")
+val releaseKeyAlias = releaseProperty("releaseKeyAlias", "SAKI_RELEASE_KEY_ALIAS")
+val releaseKeyPassword = releaseProperty("releaseKeyPassword", "SAKI_RELEASE_KEY_PASSWORD")
+
+val hasReleaseSigningProperties = listOf(
+    releaseStoreFile,
+    releaseStorePassword,
+    releaseKeyAlias,
+    releaseKeyPassword,
+).all { it != null }
+
+val sakiVersionName = providers.gradleProperty("saki.versionName")
+    .orElse("0.1.0")
+    .get()
+
+fun versionCodeFromName(versionName: String): Int {
+    val versionCore = versionName.substringBefore('-').substringBefore('+')
+    val parts = versionCore.split('.')
+    require(parts.size == 3) {
+        "saki.versionName must use MAJOR.MINOR.PATCH, but was '$versionName'"
+    }
+    val (major, minor, patch) = parts.mapIndexed { index, part ->
+        part.toIntOrNull() ?: error(
+            "saki.versionName component ${index + 1} must be numeric, but was '$versionName'"
+        )
+    }
+    require(major >= 0) { "saki.versionName major must be >= 0, but was '$versionName'" }
+    require(minor in 0..99) { "saki.versionName minor must be 0..99, but was '$versionName'" }
+    require(patch in 0..99) { "saki.versionName patch must be 0..99, but was '$versionName'" }
+    return major * 10_000 + minor * 100 + patch
 }
 
 android {
@@ -16,15 +65,30 @@ android {
         applicationId = "org.hdhmc.saki"
         minSdk = 24
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = versionCodeFromName(sakiVersionName)
+        versionName = sakiVersionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        if (hasReleaseSigningProperties) {
+            create("release") {
+                storeFile = rootProject.file(releaseStoreFile!!)
+                storePassword = releaseStorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            if (hasReleaseSigningProperties) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,84 @@
+# Release build and versioning
+
+## Version rules
+
+Saki.Android uses stable SemVer for `versionName`:
+
+```text
+MAJOR.MINOR.PATCH
+```
+
+The source of truth is `saki.versionName` in `gradle.properties`.
+
+Android `versionCode` is derived automatically from `versionName`:
+
+```text
+versionCode = MAJOR * 10000 + MINOR * 100 + PATCH
+```
+
+Examples:
+
+| versionName | versionCode |
+| --- | ---: |
+| `0.1.0` | `100` |
+| `0.1.1` | `101` |
+| `1.0.0` | `10000` |
+| `1.1.0` | `10100` |
+| `2.0.0` | `20000` |
+
+Constraints:
+
+- `versionName` must contain exactly three numeric components.
+- `MINOR` and `PATCH` must be in `0..99`.
+- Never decrease `versionName`; the derived `versionCode` must stay monotonically increasing for Android updates.
+- Bump `PATCH` for fixes, `MINOR` for user-visible feature batches, and `MAJOR` for compatibility-breaking releases or major product milestones.
+
+## Local signed release
+
+Release signing is intentionally local-only. Put these keys in `local.properties`:
+
+```properties
+releaseStoreFile=/absolute/or/project-relative/path/to/release.jks
+releaseStorePassword=...
+releaseKeyAlias=...
+releaseKeyPassword=...
+```
+
+When all four properties are present, `assembleRelease` produces a signed APK:
+
+```bash
+./gradlew clean assembleRelease
+```
+
+Output:
+
+```text
+app/build/outputs/apk/release/app-release.apk
+```
+
+Keystores (`*.jks`) must not be committed.
+
+## CI release build
+
+CI runs `assembleDebug`, `assembleRelease`, and unit tests for code changes.
+
+To produce signed release APK artifacts in CI, configure these repository secrets:
+
+| Secret | Description |
+| --- | --- |
+| `SAKI_RELEASE_KEYSTORE_BASE64` | Base64-encoded release keystore file. |
+| `SAKI_RELEASE_STORE_PASSWORD` | Keystore password. |
+| `SAKI_RELEASE_KEY_ALIAS` | Release key alias. |
+| `SAKI_RELEASE_KEY_PASSWORD` | Release key password. |
+
+Create the keystore secret from a local keystore without committing the file:
+
+```bash
+base64 -w0 release.jks
+```
+
+CI writes the decoded keystore to the runner temporary directory and passes its path to Gradle through `SAKI_RELEASE_STORE_FILE`.
+
+If any signing secret is missing, CI still runs `assembleRelease`, but the artifact is unsigned. This keeps pull request validation working without exposing signing credentials.
+
+On pushes to `master`, CI uploads both debug and release APK artifacts.

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ org.gradle.parallel=true
 kotlin.code.style=official
 # Hilt 2.57.1 still relies on legacy AGP DSL types on AGP 9.x.
 android.newDsl=false
+# Release version. Keep MAJOR.MINOR.PATCH; Android versionCode is derived as
+# MAJOR * 10000 + MINOR * 100 + PATCH.
+saki.versionName=0.1.0


### PR DESCRIPTION
## Summary
- Add release signing configuration from local.properties or CI environment variables.
- Enable R8 minify and resource shrinking for release builds.
- Add SemVer-based versionName/versionCode rules with 0.1.0 as the initial pre-release version.
- Build release APKs in CI and upload release artifacts on master pushes.
- Document local and CI signing setup in docs/release.md.

## Validation
- `/usr/bin/git diff --check`
- `./gradlew clean assembleRelease assembleDebug testDebugUnitTest -q`
- `./gradlew assembleRelease -q`
- Verified local release APK with apksigner and aapt: versionName=0.1.0, versionCode=100, signed with v2 scheme.

## Notes
- CI release signing requires repository secrets: `SAKI_RELEASE_KEYSTORE_BASE64`, `SAKI_RELEASE_STORE_PASSWORD`, `SAKI_RELEASE_KEY_ALIAS`, `SAKI_RELEASE_KEY_PASSWORD`.
- Without secrets, CI still validates an unsigned R8/resource-shrunk release build.