### PR TITLE
fix: improve fast scroll accessibility

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -90,7 +90,12 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -2559,16 +2564,51 @@ private fun AlphabetScrollBar(
     modifier: Modifier = Modifier,
 ) {
     var activeIndex by remember { mutableStateOf(-1) }
+    var selectedIndex by remember(labels) { mutableStateOf(0) }
+    val safeSelectedIndex = selectedIndex.coerceIn(0, labels.lastIndex)
+    val scrollBarDescription = stringResource(R.string.browse_alphabet_scroll_bar)
+    val currentLabel = labels.getOrNull(safeSelectedIndex).orEmpty()
+    val previousSectionLabel = stringResource(R.string.browse_fast_scroll_previous_section)
+    val nextSectionLabel = stringResource(R.string.browse_fast_scroll_next_section)
+
+    fun scrollToIndex(index: Int): Boolean {
+        if (labels.isEmpty()) return false
+        val target = index.coerceIn(0, labels.lastIndex)
+        selectedIndex = target
+        activeIndex = target
+        onScrollTo(target)
+        return true
+    }
 
     Column(
         modifier = modifier
             .fillMaxHeight()
+            .semantics {
+                contentDescription = scrollBarDescription
+                stateDescription = currentLabel
+                customActions = listOf(
+                    CustomAccessibilityAction(previousSectionLabel) {
+                        if (safeSelectedIndex <= 0) {
+                            false
+                        } else {
+                            scrollToIndex(safeSelectedIndex - 1)
+                        }
+                    },
+                    CustomAccessibilityAction(nextSectionLabel) {
+                        if (safeSelectedIndex >= labels.lastIndex) {
+                            false
+                        } else {
+                            scrollToIndex(safeSelectedIndex + 1)
+                        }
+                    },
+                )
+            }
             .pointerInput(labels) {
                 detectTapGestures { offset ->
                     val idx = (offset.y / (size.height.toFloat() / labels.size))
                         .toInt()
                         .coerceIn(0, labels.lastIndex)
-                    onScrollTo(idx)
+                    scrollToIndex(idx)
                 }
             }
             .pointerInput(labels) {
@@ -2577,8 +2617,7 @@ private fun AlphabetScrollBar(
                         val idx = (offset.y / (size.height.toFloat() / labels.size))
                             .toInt()
                             .coerceIn(0, labels.lastIndex)
-                        activeIndex = idx
-                        onScrollTo(idx)
+                        scrollToIndex(idx)
                     },
                     onDragEnd = { activeIndex = -1 },
                     onDragCancel = { activeIndex = -1 },
@@ -2587,8 +2626,7 @@ private fun AlphabetScrollBar(
                             .toInt()
                             .coerceIn(0, labels.lastIndex)
                         if (idx != activeIndex) {
-                            activeIndex = idx
-                            onScrollTo(idx)
+                            scrollToIndex(idx)
                         }
                     },
                 )

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -2564,18 +2564,24 @@ private fun AlphabetScrollBar(
     modifier: Modifier = Modifier,
 ) {
     var activeIndex by remember { mutableStateOf(-1) }
-    var selectedIndex by remember(labels) { mutableStateOf(0) }
+    var selectedLabel by remember { mutableStateOf<String?>(null) }
+    val selectedIndex = selectedLabel
+        ?.let(labels::indexOf)
+        ?.takeIf { it >= 0 }
+        ?: 0
     val safeSelectedIndex = selectedIndex.coerceIn(0, labels.lastIndex)
     val scrollBarDescription = stringResource(R.string.browse_alphabet_scroll_bar)
     val currentLabel = labels.getOrNull(safeSelectedIndex).orEmpty()
     val previousSectionLabel = stringResource(R.string.browse_fast_scroll_previous_section)
     val nextSectionLabel = stringResource(R.string.browse_fast_scroll_next_section)
 
-    fun scrollToIndex(index: Int): Boolean {
+    fun scrollToIndex(index: Int, highlight: Boolean): Boolean {
         if (labels.isEmpty()) return false
         val target = index.coerceIn(0, labels.lastIndex)
-        selectedIndex = target
-        activeIndex = target
+        selectedLabel = labels[target]
+        if (highlight) {
+            activeIndex = target
+        }
         onScrollTo(target)
         return true
     }
@@ -2591,14 +2597,14 @@ private fun AlphabetScrollBar(
                         if (safeSelectedIndex <= 0) {
                             false
                         } else {
-                            scrollToIndex(safeSelectedIndex - 1)
+                            scrollToIndex(safeSelectedIndex - 1, highlight = false)
                         }
                     },
                     CustomAccessibilityAction(nextSectionLabel) {
                         if (safeSelectedIndex >= labels.lastIndex) {
                             false
                         } else {
-                            scrollToIndex(safeSelectedIndex + 1)
+                            scrollToIndex(safeSelectedIndex + 1, highlight = false)
                         }
                     },
                 )
@@ -2608,7 +2614,7 @@ private fun AlphabetScrollBar(
                     val idx = (offset.y / (size.height.toFloat() / labels.size))
                         .toInt()
                         .coerceIn(0, labels.lastIndex)
-                    scrollToIndex(idx)
+                    scrollToIndex(idx, highlight = false)
                 }
             }
             .pointerInput(labels) {
@@ -2617,7 +2623,7 @@ private fun AlphabetScrollBar(
                         val idx = (offset.y / (size.height.toFloat() / labels.size))
                             .toInt()
                             .coerceIn(0, labels.lastIndex)
-                        scrollToIndex(idx)
+                        scrollToIndex(idx, highlight = true)
                     },
                     onDragEnd = { activeIndex = -1 },
                     onDragCancel = { activeIndex = -1 },
@@ -2626,7 +2632,7 @@ private fun AlphabetScrollBar(
                             .toInt()
                             .coerceIn(0, labels.lastIndex)
                         if (idx != activeIndex) {
-                            scrollToIndex(idx)
+                            scrollToIndex(idx, highlight = true)
                         }
                     },
                 )

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -227,6 +227,9 @@
     <string name="browse_no_artists">无艺术家</string>
     <string name="browse_no_artists_body">服务器未返回艺术家索引。</string>
     <string name="browse_shortcuts">快捷方式</string>
+    <string name="browse_alphabet_scroll_bar">字母快速滚动条</string>
+    <string name="browse_fast_scroll_previous_section">上一段</string>
+    <string name="browse_fast_scroll_next_section">下一段</string>
     <string name="browse_loading_albums">正在加载专辑</string>
     <string name="browse_no_albums">无专辑</string>
     <string name="browse_no_albums_body">试试其他专辑排序。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,6 +234,9 @@
     <string name="browse_no_artists">No artists</string>
     <string name="browse_no_artists_body">The server did not return artist indexes.</string>
     <string name="browse_shortcuts">Shortcuts</string>
+    <string name="browse_alphabet_scroll_bar">Alphabet fast scroll</string>
+    <string name="browse_fast_scroll_previous_section">Previous section</string>
+    <string name="browse_fast_scroll_next_section">Next section</string>
     <string name="browse_loading_albums">Loading albums</string>
     <string name="browse_no_albums">No albums</string>
     <string name="browse_no_albums_body">Try another album feed.</string>


### PR DESCRIPTION
## Summary
- Add accessibility semantics to the shared alphabet fast scroller used by artist and album lists.
- Expose localized state/action text and custom actions for moving to the previous/next fast-scroll section.
- Keep existing pointer/tap/drag behavior and visuals unchanged.

## Validation
- `git diff --check`
- `./gradlew compileDebugKotlin --no-daemon`

Closes #313