### PR TITLE
fix: prioritize Now Playing back handling

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -118,6 +118,7 @@ fun SakiApp(
                         viewModel = viewModel,
                         snackbarHostState = snackbarHostState,
                         showSettings = showSettings,
+                        showNowPlaying = showNowPlaying,
                         onShowSettingsChange = { showSettings = it },
                         onManageServers = { showServerManager = true },
                         onOpenNowPlaying = { showNowPlaying = true },
@@ -149,6 +150,7 @@ private fun RootShell(
     viewModel: SakiAppViewModel,
     snackbarHostState: SnackbarHostState,
     showSettings: Boolean,
+    showNowPlaying: Boolean,
     onShowSettingsChange: (Boolean) -> Unit,
     onManageServers: () -> Unit,
     onOpenNowPlaying: () -> Unit,
@@ -160,7 +162,7 @@ private fun RootShell(
     val capsuleOverlayPadding = with(density) { capsuleHeightPx.toDp() }
 
     val settingsBackModifier = Modifier.predictiveBackMotion(
-        enabled = showSettings,
+        enabled = showSettings && !showNowPlaying,
         onBack = { onShowSettingsChange(false) },
         targetAlpha = 0.35f,
     )
@@ -176,6 +178,7 @@ private fun RootShell(
                     viewModel = viewModel,
                     contentPadding = PaddingValues(),
                     bottomOverlayPadding = capsuleOverlayPadding,
+                    backHandlersEnabled = !showSettings && !showNowPlaying,
                     onManageServers = onManageServers,
                     onOpenSettings = { onShowSettingsChange(true) },
                 )
@@ -228,6 +231,7 @@ private fun BrowseRoute(
     viewModel: SakiAppViewModel,
     contentPadding: PaddingValues,
     bottomOverlayPadding: Dp,
+    backHandlersEnabled: Boolean,
     onManageServers: () -> Unit,
     onOpenSettings: () -> Unit,
 ) {
@@ -240,6 +244,7 @@ private fun BrowseRoute(
         isOfflineDegraded = endpointStatus.isOfflineDegraded,
         contentPadding = contentPadding,
         bottomOverlayPadding = bottomOverlayPadding,
+        backHandlersEnabled = backHandlersEnabled,
         onManageServers = onManageServers,
         onSelectBrowseSection = viewModel::selectBrowseSection,
         onSetSearchActive = viewModel::setSearchActive,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -137,6 +137,7 @@ fun BrowseScreen(
     isOfflineDegraded: Boolean,
     contentPadding: PaddingValues,
     bottomOverlayPadding: Dp = 0.dp,
+    backHandlersEnabled: Boolean = true,
     onManageServers: () -> Unit,
     onSelectBrowseSection: (BrowseSection) -> Unit,
     onSetSearchActive: (Boolean) -> Unit,
@@ -180,10 +181,10 @@ fun BrowseScreen(
     }
     val scrollState = rememberBrowseScrollState(uiState.selectedServerId)
 
-    BackHandler(enabled = uiState.browseStack.size > 1) {
+    BackHandler(enabled = backHandlersEnabled && uiState.browseStack.size > 1) {
         onPopDetail()
     }
-    BackHandler(enabled = uiState.browseStack.size <= 1 && uiState.isSearchActive) {
+    BackHandler(enabled = backHandlersEnabled && uiState.browseStack.size <= 1 && uiState.isSearchActive) {
         onSetSearchActive(false)
     }
 
@@ -226,6 +227,7 @@ fun BrowseScreen(
                                 availabilityUiStateFlow = availabilityUiStateFlow,
                                 isOfflineDegraded = isOfflineDegraded,
                                 bottomOverlayPadding = bottomOverlayPadding,
+                                backHandlersEnabled = backHandlersEnabled,
                                 onSelectBrowseSection = onSelectBrowseSection,
                                 onSetSearchActive = onSetSearchActive,
                                 onUpdateSearchQuery = onUpdateSearchQuery,
@@ -343,7 +345,7 @@ fun BrowseScreen(
                             else -> Modifier
                                 .fillMaxSize()
                                 .predictiveBackMotion(
-                                    enabled = true,
+                                    enabled = backHandlersEnabled,
                                     onBack = onPopDetail,
                                 )
                                 .background(background)
@@ -684,6 +686,7 @@ private fun BrowsePager(
     availabilityUiStateFlow: StateFlow<SakiBrowseAvailabilityUiState>,
     isOfflineDegraded: Boolean,
     bottomOverlayPadding: Dp,
+    backHandlersEnabled: Boolean,
     onSelectBrowseSection: (BrowseSection) -> Unit,
     onSetSearchActive: (Boolean) -> Unit,
     onUpdateSearchQuery: (String) -> Unit,
@@ -863,7 +866,7 @@ private fun BrowsePager(
                 modifier = Modifier
                     .fillMaxSize()
                     .predictiveBackMotion(
-                        enabled = true,
+                        enabled = backHandlersEnabled,
                         onBack = { onSetSearchActive(false) },
                         maxScaleReduction = 0.02f,
                         maxHorizontalShiftFraction = 0.12f,


### PR DESCRIPTION
## Summary
- Disable Browse detail/search back handlers while Settings or Now Playing overlays are visible.
- Disable Settings predictive back while Now Playing is stacked above it.
- Prevent underlying playlist/detail pages from consuming back before the currently visible Now Playing overlay.

## Validation
- `/usr/bin/git diff --check`
- `./gradlew assembleDebug --no-daemon`