### PR TITLE
[codex] Add sorted album fast scroll

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -80,6 +80,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 private const val ALBUMS_PAGE_SIZE = 36
+private const val SORTED_ALBUMS_PAGE_SIZE = 240
 private const val RANDOM_SONGS_FEED_SIZE = 200
 private const val PLAYLIST_DETAIL_PREFETCH_LIMIT = 12
 private const val PLAYLIST_DETAIL_PREFETCH_MAX_SONGS = 500
@@ -529,6 +530,7 @@ class SakiAppViewModel @Inject constructor(
         val serverId = state.selectedServerId ?: return
         val type = state.selectedAlbumFeed
         val feedState = state.albumFeedState(type)
+        val pageSize = type.albumFeedPageSize()
         if (
             !type.supportsPagination() ||
             !feedState.hasMore ||
@@ -552,7 +554,7 @@ class SakiAppViewModel @Inject constructor(
                 subsonicRepository.getAlbumList(
                     serverId = serverId,
                     type = type,
-                    size = ALBUMS_PAGE_SIZE,
+                    size = pageSize,
                     offset = offset,
                 ).data
             }.onSuccess { page ->
@@ -567,7 +569,7 @@ class SakiAppViewModel @Inject constructor(
                                 it.copy(
                                     albums = mergedAlbums,
                                     offset = offset + page.size,
-                                    hasMore = page.size >= ALBUMS_PAGE_SIZE,
+                                    hasMore = page.size >= pageSize,
                                     isLoadingMore = false,
                                     error = null,
                                 )
@@ -576,6 +578,9 @@ class SakiAppViewModel @Inject constructor(
                     }
                     runCatching { libraryCacheRepository.saveAlbums(serverId, type, mergedAlbums) }
                         .onFailure { Log.w("SakiApp", "Failed to cache albums", it) }
+                    if (type.supportsAlbumFastScroll() && page.size >= pageSize) {
+                        loadRemainingSortedAlbumPages(serverId, type, pageSize)
+                    }
                 }
             }.onFailure { throwable ->
                 if (uiState.value.selectedServerId == serverId) {
@@ -1888,6 +1893,7 @@ class SakiAppViewModel @Inject constructor(
         forceRefresh: Boolean = false,
     ) {
         val currentFeed = uiState.value.albumFeedState(type)
+        val pageSize = type.albumFeedPageSize()
         if (!forceRefresh && (currentFeed.isLoading || currentFeed.hasLoadedFromNetwork)) {
             return
         }
@@ -1929,7 +1935,7 @@ class SakiAppViewModel @Inject constructor(
                 subsonicRepository.getAlbumList(
                     serverId = serverId,
                     type = type,
-                    size = ALBUMS_PAGE_SIZE,
+                    size = pageSize,
                     offset = 0,
                 ).data
             }.onSuccess { albums ->
@@ -1943,7 +1949,7 @@ class SakiAppViewModel @Inject constructor(
                                 it.copy(
                                     albums = uniqueAlbums,
                                     offset = albums.size,
-                                    hasMore = type.supportsPagination() && albums.size >= ALBUMS_PAGE_SIZE,
+                                    hasMore = type.supportsPagination() && albums.size >= pageSize,
                                     isLoading = false,
                                     isLoadingMore = false,
                                     error = null,
@@ -1955,6 +1961,9 @@ class SakiAppViewModel @Inject constructor(
                 }
                 runCatching { libraryCacheRepository.saveAlbums(serverId, type, uniqueAlbums) }
                     .onFailure { Log.w("SakiApp", "Failed to cache albums", it) }
+                if (type.supportsAlbumFastScroll() && albums.size >= pageSize) {
+                    loadRemainingSortedAlbumPages(serverId, type, pageSize)
+                }
             }.onFailure { throwable ->
                 if (uiState.value.selectedServerId == serverId) {
                     mutableUiState.update { state ->
@@ -1970,6 +1979,77 @@ class SakiAppViewModel @Inject constructor(
                     }
                 }
             }
+        }
+    }
+
+    private suspend fun loadRemainingSortedAlbumPages(
+        serverId: Long,
+        type: AlbumListType,
+        pageSize: Int,
+    ) {
+        if (!type.supportsAlbumFastScroll()) return
+
+        while (uiState.value.selectedServerId == serverId) {
+            val feedState = uiState.value.albumFeedState(type)
+            if (!feedState.hasMore || feedState.isLoadingMore) return
+
+            val offset = feedState.offset
+            mutableUiState.update { current ->
+                current.copy(
+                    albumFeeds = current.albumFeeds.updateFeed(type) {
+                        it.copy(isLoadingMore = true, error = null)
+                    },
+                )
+            }
+
+            val page = try {
+                subsonicRepository.getAlbumList(
+                    serverId = serverId,
+                    type = type,
+                    size = pageSize,
+                    offset = offset,
+                ).data
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (throwable: Throwable) {
+                if (uiState.value.selectedServerId == serverId) {
+                    mutableUiState.update { current ->
+                        current.copy(
+                            albumFeeds = current.albumFeeds.updateFeed(type) {
+                                it.copy(isLoadingMore = false)
+                            },
+                        )
+                    }
+                    Log.w("SakiApp", "Failed to prefetch sorted album page", throwable)
+                }
+                return
+            }
+
+            if (uiState.value.selectedServerId != serverId) return
+
+            var mergedAlbums = emptyList<AlbumSummary>()
+            var shouldContinue = false
+            mutableUiState.update { current ->
+                val currentFeed = current.albumFeedState(type)
+                val visiblePage = page.withoutUnknownAlbumPlaceholders()
+                mergedAlbums = (currentFeed.albums + visiblePage).distinctBy(AlbumSummary::id)
+                shouldContinue = page.size >= pageSize
+                current.copy(
+                    albumFeeds = current.albumFeeds.updateFeed(type) {
+                        it.copy(
+                            albums = mergedAlbums,
+                            offset = offset + page.size,
+                            hasMore = shouldContinue,
+                            isLoadingMore = false,
+                            error = null,
+                        )
+                    },
+                )
+            }
+            runCatching { libraryCacheRepository.saveAlbums(serverId, type, mergedAlbums) }
+                .onFailure { Log.w("SakiApp", "Failed to cache albums", it) }
+
+            if (!shouldContinue) return
         }
     }
 
@@ -2897,4 +2977,13 @@ private fun Song.withFallbackAlbumMetadata(album: Album): Song {
 
 private fun AlbumListType.supportsPagination(): Boolean {
     return this != AlbumListType.RANDOM && this != AlbumListType.STARRED
+}
+
+private fun AlbumListType.supportsAlbumFastScroll(): Boolean {
+    return this == AlbumListType.ALPHABETICAL_BY_NAME ||
+        this == AlbumListType.ALPHABETICAL_BY_ARTIST
+}
+
+private fun AlbumListType.albumFeedPageSize(): Int {
+    return if (supportsAlbumFastScroll()) SORTED_ALBUMS_PAGE_SIZE else ALBUMS_PAGE_SIZE
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -112,6 +112,7 @@ class SakiAppViewModel @Inject constructor(
     private var lastLoadedServerId: Long? = null
     private var appliedDefaultBrowsePreference = false
     private var deferredStreamCacheSummaryJob: Job? = null
+    private val sortedAlbumPrefetchJobs = mutableMapOf<AlbumListType, Job>()
 
     private val mutableEndpointStatus = MutableStateFlow(EndpointStatus())
     val endpointStatus: StateFlow<EndpointStatus> = mutableEndpointStatus.asStateFlow()
@@ -474,6 +475,8 @@ class SakiAppViewModel @Inject constructor(
         if (previousServerId == serverId) return
         val server = uiState.value.servers.find { it.id == serverId } ?: return
 
+        sortedAlbumPrefetchJobs.values.forEach { it.cancel() }
+        sortedAlbumPrefetchJobs.clear()
         clearSearchState()
         mutableUiState.update { state ->
             state.copy(
@@ -535,7 +538,8 @@ class SakiAppViewModel @Inject constructor(
             !type.supportsPagination() ||
             !feedState.hasMore ||
             feedState.isLoading ||
-            feedState.isLoadingMore
+            feedState.isLoadingMore ||
+            sortedAlbumPrefetchJobs[type]?.isActive == true
         ) {
             return
         }
@@ -579,7 +583,7 @@ class SakiAppViewModel @Inject constructor(
                     runCatching { libraryCacheRepository.saveAlbums(serverId, type, mergedAlbums) }
                         .onFailure { Log.w("SakiApp", "Failed to cache albums", it) }
                     if (type.supportsAlbumFastScroll() && page.size >= pageSize) {
-                        loadRemainingSortedAlbumPages(serverId, type, pageSize)
+                        startSortedAlbumPrefetch(serverId, type, pageSize)
                     }
                 }
             }.onFailure { throwable ->
@@ -1892,6 +1896,9 @@ class SakiAppViewModel @Inject constructor(
         type: AlbumListType,
         forceRefresh: Boolean = false,
     ) {
+        if (forceRefresh && type.supportsAlbumFastScroll()) {
+            sortedAlbumPrefetchJobs.remove(type)?.cancel()
+        }
         val currentFeed = uiState.value.albumFeedState(type)
         val pageSize = type.albumFeedPageSize()
         if (!forceRefresh && (currentFeed.isLoading || currentFeed.hasLoadedFromNetwork)) {
@@ -1962,7 +1969,7 @@ class SakiAppViewModel @Inject constructor(
                 runCatching { libraryCacheRepository.saveAlbums(serverId, type, uniqueAlbums) }
                     .onFailure { Log.w("SakiApp", "Failed to cache albums", it) }
                 if (type.supportsAlbumFastScroll() && albums.size >= pageSize) {
-                    loadRemainingSortedAlbumPages(serverId, type, pageSize)
+                    startSortedAlbumPrefetch(serverId, type, pageSize)
                 }
             }.onFailure { throwable ->
                 if (uiState.value.selectedServerId == serverId) {
@@ -1982,6 +1989,27 @@ class SakiAppViewModel @Inject constructor(
         }
     }
 
+    private fun startSortedAlbumPrefetch(
+        serverId: Long,
+        type: AlbumListType,
+        pageSize: Int,
+    ) {
+        if (!type.supportsAlbumFastScroll()) return
+        if (sortedAlbumPrefetchJobs[type]?.isActive == true) return
+
+        val job = viewModelScope.launch {
+            loadRemainingSortedAlbumPages(serverId, type, pageSize)
+        }
+        sortedAlbumPrefetchJobs[type] = job
+        job.invokeOnCompletion {
+            viewModelScope.launch {
+                if (sortedAlbumPrefetchJobs[type] === job) {
+                    sortedAlbumPrefetchJobs.remove(type)
+                }
+            }
+        }
+    }
+
     private suspend fun loadRemainingSortedAlbumPages(
         serverId: Long,
         type: AlbumListType,
@@ -1989,9 +2017,13 @@ class SakiAppViewModel @Inject constructor(
     ) {
         if (!type.supportsAlbumFastScroll()) return
 
+        var latestMergedAlbums: List<AlbumSummary>? = null
         while (uiState.value.selectedServerId == serverId) {
             val feedState = uiState.value.albumFeedState(type)
-            if (!feedState.hasMore || feedState.isLoadingMore) return
+            if (!feedState.hasMore || feedState.isLoadingMore) {
+                cacheSortedAlbumPrefetch(serverId, type, latestMergedAlbums)
+                return
+            }
 
             val offset = feedState.offset
             mutableUiState.update { current ->
@@ -2022,6 +2054,7 @@ class SakiAppViewModel @Inject constructor(
                     }
                     Log.w("SakiApp", "Failed to prefetch sorted album page", throwable)
                 }
+                cacheSortedAlbumPrefetch(serverId, type, latestMergedAlbums)
                 return
             }
 
@@ -2046,10 +2079,27 @@ class SakiAppViewModel @Inject constructor(
                     },
                 )
             }
-            runCatching { libraryCacheRepository.saveAlbums(serverId, type, mergedAlbums) }
-                .onFailure { Log.w("SakiApp", "Failed to cache albums", it) }
+            latestMergedAlbums = mergedAlbums
 
-            if (!shouldContinue) return
+            if (!shouldContinue) {
+                cacheSortedAlbumPrefetch(serverId, type, latestMergedAlbums)
+                return
+            }
+        }
+    }
+
+    private suspend fun cacheSortedAlbumPrefetch(
+        serverId: Long,
+        type: AlbumListType,
+        albums: List<AlbumSummary>?,
+    ) {
+        if (albums == null) return
+        try {
+            libraryCacheRepository.saveAlbums(serverId, type, albums)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (throwable: Throwable) {
+            Log.w("SakiApp", "Failed to cache prefetched albums", throwable)
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -15,6 +15,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -1131,7 +1132,7 @@ fun AlbumCard(album: AlbumSummary, server: ServerConfig, onOpenAlbum: (String) -
                 contentDescription = album.name,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(170.dp),
+                    .aspectRatio(1f),
                 cornerRadiusDp = 24,
                 requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
             )

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -75,6 +75,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
@@ -126,11 +127,13 @@ import org.hdhmc.saki.presentation.asString
 import org.hdhmc.saki.ui.theme.SakiChromeIconButton
 import org.hdhmc.saki.ui.theme.SakiTheme
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -1695,8 +1698,15 @@ private fun AlbumFeedPageContent(
     onOpenAlbum: (String) -> Unit,
     bottomOverlayPadding: Dp,
 ) {
-    val fastScrollIndex = remember(feed, albums, ignoredArticles) {
-        albums.albumFastScrollIndex(feed, ignoredArticles)
+    val fastScrollIndex by produceState<AlbumFastScrollIndex?>(
+        initialValue = null,
+        feed,
+        albums,
+        ignoredArticles,
+    ) {
+        value = withContext(Dispatchers.Default) {
+            albums.albumFastScrollIndex(feed, ignoredArticles)
+        }
     }
     val contentPadding = albumFeedContentPadding(
         bottomOverlayPadding = bottomOverlayPadding,
@@ -1847,8 +1857,8 @@ private fun AlbumFastScrollOverlay(
     if (index == null || labels.size <= 1) return
 
     val haptic = LocalHapticFeedback.current
-    var showScrollBar by remember(labels) { mutableStateOf(false) }
-    LaunchedEffect(labels) {
+    var showScrollBar by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
         kotlinx.coroutines.delay(500)
         showScrollBar = true
     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -1,5 +1,6 @@
 package org.hdhmc.saki.presentation.library
 
+import android.icu.text.AlphabeticIndex
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -97,6 +98,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import java.util.Locale
 import kotlin.math.abs
 import org.hdhmc.saki.R
 import org.hdhmc.saki.domain.model.Album
@@ -110,6 +112,7 @@ import org.hdhmc.saki.domain.model.SearchResults
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.domain.model.SongFeedType
+import org.hdhmc.saki.domain.model.isUnknownAlbumPlaceholder
 import org.hdhmc.saki.presentation.BrowseSection
 import org.hdhmc.saki.presentation.AlbumFeedState
 import org.hdhmc.saki.presentation.labelRes
@@ -818,6 +821,7 @@ private fun BrowsePager(
                                     server = currentServer,
                                     selectedFeed = uiState.selectedAlbumFeed,
                                     viewMode = uiState.appPreferences.albumViewMode,
+                                    ignoredArticles = uiState.libraryIndexes?.ignoredArticles,
                                     scrollPositions = scrollState.albumFeedPositions,
                                     onSelectFeed = onSelectAlbumFeed,
                                     onLoadMore = onLoadMoreAlbums,
@@ -1513,6 +1517,7 @@ private fun AlbumsPage(
     server: ServerConfig,
     selectedFeed: AlbumListType,
     viewMode: AlbumViewMode,
+    ignoredArticles: String?,
     scrollPositions: Map<AlbumListType, AlbumFeedScrollPosition>,
     onSelectFeed: (AlbumListType) -> Unit,
     onLoadMore: () -> Unit,
@@ -1582,9 +1587,11 @@ private fun AlbumsPage(
             val feedState = albumFeeds[feed] ?: AlbumFeedState()
             val scrollPosition = scrollPositions.getValue(feed)
             AlbumFeedPageContent(
+                feed = feed,
                 albums = feedState.albums,
                 server = server,
                 viewMode = viewMode,
+                ignoredArticles = ignoredArticles,
                 scrollPosition = scrollPosition,
                 isLoading = feedState.isLoading,
                 hasMore = feedState.hasMore,
@@ -1673,9 +1680,11 @@ private const val PagerOffsetSettlingEpsilon = 0.001f
 
 @Composable
 private fun AlbumFeedPageContent(
+    feed: AlbumListType,
     albums: List<AlbumSummary>,
     server: ServerConfig,
     viewMode: AlbumViewMode,
+    ignoredArticles: String?,
     scrollPosition: AlbumFeedScrollPosition,
     isLoading: Boolean,
     hasMore: Boolean,
@@ -1686,6 +1695,14 @@ private fun AlbumFeedPageContent(
     onOpenAlbum: (String) -> Unit,
     bottomOverlayPadding: Dp,
 ) {
+    val fastScrollIndex = remember(feed, albums, ignoredArticles) {
+        albums.albumFastScrollIndex(feed, ignoredArticles)
+    }
+    val contentPadding = albumFeedContentPadding(
+        bottomOverlayPadding = bottomOverlayPadding,
+        hasFastScroll = fastScrollIndex != null,
+    )
+    val coroutineScope = rememberCoroutineScope()
     when (viewMode) {
         AlbumViewMode.GRID -> {
             val gridState = rememberRestoredLazyGridState(scrollPosition.gridPosition)
@@ -1704,37 +1721,46 @@ private fun AlbumFeedPageContent(
                     .collect { onLoadMore() }
             }
 
-            LazyVerticalGrid(
-                state = gridState,
-                modifier = Modifier.fillMaxSize(),
-                columns = GridCells.Fixed(2),
-                contentPadding = bottomContentPadding(bottomOverlayPadding),
-            ) {
-                when {
-                    isLoading && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
-                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                    }
+            Box(modifier = Modifier.fillMaxSize()) {
+                LazyVerticalGrid(
+                    state = gridState,
+                    modifier = Modifier.fillMaxSize(),
+                    columns = GridCells.Fixed(2),
+                    contentPadding = contentPadding,
+                ) {
+                    when {
+                        isLoading && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
+                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
+                        }
 
-                    error != null && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
-                        ErrorStateCard(error)
-                    }
+                        error != null && albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
+                            ErrorStateCard(error)
+                        }
 
-                    albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
-                        EmptyStateCard(
-                            stringResource(R.string.browse_no_albums),
-                            stringResource(R.string.browse_no_albums_body),
-                        )
-                    }
+                        albums.isEmpty() -> item(span = { GridItemSpan(maxLineSpan) }) {
+                            EmptyStateCard(
+                                stringResource(R.string.browse_no_albums),
+                                stringResource(R.string.browse_no_albums_body),
+                            )
+                        }
 
-                    else -> items(albums, key = { it.id }) { album ->
-                        AlbumCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
+                        else -> items(albums, key = { it.id }) { album ->
+                            AlbumCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
+                        }
+                    }
+                    if (isLoadingMore) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
+                        }
                     }
                 }
-                if (isLoadingMore) {
-                    item(span = { GridItemSpan(maxLineSpan) }) {
-                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                    }
-                }
+                AlbumFastScrollOverlay(
+                    index = fastScrollIndex,
+                    bottomOverlayPadding = bottomOverlayPadding,
+                    onScrollToAlbumIndex = { itemIndex ->
+                        coroutineScope.launch { gridState.scrollToItem(itemIndex) }
+                    },
+                )
             }
         }
 
@@ -1755,39 +1781,203 @@ private fun AlbumFeedPageContent(
                     .collect { onLoadMore() }
             }
 
-            LazyColumn(
-                state = listState,
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = bottomContentPadding(bottomOverlayPadding),
-            ) {
-                when {
-                    isLoading && albums.isEmpty() -> item {
-                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                    }
+            Box(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = contentPadding,
+                ) {
+                    when {
+                        isLoading && albums.isEmpty() -> item {
+                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
+                        }
 
-                    error != null && albums.isEmpty() -> item {
-                        ErrorStateCard(error)
-                    }
+                        error != null && albums.isEmpty() -> item {
+                            ErrorStateCard(error)
+                        }
 
-                    albums.isEmpty() -> item {
-                        EmptyStateCard(
-                            stringResource(R.string.browse_no_albums),
-                            stringResource(R.string.browse_no_albums_body),
-                        )
-                    }
+                        albums.isEmpty() -> item {
+                            EmptyStateCard(
+                                stringResource(R.string.browse_no_albums),
+                                stringResource(R.string.browse_no_albums_body),
+                            )
+                        }
 
-                    else -> items(albums, key = { it.id }) { album ->
-                        AlbumRow(album = album, server = server, onOpenAlbum = onOpenAlbum)
+                        else -> items(albums, key = { it.id }) { album ->
+                            AlbumRow(album = album, server = server, onOpenAlbum = onOpenAlbum)
+                        }
+                    }
+                    if (isLoadingMore) {
+                        item {
+                            LoadingStateCard(stringResource(R.string.browse_loading_albums))
+                        }
                     }
                 }
-                if (isLoadingMore) {
-                    item {
-                        LoadingStateCard(stringResource(R.string.browse_loading_albums))
-                    }
-                }
+                AlbumFastScrollOverlay(
+                    index = fastScrollIndex,
+                    bottomOverlayPadding = bottomOverlayPadding,
+                    onScrollToAlbumIndex = { itemIndex ->
+                        coroutineScope.launch { listState.scrollToItem(itemIndex) }
+                    },
+                )
             }
         }
     }
+}
+
+private fun albumFeedContentPadding(
+    bottomOverlayPadding: Dp,
+    hasFastScroll: Boolean,
+): PaddingValues {
+    return PaddingValues(
+        end = if (hasFastScroll) AlbumFastScrollContentEndPadding else 0.dp,
+        bottom = 24.dp + bottomOverlayPadding,
+    )
+}
+
+private val AlbumFastScrollContentEndPadding = 24.dp
+
+@Composable
+private fun AlbumFastScrollOverlay(
+    index: AlbumFastScrollIndex?,
+    bottomOverlayPadding: Dp,
+    onScrollToAlbumIndex: (Int) -> Unit,
+) {
+    val labels = index?.labels.orEmpty()
+    if (index == null || labels.size <= 1) return
+
+    val haptic = LocalHapticFeedback.current
+    var showScrollBar by remember(labels) { mutableStateOf(false) }
+    LaunchedEffect(labels) {
+        kotlinx.coroutines.delay(500)
+        showScrollBar = true
+    }
+
+    androidx.compose.animation.AnimatedVisibility(
+        visible = showScrollBar,
+        enter = androidx.compose.animation.fadeIn(),
+        exit = androidx.compose.animation.fadeOut(),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = 8.dp, bottom = 8.dp + bottomOverlayPadding),
+    ) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.CenterEnd) {
+            AlphabetScrollBar(
+                labels = labels,
+                onScrollTo = { labelIndex ->
+                    val label = labels.getOrNull(labelIndex) ?: return@AlphabetScrollBar
+                    val albumIndex = index.targetAlbumIndices[label] ?: return@AlphabetScrollBar
+                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    onScrollToAlbumIndex(albumIndex)
+                },
+            )
+        }
+    }
+}
+
+private data class AlbumFastScrollIndex(
+    val labels: List<String>,
+    val targetAlbumIndices: Map<String, Int>,
+)
+
+private fun List<AlbumSummary>.albumFastScrollIndex(
+    feed: AlbumListType,
+    ignoredArticles: String?,
+): AlbumFastScrollIndex? {
+    if (!feed.supportsAlbumFastScroll() || size < 2) return null
+
+    val articles = ignoredArticles.toIgnoredArticleList()
+    val locale = Locale.getDefault()
+    val index = AlphabeticIndex<Nothing>(locale)
+        .addLabels(Locale.ENGLISH)
+        .addLabels(Locale.JAPANESE)
+        .addLabels(Locale.CHINESE)
+        .addLabels(Locale.KOREAN)
+        .setOverflowLabel("#")
+        .setUnderflowLabel("#")
+        .buildImmutableIndex()
+    val firstAlbumIndexByBucket = linkedMapOf<Int, AlbumFastScrollBucket>()
+    forEachIndexed { albumIndex, album ->
+        if (album.isUnknownAlbumPlaceholder()) return@forEachIndexed
+        val sortValue = album.fastScrollSortValue(feed).stripIgnoredArticles(articles)
+        val bucketIndex = index.getBucketIndex(sortValue)
+        firstAlbumIndexByBucket.putIfAbsent(
+            bucketIndex,
+            AlbumFastScrollBucket(
+                label = index.getBucket(bucketIndex).label,
+                albumIndex = albumIndex,
+            ),
+        )
+    }
+
+    val scrollBarMapping = firstAlbumIndexByBucket.albumScrollBarMapping()
+    val labels = scrollBarMapping.map { it.first }
+    val targets = scrollBarMapping.toMap()
+    return if (labels.size > 1) AlbumFastScrollIndex(labels, targets) else null
+}
+
+private data class AlbumFastScrollBucket(
+    val label: String,
+    val albumIndex: Int,
+)
+
+private fun Map<Int, AlbumFastScrollBucket>.albumScrollBarMapping(): List<Pair<String, Int>> {
+    val result = mutableListOf<Pair<String, Int>>()
+    var otherTarget: Int? = null
+    entries.sortedBy { it.key }.forEach { (_, bucket) ->
+        val label = bucket.label
+        val albumIndex = bucket.albumIndex
+        when {
+            label.length == 1 && label[0] in 'A'..'Z' -> {
+                if (result.none { it.first == label }) {
+                    result.add(label to albumIndex)
+                }
+            }
+            label == "#" -> {
+                if (result.none { it.first == "#" }) {
+                    result.add(0, "#" to albumIndex)
+                }
+            }
+            otherTarget == null -> otherTarget = albumIndex
+        }
+    }
+    otherTarget?.let { result.add("…" to it) }
+    return result
+}
+
+private fun AlbumSummary.fastScrollSortValue(feed: AlbumListType): String {
+    return when (feed) {
+        AlbumListType.ALPHABETICAL_BY_ARTIST -> artist
+            ?: artists.firstOrNull()?.name
+            ?: name
+
+        else -> name
+    }.trim()
+}
+
+private fun String?.toIgnoredArticleList(): List<String> {
+    return this?.split(' ')
+        ?.map(String::trim)
+        ?.filter(String::isNotEmpty)
+        ?: emptyList()
+}
+
+private fun String.stripIgnoredArticles(articles: List<String>): String {
+    val value = trim()
+    for (article in articles) {
+        if (value.startsWith(article, ignoreCase = true) &&
+            value.length > article.length &&
+            value[article.length].isWhitespace()
+        ) {
+            return value.substring(article.length + 1).trimStart()
+        }
+    }
+    return value
+}
+
+private fun AlbumListType.supportsAlbumFastScroll(): Boolean {
+    return this == AlbumListType.ALPHABETICAL_BY_NAME ||
+        this == AlbumListType.ALPHABETICAL_BY_ARTIST
 }
 
 @Composable

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -75,7 +75,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
@@ -1698,13 +1697,9 @@ private fun AlbumFeedPageContent(
     onOpenAlbum: (String) -> Unit,
     bottomOverlayPadding: Dp,
 ) {
-    val fastScrollIndex by produceState<AlbumFastScrollIndex?>(
-        initialValue = null,
-        feed,
-        albums,
-        ignoredArticles,
-    ) {
-        value = withContext(Dispatchers.Default) {
+    var fastScrollIndex by remember(feed, ignoredArticles) { mutableStateOf<AlbumFastScrollIndex?>(null) }
+    LaunchedEffect(feed, albums, ignoredArticles) {
+        fastScrollIndex = withContext(Dispatchers.Default) {
             albums.albumFastScrollIndex(feed, ignoredArticles)
         }
     }


### PR DESCRIPTION
## Summary
- Add an A-Z fast-scroll overlay for `alphabeticalByName` and `alphabeticalByArtist` album feeds.
- Keep album grid/list item layout flat; the overlay jumps to matching album indices without adding section headers.
- Increase sorted album feed page size and prefetch remaining sorted pages in the background so the index becomes useful on large libraries.
- Keep newest/random feeds unchanged.
- Make grid album artwork square so the fast-scroll inset does not make cover aspect issues more visible.

## Validation
- `git diff --check`
- User built/installed locally and checked the UI on device.

Closes #255