### PR TITLE
fix: refresh stream cache indicators after prefetch

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
@@ -45,6 +45,7 @@ class DefaultStreamCacheRepository @Inject constructor(
     private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
     private val cacheVersion = MutableStateFlow(0L)
     private val snapshotRefreshMutex = Mutex()
+    private val requestedSnapshotRefreshLock = Any()
     private var lastSnapshot = StreamCacheSnapshot()
     private var hasAppliedInitialCacheSize = false
     private var requestedSnapshotRefreshJob: Job? = null
@@ -78,10 +79,21 @@ class DefaultStreamCacheRepository @Inject constructor(
     override fun observeCacheVersion(): Flow<Long> = cacheVersion.asStateFlow()
 
     override fun requestSnapshotRefresh() {
-        requestedSnapshotRefreshJob?.cancel()
-        requestedSnapshotRefreshJob = scope.launch {
+        val refreshJob = scope.launch {
             delay(STREAM_CACHE_SNAPSHOT_REQUEST_DEBOUNCE_MS)
-            refreshSnapshot()
+            try {
+                refreshSnapshot()
+            } finally {
+                synchronized(requestedSnapshotRefreshLock) {
+                    if (requestedSnapshotRefreshJob === coroutineContext[Job]) {
+                        requestedSnapshotRefreshJob = null
+                    }
+                }
+            }
+        }
+        synchronized(requestedSnapshotRefreshLock) {
+            requestedSnapshotRefreshJob?.cancel()
+            requestedSnapshotRefreshJob = refreshJob
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
@@ -18,6 +18,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -29,6 +30,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 @Singleton
@@ -41,8 +44,10 @@ class DefaultStreamCacheRepository @Inject constructor(
 ) : StreamCacheRepository {
     private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
     private val cacheVersion = MutableStateFlow(0L)
+    private val snapshotRefreshMutex = Mutex()
     private var lastSnapshot = StreamCacheSnapshot()
     private var hasAppliedInitialCacheSize = false
+    private var requestedSnapshotRefreshJob: Job? = null
     private val streamCache: SimpleCache
         get() = streamCacheProvider.get()
 
@@ -71,6 +76,14 @@ class DefaultStreamCacheRepository @Inject constructor(
     }
 
     override fun observeCacheVersion(): Flow<Long> = cacheVersion.asStateFlow()
+
+    override fun requestSnapshotRefresh() {
+        requestedSnapshotRefreshJob?.cancel()
+        requestedSnapshotRefreshJob = scope.launch {
+            delay(STREAM_CACHE_SNAPSHOT_REQUEST_DEBOUNCE_MS)
+            refreshSnapshot()
+        }
+    }
 
     override fun buildCacheKey(
         serverId: Long,
@@ -150,10 +163,12 @@ class DefaultStreamCacheRepository @Inject constructor(
     }
 
     private suspend fun refreshSnapshot(forceEmit: Boolean = false) {
-        val snapshot = buildSnapshot()
-        if (forceEmit || snapshot != lastSnapshot) {
-            lastSnapshot = snapshot
-            cacheVersion.update { version -> version + 1 }
+        snapshotRefreshMutex.withLock {
+            val snapshot = buildSnapshot()
+            if (forceEmit || snapshot != lastSnapshot) {
+                lastSnapshot = snapshot
+                cacheVersion.update { version -> version + 1 }
+            }
         }
     }
 
@@ -222,6 +237,7 @@ private data class StreamCacheSnapshot(
 )
 
 private const val STREAM_CACHE_SNAPSHOT_INITIAL_DELAY_MS = 5_000L
+private const val STREAM_CACHE_SNAPSHOT_REQUEST_DEBOUNCE_MS = 250L
 private const val STREAM_CACHE_SNAPSHOT_REFRESH_MS = 30_000L
 
 private fun Collection<Set<String>>.flattenToSet(): Set<String> {

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/StreamCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/StreamCacheRepository.kt
@@ -8,6 +8,15 @@ import kotlinx.coroutines.flow.Flow
 interface StreamCacheRepository {
     fun observeCacheVersion(): Flow<Long>
 
+    /**
+     * Request a debounced cache snapshot refresh after an external cache write completes.
+     *
+     * This is intentionally a hint rather than a per-span update path: callers should invoke it
+     * after a resource-level write completes so UI cache indicators can update promptly without
+     * replacing the periodic snapshot scan with frequent cache walks.
+     */
+    fun requestSnapshotRefresh()
+
     fun buildCacheKey(
         serverId: Long,
         songId: String,

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -709,6 +709,7 @@ class SakiPlaybackService : MediaSessionService() {
             if (result.cachedBytes > 0L) {
                 completedStreamPrefetchKeysByTarget[target.targetKey] = result.cacheKey
                 deferredStreamPrefetchTargets.remove(target.targetKey)
+                streamCacheRepository.requestSnapshotRefresh()
             } else {
                 deferredStreamPrefetchTargets[target.targetKey] =
                     SystemClock.elapsedRealtime() + STREAM_PREFETCH_RETRY_DELAY_MS


### PR DESCRIPTION
## Summary
- Add a debounced stream-cache snapshot refresh hint to `StreamCacheRepository`.
- Request that refresh after `CacheWriter.cache()` completes a stream prefetch resource, so list cache badges can update shortly after prefetch completion instead of waiting for the 30s periodic scan.
- Keep the existing periodic snapshot scan as a fallback and coalesce refresh requests to avoid per-span or tight-loop cache walks.
- Serialize snapshot refreshes with a mutex so periodic, preference-driven, clear-cache, and requested refreshes do not scan `SimpleCache` concurrently.

## Validation
- `/usr/bin/git diff --check`
- `./gradlew compileDebugKotlin --no-daemon`