### PR TITLE
[codex] Cache artist shortcuts

### DIFF
--- a/app/schemas/org.hdhmc.saki.data.local.database.SakiDatabase/16.json
+++ b/app/schemas/org.hdhmc.saki.data.local.database.SakiDatabase/16.json
@@ -1,0 +1,1565 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "d60da57897d1bb10cf3d24e96de7b349",
+    "entities": [
+      {
+        "tableName": "app_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `onboardingCompleted` INTEGER NOT NULL, `textScaleKey` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "onboardingCompleted",
+            "columnName": "onboardingCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textScaleKey",
+            "columnName": "textScaleKey",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `albumId` TEXT NOT NULL, `listType` TEXT NOT NULL, `name` TEXT NOT NULL, `artist` TEXT, `artistId` TEXT, `artistsJson` TEXT, `coverArtId` TEXT, `songCount` INTEGER, `durationSeconds` INTEGER, `year` INTEGER, `genre` TEXT, `created` TEXT, `sortOrder` INTEGER NOT NULL, `cachedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`serverId`, `albumId`, `listType`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listType",
+            "columnName": "listType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistsJson",
+            "columnName": "artistsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "albumId",
+            "listType"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_album_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `albumId` TEXT NOT NULL, `name` TEXT NOT NULL, `artist` TEXT, `artistId` TEXT, `artistsJson` TEXT, `coverArtId` TEXT, `songCount` INTEGER, `durationSeconds` INTEGER, `year` INTEGER, `genre` TEXT, `created` TEXT, `cachedAt` INTEGER NOT NULL, `isComplete` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `albumId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistsJson",
+            "columnName": "artistsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isComplete",
+            "columnName": "isComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "albumId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_album_detail_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `albumId` TEXT NOT NULL, `songId` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `albumId`, `sortOrder`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "albumId",
+            "sortOrder"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_album_detail_songs_serverId_albumId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_album_detail_songs_serverId_albumId` ON `${TABLE_NAME}` (`serverId`, `albumId`)"
+          },
+          {
+            "name": "index_cached_album_detail_songs_serverId_songId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_album_detail_songs_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_artist_detail_albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `albumId` TEXT NOT NULL, `name` TEXT NOT NULL, `artist` TEXT, `albumArtistId` TEXT, `artistsJson` TEXT, `coverArtId` TEXT, `songCount` INTEGER, `durationSeconds` INTEGER, `year` INTEGER, `genre` TEXT, `created` TEXT, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `artistId`, `albumId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtistId",
+            "columnName": "albumArtistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistsJson",
+            "columnName": "artistsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId",
+            "albumId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_artist_detail_albums_serverId_artistId_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "artistId",
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_artist_detail_albums_serverId_artistId_sortOrder` ON `${TABLE_NAME}` (`serverId`, `artistId`, `sortOrder`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_artist_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverArtId` TEXT, `artistImageUrl` TEXT, `albumCount` INTEGER, `cachedAt` INTEGER NOT NULL, `isComplete` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `artistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistImageUrl",
+            "columnName": "artistImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumCount",
+            "columnName": "albumCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isComplete",
+            "columnName": "isComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_artist_detail_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `artistId`, `sortOrder`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId",
+            "sortOrder"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_artist_detail_songs_serverId_artistId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_artist_detail_songs_serverId_artistId` ON `${TABLE_NAME}` (`serverId`, `artistId`)"
+          },
+          {
+            "name": "index_cached_artist_detail_songs_serverId_songId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_artist_detail_songs_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `name` TEXT NOT NULL, `sectionName` TEXT NOT NULL, `albumCount` INTEGER, `coverArtId` TEXT, `artistImageUrl` TEXT, `cachedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`serverId`, `artistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sectionName",
+            "columnName": "sectionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumCount",
+            "columnName": "albumCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistImageUrl",
+            "columnName": "artistImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_artist_shortcuts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `artistId` TEXT NOT NULL, `name` TEXT NOT NULL, `albumCount` INTEGER, `coverArtId` TEXT, `artistImageUrl` TEXT, `sortOrder` INTEGER NOT NULL, `cachedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`serverId`, `artistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumCount",
+            "columnName": "albumCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistImageUrl",
+            "columnName": "artistImageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_artist_shortcuts_serverId_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_artist_shortcuts_serverId_sortOrder` ON `${TABLE_NAME}` (`serverId`, `sortOrder`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_library_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `parentId` TEXT, `title` TEXT NOT NULL COLLATE NOCASE, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `artistsJson` TEXT, `coverArtId` TEXT, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `year` INTEGER, `genre` TEXT, `bitRate` INTEGER, `sampleRate` INTEGER, `suffix` TEXT, `contentType` TEXT, `sizeBytes` INTEGER, `path` TEXT, `created` TEXT, `cachedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`serverId`, `songId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistsJson",
+            "columnName": "artistsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "track",
+            "columnName": "track",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "songId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_library_songs_serverId_title",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_library_songs_serverId_title` ON `${TABLE_NAME}` (`serverId`, `title`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_playlist_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `playlistId` TEXT NOT NULL, `name` TEXT NOT NULL, `owner` TEXT, `isPublic` INTEGER, `songCount` INTEGER, `durationSeconds` INTEGER, `coverArtId` TEXT, `created` TEXT, `changed` TEXT, `cachedAt` INTEGER NOT NULL, `isComplete` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `playlistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPublic",
+            "columnName": "isPublic",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "changed",
+            "columnName": "changed",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isComplete",
+            "columnName": "isComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "playlistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_playlist_detail_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `playlistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `playlistId`, `sortOrder`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "playlistId",
+            "sortOrder"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_playlist_detail_songs_serverId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_playlist_detail_songs_serverId_playlistId` ON `${TABLE_NAME}` (`serverId`, `playlistId`)"
+          },
+          {
+            "name": "index_cached_playlist_detail_songs_serverId_songId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_playlist_detail_songs_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `playlistId` TEXT NOT NULL, `name` TEXT NOT NULL, `owner` TEXT, `isPublic` INTEGER, `songCount` INTEGER, `durationSeconds` INTEGER, `coverArtId` TEXT, `created` TEXT, `changed` TEXT, `cachedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`serverId`, `playlistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPublic",
+            "columnName": "isPublic",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "changed",
+            "columnName": "changed",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "playlistId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheId` TEXT NOT NULL, `serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `title` TEXT NOT NULL, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `coverArtId` TEXT, `coverArtPath` TEXT, `localPath` TEXT NOT NULL, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `suffix` TEXT, `contentType` TEXT, `bitRate` INTEGER, `sampleRate` INTEGER, `qualityKey` TEXT NOT NULL, `fileSizeBytes` INTEGER NOT NULL, `downloadedAt` INTEGER NOT NULL, PRIMARY KEY(`cacheId`))",
+        "fields": [
+          {
+            "fieldPath": "cacheId",
+            "columnName": "cacheId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtPath",
+            "columnName": "coverArtPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "track",
+            "columnName": "track",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "qualityKey",
+            "columnName": "qualityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "fileSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_songs_serverId_songId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cached_songs_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_song_artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `name` TEXT NOT NULL COLLATE NOCASE, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `songId`, `artistId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "songId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_song_artists_serverId_artistId_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "artistId",
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_song_artists_serverId_artistId_sortOrder` ON `${TABLE_NAME}` (`serverId`, `artistId`, `sortOrder`)"
+          },
+          {
+            "name": "index_cached_song_artists_serverId_songId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_song_artists_serverId_songId` ON `${TABLE_NAME}` (`serverId`, `songId`)"
+          },
+          {
+            "name": "index_cached_song_artists_serverId_name",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_song_artists_serverId_name` ON `${TABLE_NAME}` (`serverId`, `name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_song_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` INTEGER NOT NULL, `songId` TEXT NOT NULL, `parentId` TEXT, `title` TEXT NOT NULL COLLATE NOCASE, `album` TEXT, `albumId` TEXT, `artist` TEXT, `artistId` TEXT, `artistsJson` TEXT, `coverArtId` TEXT, `durationSeconds` INTEGER, `track` INTEGER, `discNumber` INTEGER, `year` INTEGER, `genre` TEXT, `bitRate` INTEGER, `sampleRate` INTEGER, `suffix` TEXT, `contentType` TEXT, `sizeBytes` INTEGER, `path` TEXT, `created` TEXT, `cachedAt` INTEGER NOT NULL, `libraryOrder` INTEGER NOT NULL DEFAULT 2147483647, PRIMARY KEY(`serverId`, `songId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artistsJson",
+            "columnName": "artistsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "coverArtId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "track",
+            "columnName": "track",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryOrder",
+            "columnName": "libraryOrder",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "2147483647"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "songId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_song_metadata_serverId_albumId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_song_metadata_serverId_albumId` ON `${TABLE_NAME}` (`serverId`, `albumId`)"
+          },
+          {
+            "name": "index_cached_song_metadata_serverId_artistId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_song_metadata_serverId_artistId` ON `${TABLE_NAME}` (`serverId`, `artistId`)"
+          },
+          {
+            "name": "index_cached_song_metadata_serverId_libraryOrder_title_songId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "libraryOrder",
+              "title",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_song_metadata_serverId_libraryOrder_title_songId` ON `${TABLE_NAME}` (`serverId`, `libraryOrder`, `title`, `songId`)"
+          },
+          {
+            "name": "index_cached_song_metadata_serverId_title_songId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "title",
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_song_metadata_serverId_title_songId` ON `${TABLE_NAME}` (`serverId`, `title`, `songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `streamQualityKey` TEXT NOT NULL, `soundBalancingEnabled` INTEGER NOT NULL, `soundBalancingModeKey` TEXT NOT NULL, `streamCacheSizeMb` INTEGER NOT NULL, `bluetoothLyricsEnabled` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamQualityKey",
+            "columnName": "streamQualityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "soundBalancingEnabled",
+            "columnName": "soundBalancingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "soundBalancingModeKey",
+            "columnName": "soundBalancingModeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamCacheSizeMb",
+            "columnName": "streamCacheSizeMb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bluetoothLyricsEnabled",
+            "columnName": "bluetoothLyricsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `clientName` TEXT NOT NULL, `apiVersion` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientName",
+            "columnName": "clientName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiVersion",
+            "columnName": "apiVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "server_endpoints",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serverId` INTEGER NOT NULL, `label` TEXT NOT NULL, `baseUrl` TEXT NOT NULL, `displayOrder` INTEGER NOT NULL, FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "displayOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_server_endpoints_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_server_endpoints_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd60da57897d1bb10cf3d24e96de7b349')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/org/hdhmc/saki/data/local/database/SakiDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/org/hdhmc/saki/data/local/database/SakiDatabaseMigrationTest.kt
@@ -40,6 +40,22 @@ class SakiDatabaseMigrationTest {
         }
     }
 
+    @Test
+    fun migrate15To16AddsArtistShortcutsCache() {
+        val databaseName = "saki-migration-15-16"
+        helper.createDatabase(databaseName, 15).close()
+
+        helper.runMigrationsAndValidate(
+            name = databaseName,
+            version = 16,
+            validateDroppedTables = true,
+            migrations = DatabaseModule.allMigrations().filter { it.startVersion >= 15 }.toTypedArray(),
+        ).apply {
+            assertTableExists("cached_artist_shortcuts")
+            close()
+        }
+    }
+
     private fun SupportSQLiteDatabase.insertLibraryListCacheRows() {
         execSQL(
             """
@@ -91,6 +107,16 @@ class SakiDatabaseMigrationTest {
             assertEquals(tableName, 1, cursor.getInt(0))
             assertEquals(tableName, 0L, cursor.getLong(1))
             assertEquals(tableName, 0L, cursor.getLong(2))
+        }
+    }
+
+    private fun SupportSQLiteDatabase.assertTableExists(tableName: String) {
+        query(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+            arrayOf(tableName),
+        ).use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(tableName, 1, cursor.getInt(0))
         }
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
@@ -12,6 +12,7 @@ import org.hdhmc.saki.data.local.entity.CachedArtistDetailAlbumEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistDetailEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistShortcutEntity
 import org.hdhmc.saki.data.local.entity.CachedLibrarySongEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailSongEntity
@@ -38,6 +39,7 @@ interface LibraryCacheDao {
         clearAllSongMetadata(serverId)
         clearSongs(serverId)
         clearAllAlbums(serverId)
+        clearArtistShortcuts(serverId)
         clearArtists(serverId)
         clearPlaylists(serverId)
     }
@@ -45,19 +47,34 @@ interface LibraryCacheDao {
     @Query("SELECT * FROM cached_artists WHERE serverId = :serverId ORDER BY sectionName, name")
     suspend fun getArtists(serverId: Long): List<CachedArtistEntity>
 
+    @Query("SELECT * FROM cached_artist_shortcuts WHERE serverId = :serverId ORDER BY sortOrder")
+    suspend fun getArtistShortcuts(serverId: Long): List<CachedArtistShortcutEntity>
+
     @Query("SELECT * FROM cached_artists WHERE serverId = :serverId AND artistId = :artistId LIMIT 1")
     suspend fun getArtistSummary(serverId: Long, artistId: String): CachedArtistEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertArtists(artists: List<CachedArtistEntity>)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertArtistShortcuts(shortcuts: List<CachedArtistShortcutEntity>)
+
     @Query("DELETE FROM cached_artists WHERE serverId = :serverId")
     suspend fun clearArtists(serverId: Long)
 
+    @Query("DELETE FROM cached_artist_shortcuts WHERE serverId = :serverId")
+    suspend fun clearArtistShortcuts(serverId: Long)
+
     @Transaction
-    suspend fun replaceArtists(serverId: Long, artists: List<CachedArtistEntity>) {
+    suspend fun replaceArtists(
+        serverId: Long,
+        artists: List<CachedArtistEntity>,
+        shortcuts: List<CachedArtistShortcutEntity>,
+    ) {
         clearArtists(serverId)
+        clearArtistShortcuts(serverId)
         insertArtists(artists)
+        insertArtistShortcuts(shortcuts)
     }
 
     @Query("SELECT * FROM cached_albums WHERE serverId = :serverId AND listType = :listType ORDER BY sortOrder")

--- a/app/src/main/java/org/hdhmc/saki/data/local/database/SakiDatabase.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/database/SakiDatabase.kt
@@ -15,6 +15,7 @@ import org.hdhmc.saki.data.local.entity.CachedArtistDetailAlbumEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistDetailEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistShortcutEntity
 import org.hdhmc.saki.data.local.entity.CachedLibrarySongEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailSongEntity
@@ -36,6 +37,7 @@ import org.hdhmc.saki.data.local.entity.ServerEntity
         CachedArtistDetailEntity::class,
         CachedArtistDetailSongEntity::class,
         CachedArtistEntity::class,
+        CachedArtistShortcutEntity::class,
         CachedLibrarySongEntity::class,
         CachedPlaylistDetailEntity::class,
         CachedPlaylistDetailSongEntity::class,
@@ -47,7 +49,7 @@ import org.hdhmc.saki.data.local.entity.ServerEntity
         ServerEntity::class,
         ServerEndpointEntity::class,
     ],
-    version = 15,
+    version = 16,
     exportSchema = true,
 )
 abstract class SakiDatabase : RoomDatabase() {

--- a/app/src/main/java/org/hdhmc/saki/data/local/entity/CachedArtistShortcutEntity.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/entity/CachedArtistShortcutEntity.kt
@@ -1,0 +1,24 @@
+package org.hdhmc.saki.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "cached_artist_shortcuts",
+    primaryKeys = ["serverId", "artistId"],
+    indices = [
+        Index(value = ["serverId", "sortOrder"]),
+    ],
+)
+data class CachedArtistShortcutEntity(
+    val serverId: Long,
+    val artistId: String,
+    val name: String,
+    val albumCount: Int?,
+    val coverArtId: String?,
+    val artistImageUrl: String?,
+    val sortOrder: Int,
+    @ColumnInfo(defaultValue = "0")
+    val cachedAt: Long,
+)

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -12,6 +12,7 @@ import org.hdhmc.saki.data.local.entity.CachedArtistDetailAlbumEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistDetailEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedArtistEntity
+import org.hdhmc.saki.data.local.entity.CachedArtistShortcutEntity
 import org.hdhmc.saki.data.local.entity.CachedLibrarySongEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailSongEntity
@@ -59,8 +60,9 @@ class DefaultLibraryCacheRepository @Inject constructor(
 
     override suspend fun getArtists(serverId: Long): LibraryIndexes? = withContext(ioDispatcher) {
         val entities = dao.getArtists(serverId)
+        val shortcutEntities = dao.getArtistShortcuts(serverId)
         val songArtistSummaries = dao.getSongArtistSummaries(serverId)
-        if (entities.isEmpty() && songArtistSummaries.isEmpty()) return@withContext null
+        if (entities.isEmpty() && shortcutEntities.isEmpty() && songArtistSummaries.isEmpty()) return@withContext null
         val detailAlbumsByArtistId = dao.getAllArtistDetailAlbums(serverId)
             .groupBy { it.artistId }
             .mapValues { (_, albums) -> albums.map { it.toDomain() } }
@@ -73,7 +75,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
         LibraryIndexes(
             lastModified = null,
             ignoredArticles = null,
-            shortcuts = emptyList(),
+            shortcuts = shortcutEntities.map { it.toDomain() },
             sections = listOf(ArtistSection(name = "#", artists = artists)),
         )
     }
@@ -94,7 +96,19 @@ class DefaultLibraryCacheRepository @Inject constructor(
                 )
             }
         }
-        dao.replaceArtists(serverId, entities)
+        val shortcuts = indexes.shortcuts.mapIndexed { index, artist ->
+            CachedArtistShortcutEntity(
+                serverId = serverId,
+                artistId = artist.id,
+                name = artist.name,
+                albumCount = artist.albumCount,
+                coverArtId = artist.coverArtId,
+                artistImageUrl = artist.artistImageUrl,
+                sortOrder = index,
+                cachedAt = cachedAt,
+            )
+        }
+        dao.replaceArtists(serverId, entities, shortcuts)
     }
 
     override suspend fun getAlbums(serverId: Long, type: AlbumListType): List<AlbumSummary> = withContext(ioDispatcher) {
@@ -384,6 +398,14 @@ class DefaultLibraryCacheRepository @Inject constructor(
     }
 
     private fun CachedArtistEntity.toDomain() = ArtistSummary(
+        id = artistId,
+        name = name,
+        albumCount = albumCount,
+        coverArtId = coverArtId,
+        artistImageUrl = artistImageUrl,
+    )
+
+    private fun CachedArtistShortcutEntity.toDomain() = ArtistSummary(
         id = artistId,
         name = name,
         albumCount = albumCount,

--- a/app/src/main/java/org/hdhmc/saki/di/DatabaseModule.kt
+++ b/app/src/main/java/org/hdhmc/saki/di/DatabaseModule.kt
@@ -504,6 +504,32 @@ object DatabaseModule {
         }
     }
 
+    private val migration15To16 = object : Migration(15, 16) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `cached_artist_shortcuts` (
+                    `serverId` INTEGER NOT NULL,
+                    `artistId` TEXT NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `albumCount` INTEGER,
+                    `coverArtId` TEXT,
+                    `artistImageUrl` TEXT,
+                    `sortOrder` INTEGER NOT NULL,
+                    `cachedAt` INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY(`serverId`, `artistId`)
+                )
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                CREATE INDEX IF NOT EXISTS `index_cached_artist_shortcuts_serverId_sortOrder`
+                ON `cached_artist_shortcuts` (`serverId`, `sortOrder`)
+                """.trimIndent(),
+            )
+        }
+    }
+
     @Provides
     @Singleton
     fun provideSakiDatabase(
@@ -521,7 +547,7 @@ object DatabaseModule {
         migration1To2, migration2To3, migration3To4, migration4To5,
         migration5To6, migration6To7, migration7To8, migration8To9,
         migration9To10, migration10To11, migration11To12, migration12To13,
-        migration13To14, migration14To15,
+        migration13To14, migration14To15, migration15To16,
     )
 
     @Provides


### PR DESCRIPTION
## Summary
- Add a `cached_artist_shortcuts` Room table to persist `LibraryIndexes.shortcuts` with stable order.
- Restore cached shortcuts in `DefaultLibraryCacheRepository.getArtists()` instead of returning an empty list.
- Clear shortcut cache with the rest of a server's library cache.
- Bump Room schema to v16 and add migration coverage for the new table.

## Validation
- `./gradlew compileDebugKotlin --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon`
- `./gradlew compileDebugAndroidTestKotlin --no-daemon`
- `git diff --check`

Closes #38