### PR TITLE
fix: filter artist detail album relationships

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
@@ -116,7 +116,19 @@ interface LibraryCacheDao {
         SELECT
             artist.artistId AS artistId,
             MIN(artist.name) AS name,
-            COUNT(DISTINCT song.albumId) AS albumCount,
+            COUNT(DISTINCT CASE
+                WHEN song.albumId IS NULL THEN NULL
+                WHEN LOWER(TRIM(REPLACE(REPLACE(song.album, '[', ''), ']', ''))) = 'unknown album'
+                    AND (
+                        (song.artistId IS NOT NULL AND song.artistId != artist.artistId)
+                        OR (
+                            song.artistId IS NULL
+                            AND song.artist IS NOT NULL
+                            AND LOWER(TRIM(song.artist)) != LOWER(TRIM(artist.name))
+                        )
+                    ) THEN NULL
+                ELSE song.albumId
+            END) AS albumCount,
             MIN(song.coverArtId) AS coverArtId
         FROM cached_song_artists AS artist
         LEFT JOIN cached_song_metadata AS song
@@ -215,6 +227,9 @@ interface LibraryCacheDao {
 
     @Query("SELECT * FROM cached_artist_detail_albums WHERE serverId = :serverId AND artistId = :artistId ORDER BY sortOrder")
     suspend fun getArtistDetailAlbums(serverId: Long, artistId: String): List<CachedArtistDetailAlbumEntity>
+
+    @Query("SELECT * FROM cached_artist_detail_albums WHERE serverId = :serverId ORDER BY artistId, sortOrder")
+    suspend fun getAllArtistDetailAlbums(serverId: Long): List<CachedArtistDetailAlbumEntity>
 
     @Query("SELECT * FROM cached_artist_detail_songs WHERE serverId = :serverId AND artistId = :artistId ORDER BY sortOrder")
     suspend fun getArtistDetailSongs(serverId: Long, artistId: String): List<CachedArtistDetailSongEntity>

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -27,12 +27,16 @@ import org.hdhmc.saki.domain.model.Artist
 import org.hdhmc.saki.domain.model.ArtistRef
 import org.hdhmc.saki.domain.model.ArtistSection
 import org.hdhmc.saki.domain.model.ArtistSummary
+import org.hdhmc.saki.domain.model.belongsToArtist
+import org.hdhmc.saki.domain.model.belongsToArtistInAlbum
 import org.hdhmc.saki.domain.model.CachedArtistDetail
 import org.hdhmc.saki.domain.model.LibraryIndexes
 import org.hdhmc.saki.domain.model.Playlist
 import org.hdhmc.saki.domain.model.PlaylistSummary
 import org.hdhmc.saki.domain.model.SearchResults
 import org.hdhmc.saki.domain.model.Song
+import org.hdhmc.saki.domain.model.visibleDetailAlbums
+import org.hdhmc.saki.domain.model.withVisibleDetailAlbums
 import org.hdhmc.saki.domain.repository.LibraryCacheRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -52,10 +56,15 @@ class DefaultLibraryCacheRepository @Inject constructor(
         val entities = dao.getArtists(serverId)
         val songArtistSummaries = dao.getSongArtistSummaries(serverId)
         if (entities.isEmpty() && songArtistSummaries.isEmpty()) return@withContext null
+        val detailAlbumsByArtistId = dao.getAllArtistDetailAlbums(serverId)
+            .groupBy { it.artistId }
+            .mapValues { (_, albums) -> albums.map { it.toDomain() } }
         val artists = mergeArtistSummaries(
             serverArtists = entities.map { it.toDomain() },
             songArtists = songArtistSummaries.map { it.toDomain() },
-        )
+        ).map { artist ->
+            artist.withDetailAlbumCount(detailAlbumsByArtistId[artist.id].orEmpty())
+        }
         LibraryIndexes(
             lastModified = null,
             ignoredArticles = null,
@@ -244,13 +253,13 @@ class DefaultLibraryCacheRepository @Inject constructor(
     ): CachedArtistDetail? = withContext(ioDispatcher) {
         val detail = dao.getArtistDetail(serverId, artistId)
         if (detail != null) {
-            val albums = dao.getArtistDetailAlbums(serverId, artistId).map { it.toDomain() }
+            val rawAlbums = dao.getArtistDetailAlbums(serverId, artistId).map { it.toDomain() }
             val topSongRefs = dao.getArtistDetailSongs(serverId, artistId)
             val topSongs = resolveSongs(serverId, topSongRefs.map { it.songId })
             val relationshipSongs = resolveSongsByArtistId(serverId, artistId)
             val songArtistSummary = dao.getSongArtistSummaries(serverId)
                 .firstOrNull { it.artistId == artistId }
-            val artist = detail.toDomain(albums).let { cachedArtist ->
+            val artist = detail.toDomain(rawAlbums).let { cachedArtist ->
                 songArtistSummary?.let { summary ->
                     cachedArtist.copy(
                         name = summary.name,
@@ -258,10 +267,19 @@ class DefaultLibraryCacheRepository @Inject constructor(
                         albumCount = cachedArtist.albumCount ?: summary.albumCount.takeIf { it > 0 },
                     )
                 } ?: cachedArtist
+            }.withVisibleDetailAlbums()
+            val albumsById = rawAlbums.associateBy(AlbumSummary::id)
+            val filteredTopSongs = topSongs.filter { song ->
+                val album = song.albumId?.let(albumsById::get)
+                if (album != null) {
+                    song.belongsToArtistInAlbum(artist, album)
+                } else {
+                    song.belongsToArtist(artist)
+                }
             }
             return@withContext CachedArtistDetail(
                 artist = artist,
-                songs = mergeSongs(topSongs, relationshipSongs),
+                songs = mergeSongs(filteredTopSongs, relationshipSongs),
                 songsAreTopSongs = relationshipSongs.isEmpty(),
             )
         }
@@ -372,9 +390,24 @@ class DefaultLibraryCacheRepository @Inject constructor(
         serverArtists: List<ArtistSummary>,
         songArtists: List<ArtistSummary>,
     ): List<ArtistSummary> {
-        return (songArtists + serverArtists)
+        // Keep the server artist index as authoritative; song-derived summaries only fill artists
+        // that are absent from getArtists/getIndexes.
+        return (serverArtists + songArtists)
             .distinctBy(ArtistSummary::id)
             .sortedBy { it.name.lowercase() }
+    }
+
+    private fun ArtistSummary.withDetailAlbumCount(albums: List<AlbumSummary>): ArtistSummary {
+        if (albums.isEmpty()) return this
+        val visibleAlbumCount = Artist(
+            id = id,
+            name = name,
+            coverArtId = coverArtId,
+            artistImageUrl = artistImageUrl,
+            albumCount = albumCount,
+            albums = albums,
+        ).visibleDetailAlbums().size
+        return copy(albumCount = visibleAlbumCount)
     }
 
     private fun CachedAlbumEntity.toDomain() = AlbumSummary(
@@ -535,7 +568,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
         val summary = dao.getArtistSummary(serverId, artistId)
         val songArtistSummary = dao.getSongArtistSummaries(serverId)
             .firstOrNull { it.artistId == artistId }
-        val artist = summary?.toDomain(albums) ?: Artist(
+        val artist = (summary?.toDomain(albums) ?: Artist(
             id = artistId,
             name = songArtistSummary?.name ?: songs.firstOrNull()?.artist ?: albums.firstOrNull()?.artist ?: artistId,
             coverArtId = songArtistSummary?.coverArtId
@@ -544,7 +577,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
             artistImageUrl = null,
             albumCount = songArtistSummary?.albumCount?.takeIf { it > 0 } ?: albums.size.takeIf { it > 0 },
             albums = albums,
-        )
+        )).withVisibleDetailAlbums()
         return CachedArtistDetail(
             artist = artist,
             songs = songs,

--- a/app/src/main/java/org/hdhmc/saki/domain/model/ArtistMatching.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/ArtistMatching.kt
@@ -1,0 +1,142 @@
+package org.hdhmc.saki.domain.model
+
+internal fun Song.belongsToArtist(artist: Artist): Boolean {
+    return belongsToArtist(artist.id, artist.name)
+}
+
+internal fun Song.belongsToArtistInAlbum(artist: Artist, album: Album): Boolean {
+    if (hasArtistIdentity()) return belongsToArtist(artist)
+    return album.isVisibleInArtistDetail(artist) && (!album.hasArtistIdentity() || album.belongsToArtist(artist))
+}
+
+internal fun Song.belongsToArtistInAlbum(artist: Artist, album: AlbumSummary): Boolean {
+    if (hasArtistIdentity()) return belongsToArtist(artist)
+    return album.isVisibleInArtistDetail(artist) && (!album.hasArtistIdentity() || album.belongsToArtist(artist))
+}
+
+internal fun Artist.withVisibleDetailAlbums(): Artist {
+    val visibleAlbums = visibleDetailAlbums()
+    return copy(
+        albums = visibleAlbums,
+        albumCount = when {
+            albumCount != null -> visibleAlbums.size
+            visibleAlbums.isNotEmpty() -> visibleAlbums.size
+            else -> null
+        },
+    )
+}
+
+internal fun Artist.visibleDetailAlbums(): List<AlbumSummary> {
+    return albums.filter { album -> album.isVisibleInArtistDetail(this) }
+}
+
+internal fun AlbumSummary.isVisibleInArtistDetail(artist: Artist): Boolean {
+    return !hasUnknownAlbumName() || !hasPrimaryArtistMismatch(artist)
+}
+
+private fun Album.isVisibleInArtistDetail(artist: Artist): Boolean {
+    return !hasUnknownAlbumName() || !hasPrimaryArtistMismatch(artist)
+}
+
+private fun Song.belongsToArtist(targetId: String, targetName: String?): Boolean {
+    val cleanTargetId = targetId.takeIf(String::isNotBlank)
+    if (cleanTargetId != null) {
+        if (artistId == cleanTargetId) return true
+        if (artists.any { it.id == cleanTargetId }) return true
+    }
+
+    val targetNames = targetName.nameParts()
+    if (targetNames.isEmpty()) return false
+    return artist.nameParts().matchesAny(targetNames) || artists.any { it.name.nameParts().matchesAny(targetNames) }
+}
+
+private fun Album.belongsToArtist(artist: Artist): Boolean {
+    return belongsToArtist(artist.id, artist.name)
+}
+
+private fun AlbumSummary.belongsToArtist(artist: Artist): Boolean {
+    return belongsToArtist(artist.id, artist.name)
+}
+
+private fun Album.belongsToArtist(targetId: String, targetName: String?): Boolean {
+    val cleanTargetId = targetId.takeIf(String::isNotBlank)
+    if (cleanTargetId != null) {
+        if (artistId == cleanTargetId) return true
+        if (artists.any { it.id == cleanTargetId }) return true
+    }
+
+    val targetNames = targetName.nameParts()
+    if (targetNames.isEmpty()) return false
+    return artist.nameParts().matchesAny(targetNames) || artists.any { it.name.nameParts().matchesAny(targetNames) }
+}
+
+private fun AlbumSummary.belongsToArtist(targetId: String, targetName: String?): Boolean {
+    val cleanTargetId = targetId.takeIf(String::isNotBlank)
+    if (cleanTargetId != null) {
+        if (artistId == cleanTargetId) return true
+        if (artists.any { it.id == cleanTargetId }) return true
+    }
+
+    val targetNames = targetName.nameParts()
+    if (targetNames.isEmpty()) return false
+    return artist.nameParts().matchesAny(targetNames) || artists.any { it.name.nameParts().matchesAny(targetNames) }
+}
+
+private fun Album.hasPrimaryArtistMismatch(artist: Artist): Boolean {
+    val targetId = artist.id.takeIf(String::isNotBlank)
+    if (targetId != null && !artistId.isNullOrBlank()) return artistId != targetId
+
+    val targetNames = artist.name.nameParts()
+    if (targetNames.isNotEmpty() && !this.artist.isNullOrBlank()) {
+        return !this.artist.nameParts().matchesAny(targetNames)
+    }
+    return false
+}
+
+private fun AlbumSummary.hasPrimaryArtistMismatch(artist: Artist): Boolean {
+    val targetId = artist.id.takeIf(String::isNotBlank)
+    if (targetId != null && !artistId.isNullOrBlank()) return artistId != targetId
+
+    val targetNames = artist.name.nameParts()
+    if (targetNames.isNotEmpty() && !this.artist.isNullOrBlank()) {
+        return !this.artist.nameParts().matchesAny(targetNames)
+    }
+    return false
+}
+
+private fun Album.hasUnknownAlbumName(): Boolean {
+    return name.isUnknownAlbumName()
+}
+
+private fun AlbumSummary.hasUnknownAlbumName(): Boolean {
+    return name.isUnknownAlbumName()
+}
+
+private fun Song.hasArtistIdentity(): Boolean {
+    return !artistId.isNullOrBlank() || !artist.isNullOrBlank() || artists.any { it.id.isNotBlank() || it.name.isNotBlank() }
+}
+
+private fun Album.hasArtistIdentity(): Boolean {
+    return !artistId.isNullOrBlank() || !artist.isNullOrBlank() || artists.any { it.id.isNotBlank() || it.name.isNotBlank() }
+}
+
+private fun AlbumSummary.hasArtistIdentity(): Boolean {
+    return !artistId.isNullOrBlank() || !artist.isNullOrBlank() || artists.any { it.id.isNotBlank() || it.name.isNotBlank() }
+}
+
+private fun String?.nameParts(): List<String> {
+    val normalized = this?.trim()?.takeIf(String::isNotBlank)
+    return normalized?.let(::listOf).orEmpty()
+}
+
+private fun List<String>.matchesAny(targetNames: List<String>): Boolean {
+    return any { candidate -> targetNames.any { target -> candidate.equals(target, ignoreCase = true) } }
+}
+
+private fun String.isUnknownAlbumName(): Boolean {
+    val normalized = trim()
+        .removePrefix("[")
+        .removeSuffix("]")
+        .trim()
+    return normalized.equals("Unknown Album", ignoreCase = true)
+}

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -19,6 +19,7 @@ import org.hdhmc.saki.domain.model.ThemeStyle
 import org.hdhmc.saki.domain.model.AlbumSummary
 import org.hdhmc.saki.domain.model.Artist
 import org.hdhmc.saki.domain.model.ArtistSummary
+import org.hdhmc.saki.domain.model.belongsToArtistInAlbum
 import org.hdhmc.saki.domain.model.CacheStorageSummary
 import org.hdhmc.saki.domain.model.CachedArtistDetail
 import org.hdhmc.saki.domain.model.CachedSong
@@ -41,6 +42,7 @@ import org.hdhmc.saki.domain.model.SongLyrics
 import org.hdhmc.saki.domain.model.SoundBalancingMode
 import org.hdhmc.saki.domain.model.StreamQuality
 import org.hdhmc.saki.domain.model.TextScale
+import org.hdhmc.saki.domain.model.withVisibleDetailAlbums
 import org.hdhmc.saki.domain.repository.AppPreferencesRepository
 import org.hdhmc.saki.domain.repository.CachedSongRepository
 import org.hdhmc.saki.domain.repository.LibraryCacheRepository
@@ -840,14 +842,14 @@ class SakiAppViewModel @Inject constructor(
                 val topSongs = buildArtistTopSongs(serverId, artist)
                 val relationshipDetail = libraryCacheRepository.getArtistDetail(serverId, artistId)
                 val relationshipSongs = relationshipDetail?.songs.orEmpty()
-                val displayArtist = relationshipDetail?.artist?.let { localArtist ->
+                val displayArtist = (relationshipDetail?.artist?.let { localArtist ->
                     artist.copy(
                         name = localArtist.name,
                         coverArtId = artist.coverArtId ?: localArtist.coverArtId,
                         artistImageUrl = artist.artistImageUrl ?: localArtist.artistImageUrl,
                         albumCount = artist.albumCount ?: localArtist.albumCount,
                     )
-                } ?: artist
+                } ?: artist).withVisibleDetailAlbums()
                 val songs = (topSongs + relationshipSongs).distinctBy(Song::id)
                 Triple(displayArtist, songs, false)
             }.onSuccess { (artist, songs, songsAreTopSongs) ->
@@ -2190,9 +2192,9 @@ class SakiAppViewModel @Inject constructor(
                     .map { it.await() }
             }
             .flatMap { album ->
-                album.songs.map { song ->
-                    song.withFallbackAlbumMetadata(album)
-                }
+                album.songs
+                    .filter { song -> song.belongsToArtistInAlbum(artist, album) }
+                    .map { song -> song.withFallbackAlbumMetadata(album) }
             }
             .distinctBy(Song::id)
     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -92,6 +92,7 @@ import org.hdhmc.saki.domain.model.Playlist
 import org.hdhmc.saki.domain.model.PlaylistSummary
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.Song
+import org.hdhmc.saki.domain.model.visibleDetailAlbums
 import org.hdhmc.saki.ui.theme.sakiCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiSubtleCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiTonalContainerColor
@@ -117,7 +118,12 @@ fun ArtistDetailScreen(
     isPlaying: Boolean = false,
     onBack: () -> Unit = {},
 ) {
-    val albumCount = artist.albumCount
+    val visibleAlbums = artist.visibleDetailAlbums()
+    val albumCount = when {
+        artist.albumCount != null -> visibleAlbums.size
+        visibleAlbums.isNotEmpty() -> visibleAlbums.size
+        else -> null
+    }
     if (!SakiTheme.visuals.useExpressiveSurfaceContainers) {
         LibraryDetailScaffold(
             title = artist.name,
@@ -151,7 +157,7 @@ fun ArtistDetailScreen(
                             )
                         }
                     }
-                    if (artist.albums.isNotEmpty()) {
+                    if (visibleAlbums.isNotEmpty()) {
                         item {
                             SectionTitle(
                                 stringResource(R.string.library_albums),
@@ -160,7 +166,7 @@ fun ArtistDetailScreen(
                         }
                         item {
                             LazyRow {
-                                items(artist.albums, key = { it.id }) { album ->
+                                items(visibleAlbums, key = { it.id }) { album ->
                                     AlbumMiniCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
                                 }
                             }
@@ -172,7 +178,7 @@ fun ArtistDetailScreen(
         return
     }
 
-    val heroArtwork = artist.albums.firstOrNull()?.let { resolveArtworkModel(server, it.coverArtId, null) }
+    val heroArtwork = visibleAlbums.firstOrNull()?.let { resolveArtworkModel(server, it.coverArtId, null) }
         ?: songs.firstOrNull()?.let { resolveArtworkModel(server, it.coverArtId, cachedSongsBySongId[it.id]) }
     val accent = animateColorAsState(
         rememberArtworkAccentColor(
@@ -227,7 +233,7 @@ fun ArtistDetailScreen(
                         )
                     }
                 }
-                if (artist.albums.isNotEmpty()) {
+                if (visibleAlbums.isNotEmpty()) {
                     item {
                         SectionTitle(
                             stringResource(R.string.library_albums),
@@ -236,7 +242,7 @@ fun ArtistDetailScreen(
                     }
                     item {
                         LazyRow {
-                            items(artist.albums, key = { it.id }) { album ->
+                            items(visibleAlbums, key = { it.id }) { album ->
                                 AlbumMiniCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
                             }
                         }

--- a/app/src/test/java/org/hdhmc/saki/domain/model/ArtistMatchingTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/domain/model/ArtistMatchingTest.kt
@@ -1,0 +1,195 @@
+package org.hdhmc.saki.domain.model
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArtistMatchingTest {
+    private val yanhe = Artist(
+        id = "yanhe",
+        name = "言和",
+        coverArtId = null,
+        artistImageUrl = null,
+        albumCount = null,
+        albums = emptyList(),
+    )
+
+    private val luotianyi = ArtistRef(id = "luotianyi", name = "洛天依")
+    private val yanheRef = ArtistRef(id = "yanhe", name = "言和")
+
+    @Test
+    fun `explicit song artist wins over shared unknown album artist list`() {
+        val sharedUnknownAlbum = album(
+            artistId = "luotianyi",
+            artist = "洛天依",
+            artists = listOf(luotianyi, yanheRef),
+        )
+        val song = song(
+            artistId = "luotianyi",
+            artist = "洛天依",
+            artists = listOf(luotianyi),
+        )
+
+        assertFalse(song.belongsToArtistInAlbum(yanhe, sharedUnknownAlbum))
+    }
+
+    @Test
+    fun `multi artist song is included when target artist is in song artists`() {
+        val sharedUnknownAlbum = album(
+            artistId = "luotianyi",
+            artist = "洛天依",
+            artists = listOf(luotianyi, yanheRef),
+        )
+        val song = song(
+            artistId = "luotianyi",
+            artist = "洛天依 • 言和",
+            artists = listOf(luotianyi, yanheRef),
+        )
+
+        assertTrue(song.belongsToArtistInAlbum(yanhe, sharedUnknownAlbum))
+    }
+
+    @Test
+    fun `song without artist metadata falls back to album artist`() {
+        val yanheAlbum = album(
+            artistId = "yanhe",
+            artist = "言和",
+            artists = listOf(yanheRef),
+        )
+        val song = song(
+            artistId = null,
+            artist = null,
+            artists = emptyList(),
+        )
+
+        assertTrue(song.belongsToArtistInAlbum(yanhe, yanheAlbum))
+    }
+
+    @Test
+    fun `name fallback does not split slash ampersand or comma inside artist names`() {
+        val acdc = yanhe.copy(id = "acdc", name = "AC/DC")
+        val earthWindAndFire = yanhe.copy(id = "ewf", name = "Earth, Wind & Fire")
+        val nightcord = yanhe.copy(id = "nightcord", name = "25時、ナイトコードで。")
+
+        assertTrue(song(artistId = null, artist = "AC/DC", artists = emptyList()).belongsToArtist(acdc))
+        assertTrue(song(artistId = null, artist = "Earth, Wind & Fire", artists = emptyList()).belongsToArtist(earthWindAndFire))
+        assertTrue(song(artistId = null, artist = "25時、ナイトコードで。", artists = emptyList()).belongsToArtist(nightcord))
+        assertFalse(song(artistId = null, artist = "AC", artists = emptyList()).belongsToArtist(acdc))
+        assertFalse(song(artistId = null, artist = "Earth", artists = emptyList()).belongsToArtist(earthWindAndFire))
+        assertFalse(song(artistId = null, artist = "25時", artists = emptyList()).belongsToArtist(nightcord))
+    }
+
+    @Test
+    fun `name fallback does not split collaboration strings in the client`() {
+        val song = song(
+            artistId = null,
+            artist = "洛天依 • 言和",
+            artists = emptyList(),
+        )
+
+        assertFalse(song.belongsToArtist(yanhe))
+    }
+
+    @Test
+    fun `artist detail hides unknown album bucket owned by another primary artist`() {
+        val luotianyiUnknownAlbum = albumSummary(
+            id = "unknown-luotianyi",
+            name = "[Unknown Album]",
+            artistId = "luotianyi",
+            artist = "洛天依",
+            artists = listOf(luotianyi, yanheRef),
+        )
+        val yanheUnknownAlbum = albumSummary(
+            id = "unknown-yanhe",
+            name = "[Unknown Album]",
+            artistId = "yanhe",
+            artist = "言和",
+            artists = listOf(yanheRef),
+        )
+        val collaborationAlbum = albumSummary(
+            id = "collaboration",
+            name = "人·間",
+            artistId = "xinhua",
+            artist = "心华",
+            artists = listOf(ArtistRef(id = "xinhua", name = "心华"), yanheRef),
+        )
+        val artist = yanhe.copy(
+            albumCount = 3,
+            albums = listOf(luotianyiUnknownAlbum, yanheUnknownAlbum, collaborationAlbum),
+        )
+
+        val normalizedArtist = artist.withVisibleDetailAlbums()
+
+        assertTrue(normalizedArtist.albums.any { it.id == "unknown-yanhe" })
+        assertTrue(normalizedArtist.albums.any { it.id == "collaboration" })
+        assertFalse(normalizedArtist.albums.any { it.id == "unknown-luotianyi" })
+        assertTrue(normalizedArtist.albumCount == 2)
+    }
+
+    private fun album(
+        artistId: String?,
+        artist: String?,
+        artists: List<ArtistRef>,
+    ) = Album(
+        id = "unknown-album",
+        name = "[Unknown Album]",
+        artist = artist,
+        artistId = artistId,
+        artists = artists,
+        coverArtId = null,
+        songCount = null,
+        durationSeconds = null,
+        year = null,
+        genre = null,
+        created = null,
+        songs = emptyList(),
+    )
+
+    private fun albumSummary(
+        id: String,
+        name: String,
+        artistId: String?,
+        artist: String?,
+        artists: List<ArtistRef>,
+    ) = AlbumSummary(
+        id = id,
+        name = name,
+        artist = artist,
+        artistId = artistId,
+        artists = artists,
+        coverArtId = null,
+        songCount = null,
+        durationSeconds = null,
+        year = null,
+        genre = null,
+        created = null,
+    )
+
+    private fun song(
+        artistId: String?,
+        artist: String?,
+        artists: List<ArtistRef>,
+    ) = Song(
+        id = "song",
+        parentId = null,
+        title = "Song",
+        album = "[Unknown Album]",
+        albumId = "unknown-album",
+        artist = artist,
+        artistId = artistId,
+        artists = artists,
+        coverArtId = null,
+        durationSeconds = null,
+        track = null,
+        discNumber = null,
+        year = null,
+        genre = null,
+        bitRate = null,
+        sampleRate = null,
+        suffix = null,
+        contentType = null,
+        sizeBytes = null,
+        path = null,
+        created = null,
+    )
+}


### PR DESCRIPTION
## Summary
- Add shared artist/album/song matching helpers for artist detail filtering.
- Filter artist detail top songs and visible albums so shared `[Unknown Album]` buckets do not leak unrelated songs into the current artist.
- Align artist list album counts with filtered artist detail albums when cached detail data is available.
- Add focused unit coverage for explicit artist identity, multi-artist songs, fallback album matching, and hidden unrelated Unknown Album buckets.

## Validation
- `./gradlew testDebugUnitTest --tests org.hdhmc.saki.domain.model.ArtistMatchingTest --no-daemon`
- `./gradlew assembleDebug --no-daemon`
- `./gradlew assembleRelease --no-daemon`
- Installed release APK on `10.111.111.90:34567` for manual verification