### PR TITLE
fix: align song feed chips and cache slider preview

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -2030,8 +2030,8 @@ private fun AlbumFeedControls(
             contentPadding = PaddingValues(vertical = 10.dp),
         ) {
             items(feeds) { feed ->
-                AlbumFeedChip(
-                    feed = feed,
+                BrowseFeedChip(
+                    label = stringResource(feed.labelRes()),
                     selected = selectedFeed == feed,
                     onClick = { onSelectFeed(feed) },
                     modifier = Modifier.padding(end = 8.dp),
@@ -2052,14 +2052,13 @@ private fun AlbumFeedControls(
 }
 
 @Composable
-private fun AlbumFeedChip(
-    feed: AlbumListType,
+private fun BrowseFeedChip(
+    label: String,
     selected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val visuals = SakiTheme.visuals
-    val label = stringResource(feed.labelRes())
     if (visuals.browseSectionChipSelectedContainerAlpha <= 0f) {
         FilterChip(
             selected = selected,
@@ -2437,15 +2436,15 @@ private fun SongFeedControls(
             .padding(horizontal = 16.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        FilterChip(
+        BrowseFeedChip(
+            label = stringResource(R.string.browse_song_feed_default),
             selected = selected == SongFeedType.DEFAULT,
             onClick = { onSelect(SongFeedType.DEFAULT) },
-            label = { Text(stringResource(R.string.browse_song_feed_default)) },
         )
-        FilterChip(
+        BrowseFeedChip(
+            label = stringResource(R.string.browse_song_feed_random),
             selected = selected == SongFeedType.RANDOM,
             onClick = { onSelect(SongFeedType.RANDOM) },
-            label = { Text(stringResource(R.string.browse_song_feed_random)) },
         )
     }
 }

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -678,6 +678,7 @@ fun SettingsScreen(
                 storageSummary.streamCachedSongCount,
                 storageSummary.streamCachedSongCount,
             )
+            val previewStreamCacheSizeMb = streamCacheSliderValue.toStreamCacheSizeMb()
             val streamCacheBody = if (selectedServer != null) {
                 stringResource(R.string.settings_cache_count_on_server, streamCacheCount, selectedServer.name)
             } else {
@@ -699,7 +700,7 @@ fun SettingsScreen(
                     Text(
                         text = stringResource(
                             R.string.settings_cache_limit,
-                            formatStorageSize(configuredStreamCacheSizeMb.toLong() * 1024L * 1024L),
+                            formatStorageSize(previewStreamCacheSizeMb.toLong() * 1024L * 1024L),
                         ),
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -707,7 +708,7 @@ fun SettingsScreen(
                 }
                 LinearProgressIndicator(
                     progress = {
-                        val limit = configuredStreamCacheSizeMb.toLong() * 1024L * 1024L
+                        val limit = previewStreamCacheSizeMb.toLong() * 1024L * 1024L
                         if (limit <= 0L) 0f
                         else (storageSummary.streamCacheBytes.toFloat() / limit.toFloat()).coerceIn(0f, 1f)
                     },
@@ -781,6 +782,7 @@ fun SettingsScreen(
         }
 
         item {
+            val previewImageCacheSizeMb = imageCacheSliderValue.toImageCacheSizeMb()
             SettingsSectionCard(
                 title = stringResource(R.string.settings_cover_art_cache_title),
                 body = stringResource(R.string.settings_cover_art_cache_body),
@@ -797,7 +799,7 @@ fun SettingsScreen(
                     Text(
                         text = stringResource(
                             R.string.settings_cache_limit,
-                            formatStorageSize(configuredImageCacheSizeMb.toLong() * 1024L * 1024L),
+                            formatStorageSize(previewImageCacheSizeMb.toLong() * 1024L * 1024L),
                         ),
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -805,7 +807,7 @@ fun SettingsScreen(
                 }
                 LinearProgressIndicator(
                     progress = {
-                        val limit = configuredImageCacheSizeMb.toLong() * 1024L * 1024L
+                        val limit = previewImageCacheSizeMb.toLong() * 1024L * 1024L
                         if (limit <= 0L) 0f
                         else (storageSummary.imageCacheBytes.toFloat() / limit.toFloat()).coerceIn(0f, 1f)
                     },


### PR DESCRIPTION
## Summary
- Reuse the browse feed chip styling for the Songs Default/Random feed controls so they match album feed pills under M3E.
- Show the current dragged value for stream cache and cover art cache slider limits.
- Preview cache usage progress against the dragged limit while keeping persistence on slider release.

## Validation
- `git diff --check`
- `./gradlew compileDebugKotlin --no-daemon`