### PR TITLE
feat: add Songs random feed as a swipeable sub-tab

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/remote/subsonic/SubsonicDtos.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/remote/subsonic/SubsonicDtos.kt
@@ -28,6 +28,7 @@ data class SubsonicResponseDto(
     val playlists: PlaylistsDto? = null,
     val playlist: PlaylistDto? = null,
     val searchResult3: SearchResult3Dto? = null,
+    val randomSongs: RandomSongsDto? = null,
     val lyricsList: LyricsListDto? = null,
     val playQueue: PlayQueueDto? = null,
 )
@@ -159,6 +160,11 @@ data class PlaylistDto(
 data class SearchResult3Dto(
     val artist: List<ArtistDto> = emptyList(),
     val album: List<AlbumDto> = emptyList(),
+    val song: List<SongDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+data class RandomSongsDto(
     val song: List<SongDto> = emptyList(),
 )
 

--- a/app/src/main/java/org/hdhmc/saki/data/remote/subsonic/SubsonicMappers.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/remote/subsonic/SubsonicMappers.kt
@@ -137,6 +137,10 @@ internal fun SubsonicResponseDto.toSearchResults(): SearchResults {
     )
 }
 
+internal fun SubsonicResponseDto.toRandomSongs(): List<Song> {
+    return randomSongs?.song.orEmpty().map(SongDto::toSong)
+}
+
 internal fun SubsonicResponseDto.toSavedPlayQueue(): SavedPlayQueue {
     val payload = playQueue ?: return SavedPlayQueue(emptyList(), null, 0)
     return SavedPlayQueue(

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultSubsonicRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultSubsonicRepository.kt
@@ -20,6 +20,7 @@ import org.hdhmc.saki.data.remote.subsonic.toPingResult
 import org.hdhmc.saki.data.remote.subsonic.toPlaylist
 import org.hdhmc.saki.data.remote.subsonic.toPlaylistSummaries
 import org.hdhmc.saki.data.remote.subsonic.toSavedPlayQueue
+import org.hdhmc.saki.data.remote.subsonic.toRandomSongs
 import org.hdhmc.saki.data.remote.subsonic.toSearchResults
 import org.hdhmc.saki.data.remote.subsonic.toSong
 import org.hdhmc.saki.di.IoDispatcher
@@ -244,6 +245,23 @@ class DefaultSubsonicRepository @Inject constructor(
             ),
         ) { response ->
             response.toSearchResults()
+        }
+    }
+
+    override suspend fun getRandomSongs(
+        serverId: Long,
+        size: Int,
+        musicFolderId: String?,
+    ): SubsonicCallResult<List<Song>> = withContext(ioDispatcher) {
+        executeWithFallback(
+            serverId = serverId,
+            path = "getRandomSongs.view",
+            extraQuery = mapOfNotNull(
+                "size" to size.coerceAtLeast(0).toString(),
+                "musicFolderId" to musicFolderId,
+            ),
+        ) { response ->
+            response.toRandomSongs()
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/domain/model/SubsonicModels.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/SubsonicModels.kt
@@ -83,6 +83,11 @@ enum class AlbumListType(val apiValue: String) {
     }
 }
 
+enum class SongFeedType {
+    DEFAULT,
+    RANDOM,
+}
+
 data class AlbumSummary(
     val id: String,
     val name: String,

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/SubsonicRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/SubsonicRepository.kt
@@ -77,6 +77,12 @@ interface SubsonicRepository {
         musicFolderId: String? = null,
     ): SubsonicCallResult<SearchResults>
 
+    suspend fun getRandomSongs(
+        serverId: Long,
+        size: Int = 50,
+        musicFolderId: String? = null,
+    ): SubsonicCallResult<List<Song>>
+
     suspend fun buildStreamRequest(
         serverId: Long,
         songId: String,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -253,6 +253,7 @@ private fun BrowseRoute(
         onClearRecentSearchQueries = viewModel::clearRecentSearchQueries,
         onRefreshCurrentTab = viewModel::refreshCurrentTab,
         onSelectAlbumFeed = viewModel::selectAlbumFeed,
+        onSelectSongFeed = viewModel::selectSongFeed,
         onLoadMoreAlbums = viewModel::loadMoreAlbums,
         onLoadPreviousSongs = viewModel::loadPreviousSongs,
         onLoadMoreSongs = viewModel::loadMoreSongs,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -796,7 +796,11 @@ class SakiAppViewModel @Inject constructor(
             BrowseSection.ARTISTS -> loadArtists(serverId, forceRefresh = true)
             BrowseSection.ALBUMS -> loadAlbums(serverId, uiState.value.selectedAlbumFeed, forceRefresh = true)
             BrowseSection.PLAYLISTS -> loadPlaylists(serverId, forceRefresh = true)
-            BrowseSection.SONGS -> loadSongs(serverId, forceRefresh = true)
+            BrowseSection.SONGS -> if (uiState.value.selectedSongFeed == SongFeedType.RANDOM) {
+                refreshRandomSongs()
+            } else {
+                loadSongs(serverId, forceRefresh = true)
+            }
         }
     }
 
@@ -1538,6 +1542,10 @@ class SakiAppViewModel @Inject constructor(
                 hasLoadedSongsFromNetwork = if (serverChanged) false else state.hasLoadedSongsFromNetwork,
                 isSongsLoadingPrevious = if (serverChanged) false else state.isSongsLoadingPrevious,
                 isSongsLoadingMore = if (serverChanged) false else state.isSongsLoadingMore,
+                selectedSongFeed = if (serverChanged) SongFeedType.DEFAULT else state.selectedSongFeed,
+                randomSongs = if (serverChanged) emptyList() else state.randomSongs,
+                isRandomSongsLoading = if (serverChanged) false else state.isRandomSongsLoading,
+                randomSongsError = if (serverChanged) null else state.randomSongsError,
                 cacheStorageSummary = if (serverChanged) {
                     state.cacheStorageSummary.copy(
                         streamCachedSongCount = 0,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -38,6 +38,7 @@ import org.hdhmc.saki.domain.model.PlaylistSummary
 import org.hdhmc.saki.domain.model.SearchResults
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.Song
+import org.hdhmc.saki.domain.model.SongFeedType
 import org.hdhmc.saki.domain.model.SongLyrics
 import org.hdhmc.saki.domain.model.SoundBalancingMode
 import org.hdhmc.saki.domain.model.StreamQuality
@@ -78,6 +79,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 private const val ALBUMS_PAGE_SIZE = 36
+private const val RANDOM_SONGS_FEED_SIZE = 200
 private const val PLAYLIST_DETAIL_PREFETCH_LIMIT = 12
 private const val PLAYLIST_DETAIL_PREFETCH_MAX_SONGS = 500
 private const val SONG_METADATA_SYNC_PAGE_SIZE = 500
@@ -1100,6 +1102,48 @@ class SakiAppViewModel @Inject constructor(
                 openNowPlayingRequestsFlow.emit(Unit)
             }.onFailure { throwable ->
                 snackbarMessages.emit(SnackbarMessage(throwable.localizedOr(R.string.error_start_playback)))
+            }
+        }
+    }
+
+    fun selectSongFeed(feed: SongFeedType) {
+        val serverId = uiState.value.selectedServerId ?: return
+        mutableUiState.update { it.copy(selectedSongFeed = feed) }
+        if (
+            feed == SongFeedType.RANDOM &&
+            uiState.value.randomSongs.isEmpty() &&
+            !uiState.value.isRandomSongsLoading
+        ) {
+            loadRandomSongs(serverId)
+        }
+    }
+
+    fun refreshRandomSongs() {
+        val serverId = uiState.value.selectedServerId ?: return
+        if (uiState.value.isRandomSongsLoading) return
+        loadRandomSongs(serverId)
+    }
+
+    private fun loadRandomSongs(serverId: Long) {
+        mutableUiState.update { it.copy(isRandomSongsLoading = true, randomSongsError = null) }
+        viewModelScope.launch {
+            val songs = runCatching {
+                subsonicRepository.getRandomSongs(serverId, size = RANDOM_SONGS_FEED_SIZE).data
+            }.getOrElse { emptyList() }
+                .distinctBy(Song::id)
+                .ifEmpty {
+                    runCatching { libraryCacheRepository.getSongs(serverId) }
+                        .getOrDefault(emptyList())
+                        .shuffled()
+                        .take(RANDOM_SONGS_FEED_SIZE)
+                }
+            if (uiState.value.selectedServerId != serverId) return@launch
+            mutableUiState.update {
+                it.copy(
+                    randomSongs = songs,
+                    isRandomSongsLoading = false,
+                    randomSongsError = if (songs.isEmpty()) UiText.resource(R.string.browse_no_songs) else null,
+                )
             }
         }
     }
@@ -2522,6 +2566,10 @@ data class SakiAppUiState(
     val isSongsLoadingPrevious: Boolean = false,
     val isSongsLoadingMore: Boolean = false,
     val songsError: UiText? = null,
+    val selectedSongFeed: SongFeedType = SongFeedType.DEFAULT,
+    val randomSongs: List<Song> = emptyList(),
+    val isRandomSongsLoading: Boolean = false,
+    val randomSongsError: UiText? = null,
     val isSongMetadataSyncing: Boolean = false,
     val songMetadataSyncCount: Int = 0,
     val isSearchActive: Boolean = false,
@@ -2619,6 +2667,10 @@ data class SakiBrowseUiState(
     val isSongsLoadingPrevious: Boolean = false,
     val isSongsLoadingMore: Boolean = false,
     val songsError: UiText? = null,
+    val selectedSongFeed: SongFeedType = SongFeedType.DEFAULT,
+    val randomSongs: List<Song> = emptyList(),
+    val isRandomSongsLoading: Boolean = false,
+    val randomSongsError: UiText? = null,
     val isSearchActive: Boolean = false,
     val searchQuery: String = "",
     val searchResults: SearchResults = SearchResults(),
@@ -2730,6 +2782,10 @@ private fun SakiAppUiState.toBrowseUiState(): SakiBrowseUiState {
         isSongsLoadingPrevious = isSongsLoadingPrevious,
         isSongsLoadingMore = isSongsLoadingMore,
         songsError = songsError,
+        selectedSongFeed = selectedSongFeed,
+        randomSongs = randomSongs,
+        isRandomSongsLoading = isRandomSongsLoading,
+        randomSongsError = randomSongsError,
         isSearchActive = isSearchActive,
         searchQuery = searchQuery,
         searchResults = searchResults,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -749,7 +749,7 @@ private fun BrowsePager(
             )
             Box(modifier = Modifier.weight(1f)) {
                 val isRefreshing = uiState.isArtistsLoading || uiState.isAlbumsLoading ||
-                    uiState.isPlaylistsLoading || uiState.isSongsLoading
+                    uiState.isPlaylistsLoading || uiState.isSongsLoading || uiState.isRandomSongsLoading
                 val pullState = rememberPullToRefreshState()
                 val haptic = LocalHapticFeedback.current
                 val isOverThreshold = !isRefreshing && pullState.distanceFraction >= 1f

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Button
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -108,6 +109,7 @@ import org.hdhmc.saki.domain.model.Playlist
 import org.hdhmc.saki.domain.model.SearchResults
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.Song
+import org.hdhmc.saki.domain.model.SongFeedType
 import org.hdhmc.saki.presentation.BrowseSection
 import org.hdhmc.saki.presentation.AlbumFeedState
 import org.hdhmc.saki.presentation.labelRes
@@ -145,6 +147,7 @@ fun BrowseScreen(
     onClearRecentSearchQueries: () -> Unit,
     onRefreshCurrentTab: () -> Unit,
     onSelectAlbumFeed: (AlbumListType) -> Unit,
+    onSelectSongFeed: (SongFeedType) -> Unit,
     onLoadMoreAlbums: () -> Unit,
     onLoadPreviousSongs: () -> Unit,
     onLoadMoreSongs: () -> Unit,
@@ -234,6 +237,7 @@ fun BrowseScreen(
                                 onClearRecentSearchQueries = onClearRecentSearchQueries,
                                 onRefreshCurrentTab = onRefreshCurrentTab,
                                 onSelectAlbumFeed = onSelectAlbumFeed,
+                                onSelectSongFeed = onSelectSongFeed,
                                 onLoadMoreAlbums = onLoadMoreAlbums,
                                 onLoadPreviousSongs = onLoadPreviousSongs,
                                 onLoadMoreSongs = onLoadMoreSongs,
@@ -693,6 +697,7 @@ private fun BrowsePager(
     onClearRecentSearchQueries: () -> Unit,
     onRefreshCurrentTab: () -> Unit,
     onSelectAlbumFeed: (AlbumListType) -> Unit,
+    onSelectSongFeed: (SongFeedType) -> Unit,
     onLoadMoreAlbums: () -> Unit,
     onLoadPreviousSongs: () -> Unit,
     onLoadMoreSongs: () -> Unit,
@@ -832,6 +837,7 @@ private fun BrowsePager(
                                 )
 
                                 BrowseSection.SONGS -> SongsPageRoute(
+                                    browsePagerState = pagerState,
                                     songs = uiState.songs,
                                     songsOffset = uiState.songsOffset,
                                     hasPrevious = uiState.hasPreviousSongs,
@@ -852,6 +858,11 @@ private fun BrowsePager(
                                     onPlayLibrarySongs = onPlayLibrarySongs,
                                     onOfflineSongUnavailable = onOfflineSongUnavailable,
                                     onShowSongActions = onShowSongActions,
+                                    selectedSongFeed = uiState.selectedSongFeed,
+                                    randomSongs = uiState.randomSongs,
+                                    isRandomSongsLoading = uiState.isRandomSongsLoading,
+                                    randomSongsError = uiState.randomSongsError?.asString(),
+                                    onSelectSongFeed = onSelectSongFeed,
                                 )
                             }
                         }
@@ -1523,7 +1534,7 @@ private fun AlbumsPage(
         state = browsePagerState,
         pagerSnapDistance = PagerSnapDistance.atMost(1),
     )
-    val feedBoundaryHandoffConnection = rememberAlbumFeedBoundaryHandoffConnection(
+    val feedBoundaryHandoffConnection = rememberFeedBoundaryHandoffConnection(
         feedPagerState = feedPagerState,
         browsePagerState = browsePagerState,
         browsePagerFlingBehavior = browsePagerFlingBehavior,
@@ -1589,7 +1600,7 @@ private fun AlbumsPage(
 }
 
 @Composable
-private fun rememberAlbumFeedBoundaryHandoffConnection(
+private fun rememberFeedBoundaryHandoffConnection(
     feedPagerState: PagerState,
     browsePagerState: PagerState,
     browsePagerFlingBehavior: TargetedFlingBehavior,
@@ -1606,7 +1617,7 @@ private fun rememberAlbumFeedBoundaryHandoffConnection(
                 }
 
                 val scrollDelta = -available.x
-                if (!feedPagerState.shouldHandOffAlbumFeedDelta(scrollDelta)) {
+                if (!feedPagerState.shouldHandOffFeedDelta(scrollDelta)) {
                     handedOffGesture = false
                     return Offset.Zero
                 }
@@ -1644,7 +1655,7 @@ private fun rememberAlbumFeedBoundaryHandoffConnection(
     }
 }
 
-private fun PagerState.shouldHandOffAlbumFeedDelta(scrollDelta: Float): Boolean {
+private fun PagerState.shouldHandOffFeedDelta(scrollDelta: Float): Boolean {
     val isSettledAtFeedBoundary = currentPage == settledPage &&
         currentPage == targetPage &&
         abs(currentPageOffsetFraction) <= PagerOffsetSettlingEpsilon
@@ -1931,6 +1942,7 @@ private fun PlaylistsPage(
 
 @Composable
 private fun SongsPageRoute(
+    browsePagerState: PagerState,
     songs: List<Song>,
     songsOffset: Int,
     hasPrevious: Boolean,
@@ -1951,39 +1963,118 @@ private fun SongsPageRoute(
     onPlayLibrarySongs: (Int) -> Unit,
     onOfflineSongUnavailable: () -> Unit,
     onShowSongActions: (Song) -> Unit,
+    selectedSongFeed: SongFeedType,
+    randomSongs: List<Song>,
+    isRandomSongsLoading: Boolean,
+    randomSongsError: String?,
+    onSelectSongFeed: (SongFeedType) -> Unit,
 ) {
     val playbackUiState by playbackUiStateFlow.collectAsStateWithLifecycle()
     val availabilityUiState by availabilityUiStateFlow.collectAsStateWithLifecycle()
     val cachedSongsBySongId = rememberCachedSongsBySongId(availabilityUiState)
-    SongsPage(
-        songs = songs,
-        songsOffset = songsOffset,
-        hasPrevious = hasPrevious,
-        hasMore = hasMore,
-        server = server,
-        cachedSongsBySongId = cachedSongsBySongId,
-        streamCachedSongIds = availabilityUiState.streamCachedSongIds,
-        downloadingSongIds = availabilityUiState.downloadingSongIds,
-        isOfflineDegraded = isOfflineDegraded,
-        isLoading = isLoading,
-        isLoadingPrevious = isLoadingPrevious,
-        isLoadingMore = isLoadingMore,
-        error = error,
-        bottomOverlayPadding = bottomOverlayPadding,
-        scrollPosition = scrollPosition,
-        currentPlaybackSongId = playbackUiState.currentPlaybackSongId,
-        isPlaying = playbackUiState.isPlaying,
-        onLoadPrevious = onLoadPrevious,
-        onLoadMore = onLoadMore,
-        onPlaySongs = onPlaySongs,
-        onPlayLibrarySongs = onPlayLibrarySongs,
-        onOfflineSongUnavailable = onOfflineSongUnavailable,
-        onShowSongActions = onShowSongActions,
+
+    val feeds = SongFeedType.entries
+    val selectedSongFeedState = rememberUpdatedState(selectedSongFeed)
+    val feedPagerState = rememberPagerState(
+        initialPage = feeds.indexOf(selectedSongFeed).coerceAtLeast(0),
+        pageCount = { feeds.size },
     )
+    val feedPagerFlingBehavior = PagerDefaults.flingBehavior(
+        state = feedPagerState,
+        pagerSnapDistance = PagerSnapDistance.atMost(1),
+    )
+    val browsePagerFlingBehavior = PagerDefaults.flingBehavior(
+        state = browsePagerState,
+        pagerSnapDistance = PagerSnapDistance.atMost(1),
+    )
+    val feedBoundaryHandoffConnection = rememberFeedBoundaryHandoffConnection(
+        feedPagerState = feedPagerState,
+        browsePagerState = browsePagerState,
+        browsePagerFlingBehavior = browsePagerFlingBehavior,
+    )
+    val coroutineScope = rememberCoroutineScope()
+    val highlightedFeed = feeds[feedPagerState.targetPage.coerceIn(0, feeds.lastIndex)]
+
+    LaunchedEffect(selectedSongFeed) {
+        val targetPage = feeds.indexOf(selectedSongFeed).coerceAtLeast(0)
+        if (feedPagerState.settledPage != targetPage && feedPagerState.targetPage != targetPage) {
+            feedPagerState.animateScrollToPage(targetPage)
+        }
+    }
+    LaunchedEffect(feedPagerState) {
+        snapshotFlow { feedPagerState.settledPage }
+            .distinctUntilChanged()
+            .map { feeds[it] }
+            .filter { it != selectedSongFeedState.value }
+            .collect { onSelectSongFeed(it) }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        SongFeedControls(
+            selected = highlightedFeed,
+            onSelect = { feed ->
+                val targetPage = feeds.indexOf(feed)
+                if (targetPage >= 0 && feedPagerState.targetPage != targetPage) {
+                    coroutineScope.launch { feedPagerState.animateScrollToPage(targetPage) }
+                }
+            },
+        )
+        HorizontalPager(
+            state = feedPagerState,
+            modifier = Modifier
+                .weight(1f)
+                .nestedScroll(feedBoundaryHandoffConnection),
+            flingBehavior = feedPagerFlingBehavior,
+        ) { page ->
+            when (feeds[page]) {
+                SongFeedType.DEFAULT -> DefaultSongsContent(
+                    songs = songs,
+                    songsOffset = songsOffset,
+                    hasPrevious = hasPrevious,
+                    hasMore = hasMore,
+                    server = server,
+                    cachedSongsBySongId = cachedSongsBySongId,
+                    streamCachedSongIds = availabilityUiState.streamCachedSongIds,
+                    downloadingSongIds = availabilityUiState.downloadingSongIds,
+                    isOfflineDegraded = isOfflineDegraded,
+                    isLoading = isLoading,
+                    isLoadingPrevious = isLoadingPrevious,
+                    isLoadingMore = isLoadingMore,
+                    error = error,
+                    bottomOverlayPadding = bottomOverlayPadding,
+                    scrollPosition = scrollPosition,
+                    currentPlaybackSongId = playbackUiState.currentPlaybackSongId,
+                    isPlaying = playbackUiState.isPlaying,
+                    onLoadPrevious = onLoadPrevious,
+                    onLoadMore = onLoadMore,
+                    onPlaySongs = onPlaySongs,
+                    onPlayLibrarySongs = onPlayLibrarySongs,
+                    onOfflineSongUnavailable = onOfflineSongUnavailable,
+                    onShowSongActions = onShowSongActions,
+                )
+                SongFeedType.RANDOM -> RandomSongsContent(
+                    songs = randomSongs,
+                    server = server,
+                    cachedSongsBySongId = cachedSongsBySongId,
+                    streamCachedSongIds = availabilityUiState.streamCachedSongIds,
+                    downloadingSongIds = availabilityUiState.downloadingSongIds,
+                    isOfflineDegraded = isOfflineDegraded,
+                    isLoading = isRandomSongsLoading,
+                    error = randomSongsError,
+                    bottomOverlayPadding = bottomOverlayPadding,
+                    currentPlaybackSongId = playbackUiState.currentPlaybackSongId,
+                    isPlaying = playbackUiState.isPlaying,
+                    onPlaySongs = onPlaySongs,
+                    onOfflineSongUnavailable = onOfflineSongUnavailable,
+                    onShowSongActions = onShowSongActions,
+                )
+            }
+        }
+    }
 }
 
 @Composable
-private fun SongsPage(
+private fun DefaultSongsContent(
     songs: List<Song>,
     songsOffset: Int,
     hasPrevious: Boolean,
@@ -2124,6 +2215,98 @@ private fun SongsPage(
             item {
                 LoadingStateCard(stringResource(R.string.browse_loading_songs))
             }
+        }
+    }
+}
+
+@Composable
+private fun SongFeedControls(
+    selected: SongFeedType,
+    onSelect: (SongFeedType) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        FilterChip(
+            selected = selected == SongFeedType.DEFAULT,
+            onClick = { onSelect(SongFeedType.DEFAULT) },
+            label = { Text(stringResource(R.string.browse_song_feed_default)) },
+        )
+        FilterChip(
+            selected = selected == SongFeedType.RANDOM,
+            onClick = { onSelect(SongFeedType.RANDOM) },
+            label = { Text(stringResource(R.string.browse_song_feed_random)) },
+        )
+    }
+}
+
+@Composable
+private fun RandomSongsContent(
+    songs: List<Song>,
+    server: ServerConfig,
+    cachedSongsBySongId: Map<String, CachedSong>,
+    streamCachedSongIds: Set<String>,
+    downloadingSongIds: Set<String>,
+    isOfflineDegraded: Boolean,
+    isLoading: Boolean,
+    error: String?,
+    bottomOverlayPadding: Dp,
+    currentPlaybackSongId: String? = null,
+    isPlaying: Boolean = false,
+    onPlaySongs: (List<Song>, Int) -> Unit,
+    onOfflineSongUnavailable: () -> Unit,
+    onShowSongActions: (Song) -> Unit,
+) {
+    if (isLoading && songs.isEmpty()) {
+        LoadingStateCard(stringResource(R.string.browse_loading_songs))
+        return
+    }
+    if (error != null && songs.isEmpty()) {
+        ErrorStateCard(error)
+        return
+    }
+    if (songs.isEmpty()) {
+        EmptyStateCard(
+            stringResource(R.string.browse_no_songs),
+            stringResource(R.string.browse_no_songs_body),
+        )
+        return
+    }
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = bottomContentPadding(bottomOverlayPadding),
+    ) {
+        itemsIndexed(songs, key = { index, s -> "random-$index-${s.id}" }) { index, song ->
+            AlbumTrackRow(
+                song = song,
+                index = index,
+                useTrackNumbers = false,
+                albumArtistLabel = null,
+                cachedSong = cachedSongsBySongId[song.id],
+                isStreamCached = song.id in streamCachedSongIds,
+                isDownloading = song.id in downloadingSongIds,
+                isOfflineDegraded = isOfflineDegraded,
+                isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds),
+                isCurrent = currentPlaybackSongId == song.id,
+                isPlaying = isPlaying,
+                accentColor = MaterialTheme.colorScheme.primary,
+                artworkModel = resolveArtworkModel(server, song.coverArtId, cachedSongsBySongId[song.id]),
+                onClick = {
+                    playOfflineAwareSongs(
+                        songs = songs,
+                        startIndex = index,
+                        isOfflineDegraded = isOfflineDegraded,
+                        cachedSongsBySongId = cachedSongsBySongId,
+                        streamCachedSongIds = streamCachedSongIds,
+                        onPlaySongs = onPlaySongs,
+                        onUnavailable = onOfflineSongUnavailable,
+                    )
+                },
+                onMore = { onShowSongActions(song) },
+            )
         }
     }
 }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -146,6 +146,8 @@
     <string name="library_artist_songs">歌曲</string>
     <string name="library_artist_songs_subtitle">%1$s 的歌曲</string>
     <string name="library_albums">专辑</string>
+    <string name="browse_song_feed_default">默认</string>
+    <string name="browse_song_feed_random">随机</string>
     <string name="library_albums_subtitle_full_release">查看完整专辑页面</string>
     <string name="library_loading_album">正在加载专辑</string>
     <string name="library_track_list">曲目列表</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,8 @@
     <string name="library_artist_songs">Songs</string>
     <string name="library_artist_songs_subtitle">Songs by %1$s</string>
     <string name="library_albums">Albums</string>
+    <string name="browse_song_feed_default">Default</string>
+    <string name="browse_song_feed_random">Random</string>
     <string name="library_albums_subtitle_full_release">Tap into the full release page</string>
     <string name="library_loading_album">Loading album</string>
     <string name="library_track_list">Track list</string>


### PR DESCRIPTION
## Summary
- Turn the Songs tab into a swipeable sub-feed pager (默认 / 随机), mirroring the Albums tab's feed pager so the interaction is consistent — chips and a `HorizontalPager` stay in sync, and swiping past a feed boundary hands off to the outer browse pager.
- Generalize the album feed boundary hand-off so both tabs share it: `rememberAlbumFeedBoundaryHandoffConnection` → `rememberFeedBoundaryHandoffConnection`, `shouldHandOffAlbumFeedDelta` → `shouldHandOffFeedDelta` (logic unchanged; reuses the #304 hand-off).
- Add a **Random** feed: pulls a bounded random sample from the whole library (`getRandomSongs`, with a local cached `getSongs().shuffled()` fallback when offline), shuffle **off**. Tapping a track plays the pre-randomized list sequentially via the existing `playQueue` path — i.e. random playback with **no** shuffle-mode / virtual-queue machinery, so it carries none of the shuffle/restore regression surface.
- Add `getRandomSongs` to the Subsonic layer (`getRandomSongs.view`): `RandomSongsDto`, `toRandomSongs` mapper, repository interface + impl.

## Why this approach
This replaces the earlier "shuffle all" idea. Because the Random feed is just a concrete, pre-randomized list played in order:
- No `SakiShuffleOrder` / `shuffleModeEnabled` involved on this path.
- Queue save/restore is identical to an album/playlist queue — the random order is baked into the snapshot, so restart resumes the same order deterministically (no shuffle-state to lose, avoiding the #284/#287 class of bugs).
- Whole-library coverage comes from the server's random endpoint instead of materializing the full library into Media3.

## Behavior notes
- Switching to the Random feed loads it on demand. **Switching tabs back and forth keeps the current random set** (it does not re-roll); **pull-to-refresh re-rolls** a new random set. An already-playing queue is never touched by feed changes.
- Random feed is a bounded sample (200), i.e. a "random radio", not a full-library stream — intentional.
- Switching servers resets the Songs feed to 默认 and clears the random state.
- Only 默认 / 随机 for now; 收藏 / 流派 can be added as further feed pages later (the API has no songs-level newest/frequent/recent, unlike albums).
- Pre-existing, out of scope: an offline-degraded restore filters the queue to playable songs and does not rebuild on reconnect.

## Validation
- `./gradlew compileDebugKotlin --no-daemon`
- `./gradlew assembleDebug --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon`
- Manual on-device testing of feed swipe, boundary hand-off to outer tabs, random-feed sequential playback, pull-to-refresh re-roll, and offline fallback.