### PR TITLE
fix: filter unknown album placeholders from feeds

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -37,6 +37,7 @@ import org.hdhmc.saki.domain.model.SearchResults
 import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.domain.model.visibleDetailAlbums
 import org.hdhmc.saki.domain.model.withVisibleDetailAlbums
+import org.hdhmc.saki.domain.model.withoutUnknownAlbumPlaceholders
 import org.hdhmc.saki.domain.repository.LibraryCacheRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -91,11 +92,13 @@ class DefaultLibraryCacheRepository @Inject constructor(
     }
 
     override suspend fun getAlbums(serverId: Long, type: AlbumListType): List<AlbumSummary> = withContext(ioDispatcher) {
-        dao.getAlbums(serverId, type.apiValue).map { it.toDomain() }
+        dao.getAlbums(serverId, type.apiValue)
+            .map { it.toDomain() }
+            .withoutUnknownAlbumPlaceholders()
     }
 
     override suspend fun saveAlbums(serverId: Long, type: AlbumListType, albums: List<AlbumSummary>) = withContext(ioDispatcher) {
-        val entities = albums.mapIndexed { index, album ->
+        val entities = albums.withoutUnknownAlbumPlaceholders().mapIndexed { index, album ->
             CachedAlbumEntity(
                 serverId = serverId,
                 albumId = album.id,

--- a/app/src/main/java/org/hdhmc/saki/domain/model/ArtistMatching.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/ArtistMatching.kt
@@ -105,11 +105,11 @@ private fun AlbumSummary.hasPrimaryArtistMismatch(artist: Artist): Boolean {
 }
 
 private fun Album.hasUnknownAlbumName(): Boolean {
-    return name.isUnknownAlbumName()
+    return isUnknownAlbumPlaceholder()
 }
 
 private fun AlbumSummary.hasUnknownAlbumName(): Boolean {
-    return name.isUnknownAlbumName()
+    return isUnknownAlbumPlaceholder()
 }
 
 private fun Song.hasArtistIdentity(): Boolean {
@@ -131,12 +131,4 @@ private fun String?.nameParts(): List<String> {
 
 private fun List<String>.matchesAny(targetNames: List<String>): Boolean {
     return any { candidate -> targetNames.any { target -> candidate.equals(target, ignoreCase = true) } }
-}
-
-private fun String.isUnknownAlbumName(): Boolean {
-    val normalized = trim()
-        .removePrefix("[")
-        .removeSuffix("]")
-        .trim()
-    return normalized.equals("Unknown Album", ignoreCase = true)
 }

--- a/app/src/main/java/org/hdhmc/saki/domain/model/UnknownAlbum.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/UnknownAlbum.kt
@@ -1,0 +1,21 @@
+package org.hdhmc.saki.domain.model
+
+internal fun AlbumSummary.isUnknownAlbumPlaceholder(): Boolean {
+    return name.isUnknownAlbumPlaceholderName()
+}
+
+internal fun Album.isUnknownAlbumPlaceholder(): Boolean {
+    return name.isUnknownAlbumPlaceholderName()
+}
+
+internal fun String.isUnknownAlbumPlaceholderName(): Boolean {
+    val normalized = trim()
+        .removePrefix("[")
+        .removeSuffix("]")
+        .trim()
+    return normalized.equals("Unknown Album", ignoreCase = true)
+}
+
+internal fun List<AlbumSummary>.withoutUnknownAlbumPlaceholders(): List<AlbumSummary> {
+    return filterNot(AlbumSummary::isUnknownAlbumPlaceholder)
+}

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -43,6 +43,7 @@ import org.hdhmc.saki.domain.model.SongLyrics
 import org.hdhmc.saki.domain.model.SoundBalancingMode
 import org.hdhmc.saki.domain.model.StreamQuality
 import org.hdhmc.saki.domain.model.TextScale
+import org.hdhmc.saki.domain.model.withoutUnknownAlbumPlaceholders
 import org.hdhmc.saki.domain.model.withVisibleDetailAlbums
 import org.hdhmc.saki.domain.repository.AppPreferencesRepository
 import org.hdhmc.saki.domain.repository.CachedSongRepository
@@ -559,14 +560,14 @@ class SakiAppViewModel @Inject constructor(
                     var mergedAlbums = emptyList<AlbumSummary>()
                     mutableUiState.update { current ->
                         val currentFeed = current.albumFeedState(type)
-                        mergedAlbums = (currentFeed.albums + page).distinctBy(AlbumSummary::id)
-                        val addedAny = mergedAlbums.size > currentFeed.albums.size
+                        val visiblePage = page.withoutUnknownAlbumPlaceholders()
+                        mergedAlbums = (currentFeed.albums + visiblePage).distinctBy(AlbumSummary::id)
                         current.copy(
                             albumFeeds = current.albumFeeds.updateFeed(type) {
                                 it.copy(
                                     albums = mergedAlbums,
-                                    offset = mergedAlbums.size,
-                                    hasMore = page.size >= ALBUMS_PAGE_SIZE && addedAny,
+                                    offset = offset + page.size,
+                                    hasMore = page.size >= ALBUMS_PAGE_SIZE,
                                     isLoadingMore = false,
                                     error = null,
                                 )
@@ -1894,13 +1895,14 @@ class SakiAppViewModel @Inject constructor(
         viewModelScope.launch {
             if (!forceRefresh) {
                 val cached = runCatching { libraryCacheRepository.getAlbums(serverId, type) }.getOrNull()
-                if (!cached.isNullOrEmpty() && uiState.value.selectedServerId == serverId) {
+                val visibleCached = cached?.withoutUnknownAlbumPlaceholders().orEmpty()
+                if (visibleCached.isNotEmpty() && uiState.value.selectedServerId == serverId) {
                     mutableUiState.update { state ->
                         state.copy(
                             albumFeeds = state.albumFeeds.updateFeed(type) {
                                 it.copy(
-                                    albums = cached,
-                                    offset = cached.size,
+                                    albums = visibleCached,
+                                    offset = visibleCached.size,
                                     hasMore = type.supportsPagination(),
                                     error = null,
                                 )
@@ -1931,14 +1933,16 @@ class SakiAppViewModel @Inject constructor(
                     offset = 0,
                 ).data
             }.onSuccess { albums ->
-                val uniqueAlbums = albums.distinctBy(AlbumSummary::id)
+                val uniqueAlbums = albums
+                    .withoutUnknownAlbumPlaceholders()
+                    .distinctBy(AlbumSummary::id)
                 if (uiState.value.selectedServerId == serverId) {
                     mutableUiState.update { state ->
                         state.copy(
                             albumFeeds = state.albumFeeds.updateFeed(type) {
                                 it.copy(
                                     albums = uniqueAlbums,
-                                    offset = uniqueAlbums.size,
+                                    offset = albums.size,
                                     hasMore = type.supportsPagination() && albums.size >= ALBUMS_PAGE_SIZE,
                                     isLoading = false,
                                     isLoadingMore = false,

--- a/app/src/test/java/org/hdhmc/saki/domain/model/UnknownAlbumTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/domain/model/UnknownAlbumTest.kt
@@ -1,0 +1,50 @@
+package org.hdhmc.saki.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UnknownAlbumTest {
+    @Test
+    fun unknownAlbumPlaceholderMatchesCommonServerAndFallbackNames() {
+        assertTrue("Unknown Album".isUnknownAlbumPlaceholderName())
+        assertTrue("[Unknown Album]".isUnknownAlbumPlaceholderName())
+        assertTrue(" [unknown album] ".isUnknownAlbumPlaceholderName())
+    }
+
+    @Test
+    fun unknownAlbumPlaceholderDoesNotMatchRealAlbumNamesContainingWords() {
+        assertFalse("Unknown Album Sessions".isUnknownAlbumPlaceholderName())
+        assertFalse("The Unknown Album".isUnknownAlbumPlaceholderName())
+        assertFalse("Unknown".isUnknownAlbumPlaceholderName())
+    }
+
+    @Test
+    fun filtersUnknownAlbumPlaceholdersWithoutRemovingNormalAlbums() {
+        val albums = listOf(
+            album(id = "unknown-1", name = "[Unknown Album]"),
+            album(id = "album-1", name = "Real Album"),
+            album(id = "album-2", name = "Unknown Album Sessions"),
+            album(id = "unknown-2", name = "Unknown Album"),
+        )
+
+        assertEquals(
+            listOf("album-1", "album-2"),
+            albums.withoutUnknownAlbumPlaceholders().map(AlbumSummary::id),
+        )
+    }
+
+    private fun album(id: String, name: String): AlbumSummary = AlbumSummary(
+        id = id,
+        name = name,
+        artist = null,
+        artistId = null,
+        coverArtId = null,
+        songCount = null,
+        durationSeconds = null,
+        year = null,
+        genre = null,
+        created = null,
+    )
+}


### PR DESCRIPTION
## Summary
- Add a domain-level unknown-album placeholder helper for `Unknown Album` / `[Unknown Album]` names.
- Filter placeholder albums from album feed network results before displaying and caching them.
- Filter cached album feeds on read/write so old placeholder entries no longer keep polluting album feeds after refresh.
- Reuse the same placeholder detection in artist-detail album visibility logic.
- Keep unalbumed songs reachable through Songs/search/artist detail paths; this PR intentionally does not add a virtual Unknown Albums collection.

## Notes
- Pagination offsets continue to advance by the raw server page size, not the filtered visible count, so hidden placeholder rows do not cause repeated page requests.
- `loadMoreAlbums` keeps `hasMore` based on the raw server page size so filtered pages can still advance to later real albums.

## Validation
- `/usr/bin/git diff --check`
- `./gradlew testDebugUnitTest --tests org.hdhmc.saki.domain.model.UnknownAlbumTest --tests org.hdhmc.saki.domain.model.ArtistMatchingTest --no-daemon`
- `./gradlew compileDebugKotlin --no-daemon`

Closes #254