### PR TITLE
fix: unify predictive back by surface role (#317)

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
@@ -23,6 +23,27 @@ import kotlinx.coroutines.CancellationException
 
 private val PredictiveBackInterpolator = PathInterpolator(0.1f, 0.1f, 0f, 1f)
 
+/**
+ * Predictive-back model by surface role (issue #317).
+ *
+ * Every animated back gesture must preview the same target the completed back will reach. Pick the
+ * treatment by what the surface *is*, not ad-hoc per screen:
+ *
+ * - **Page / route** (Now Playing, Settings, Search overlay, Browse detail pages): use
+ *   [predictiveBackMotion] — scale + rounded corners + slight translate, revealing the previous
+ *   surface. Gate `enabled` so it is OFF whenever a higher-priority surface is consuming back
+ *   (a sheet, dialog, menu, or an internal expanded state). See `NowPlayingOverlay`.
+ * - **Anchored sheet** (queue sheet): do NOT use page motion. Map predictive progress to the sheet
+ *   anchors (Expanded -> PartiallyExpanded -> Hidden) with a single offset source of truth and a
+ *   critically-damped (non-bouncy) commit so the settle never rebounds. Reference implementation:
+ *   `PlayerQueueSheet` in PlayerChrome.kt.
+ * - **Dialog / menu** (AlertDialog, DropdownMenu, single-anchor ModalBottomSheet): rely on the
+ *   Material/system default dismiss. These render in their own window / install their own back
+ *   handling, so they already pre-empt the page motion underneath — just make sure the page's
+ *   `predictiveBackMotion` is not *also* enabled for an inline (non-window) overlay.
+ * - **Internal state** (lyrics panel, other in-page expanded/collapsed states): a plain
+ *   `BackHandler` that undoes the state first, and keep the page motion disabled while it is shown.
+ */
 @Composable
 fun Modifier.predictiveBackMotion(
     enabled: Boolean,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -1,7 +1,6 @@
 package org.hdhmc.saki.presentation.library
 
 import android.icu.text.AlphabeticIndex
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
@@ -194,12 +193,9 @@ fun BrowseScreen(
     }
     val scrollState = rememberBrowseScrollState(uiState.selectedServerId)
 
-    BackHandler(enabled = backHandlersEnabled && uiState.browseStack.size > 1) {
-        onPopDetail()
-    }
-    BackHandler(enabled = backHandlersEnabled && uiState.browseStack.size <= 1 && uiState.isSearchActive) {
-        onSetSearchActive(false)
-    }
+    // Back for detail pop and search-close is owned by the page-level `predictiveBackMotion`
+    // surfaces below (the topmost detail page / the search overlay), which are composed deeper
+    // and so handle both the gesture and the back button with the reveal animation.
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -69,6 +69,7 @@ import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.activity.compose.BackHandler
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -465,6 +466,8 @@ fun NowPlayingOverlay(
     var showMenu by remember(track.songId) { mutableStateOf(false) }
     var showLyrics by remember { mutableStateOf(false) }
     var showEndpointStatus by remember { mutableStateOf(false) }
+    val queueSheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden)
+    var showQueueSheet by remember { mutableStateOf(false) }
     val visualSnapshot = rememberNowPlayingVisualSnapshot(
         queue = playbackState.queue,
         currentIndex = playbackState.currentIndex,
@@ -536,14 +539,23 @@ fun NowPlayingOverlay(
     }
 
     val latestOnDismiss by rememberUpdatedState(onDismiss)
+    // Back is consumed by the topmost transient/anchored surface first; only run the
+    // page-level predictive back (dismiss Now Playing) when none of them are showing.
+    val backConsumedByOverlay =
+        showQueueSheet || showDetails || showMenu || showLyrics || showEndpointStatus
     val predictiveBackModifier = Modifier.predictiveBackMotion(
-        enabled = visible,
+        enabled = visible && !backConsumedByOverlay,
         onBack = { latestOnDismiss() },
     )
+    // Internal-state back: collapse the lyrics panel before exiting the page.
+    BackHandler(enabled = visible && showLyrics) { showLyrics = false }
 
-    // Reset lyrics overlay when Now Playing is dismissed
+    // Reset transient Now Playing overlays when the player is dismissed.
     LaunchedEffect(visible) {
-        if (!visible) showLyrics = false
+        if (!visible) {
+            showLyrics = false
+            showQueueSheet = false
+        }
     }
 
     AnimatedVisibility(
@@ -713,10 +725,6 @@ fun NowPlayingOverlay(
             val horizontalPadding = if (shortScreen) 16.dp else 20.dp
             val verticalSpacing = if (shortScreen) 8.dp else 12.dp
             val showQueueAffordance = playbackState.queue.size > 1
-
-            // Queue bottom sheet state
-            val queueSheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden)
-            var showQueueSheet by remember { mutableStateOf(false) }
             val latestOpenQueueSheet by rememberUpdatedState { showQueueSheet = true }
             val dismissSwipeModifier = Modifier.pointerInput(visible) {
                 if (!visible) return@pointerInput
@@ -1143,6 +1151,12 @@ fun NowPlayingOverlay(
                     sheetState = queueSheetState,
                     containerColor = MaterialTheme.colorScheme.surface,
                 ) {
+                    // Two-step back for the anchored queue sheet: Expanded collapses to
+                    // PartiallyExpanded; PartiallyExpanded falls through to the sheet's own dismiss.
+                    val queueScope = rememberCoroutineScope()
+                    BackHandler(enabled = queueSheetState.currentValue == SheetValue.Expanded) {
+                        queueScope.launch { queueSheetState.partialExpand() }
+                    }
                     Text(
                         text = stringResource(R.string.player_queue),
                         style = MaterialTheme.typography.headlineSmall,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -1795,10 +1795,24 @@ private fun PlayerQueueSheet(
             QueueSheetAnchor.Hidden -> hiddenOffset
         }
 
-        fun nearestAnchor(value: Float): QueueSheetAnchor = when {
-            value <= (expandedOffset + partialOffset) / 2f -> QueueSheetAnchor.Expanded
-            value <= (partialOffset + hiddenOffset) / 2f -> QueueSheetAnchor.Partial
-            else -> QueueSheetAnchor.Hidden
+        // Mirror M3 ModalBottomSheet settling: a flick past the velocity threshold moves to the
+        // next anchor in the fling direction; otherwise snap to the nearest anchor (positional).
+        // The velocity rule is what makes a short one-handed swipe actually expand the sheet.
+        val velocityThresholdPx = with(density) { 125.dp.toPx() }
+        val anchorOffsets = listOf(
+            QueueSheetAnchor.Expanded to expandedOffset,
+            QueueSheetAnchor.Partial to partialOffset,
+            QueueSheetAnchor.Hidden to hiddenOffset,
+        )
+        fun settleTarget(value: Float, velocityY: Float): QueueSheetAnchor {
+            val expandSide = anchorOffsets.last { it.second <= value }
+            val collapseSide = anchorOffsets.first { it.second >= value }
+            return when {
+                velocityY <= -velocityThresholdPx -> expandSide.first
+                velocityY >= velocityThresholdPx -> collapseSide.first
+                value - expandSide.second <= collapseSide.second - value -> expandSide.first
+                else -> collapseSide.first
+            }
         }
 
         var offsetY by remember { mutableFloatStateOf(hiddenOffset) }
@@ -1881,7 +1895,7 @@ private fun PlayerQueueSheet(
 
                 override suspend fun onPreFling(available: Velocity): Velocity {
                     if (offsetY > expandedOffset) {
-                        settleTo(nearestAnchor(offsetY))
+                        settleTo(settleTarget(offsetY, available.y))
                         return available
                     }
                     return Velocity.Zero
@@ -1900,7 +1914,9 @@ private fun PlayerQueueSheet(
             tonalElevation = 1.dp,
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
-                Box(
+                // The whole header (handle + title) is the drag grab area so the sheet can be
+                // expanded/collapsed one-handed like the M3 ModalBottomSheet, not only via the pill.
+                Column(
                     modifier = Modifier
                         .fillMaxWidth()
                         .draggable(
@@ -1909,25 +1925,29 @@ private fun PlayerQueueSheet(
                             },
                             orientation = Orientation.Vertical,
                             onDragStarted = { motionJob?.cancel() },
-                            onDragStopped = { settleTo(nearestAnchor(offsetY)) },
+                            onDragStopped = { velocity -> settleTo(settleTarget(offsetY, velocity)) },
                         ),
-                    contentAlignment = Alignment.Center,
                 ) {
                     Box(
-                        modifier = Modifier
-                            .padding(vertical = 12.dp)
-                            .size(width = 32.dp, height = 4.dp)
-                            .background(
-                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                                RoundedCornerShape(2.dp),
-                            ),
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .padding(vertical = 12.dp)
+                                .size(width = 32.dp, height = 4.dp)
+                                .background(
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                    RoundedCornerShape(2.dp),
+                                ),
+                        )
+                    }
+                    Text(
+                        text = stringResource(R.string.player_queue),
+                        style = MaterialTheme.typography.headlineSmall,
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
                     )
                 }
-                Text(
-                    text = stringResource(R.string.player_queue),
-                    style = MaterialTheme.typography.headlineSmall,
-                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
-                )
                 val queueListState = rememberLazyListState(
                     initialFirstVisibleItemIndex = (currentIndex - 2).coerceAtLeast(0),
                 )

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -1149,21 +1149,6 @@ fun NowPlayingOverlay(
                 }
             }
 
-            // Queue sheet (custom anchored surface — owns its own predictive back so the
-            // Expanded -> PartiallyExpanded -> Hidden transitions animate as sheet anchors,
-            // and the back-commit eases in without a rebound).
-            if (showQueueSheet) {
-                PlayerQueueSheet(
-                    queue = playbackState.queue,
-                    currentIndex = playbackState.currentIndex,
-                    serversById = serversById,
-                    verticalSpacing = verticalSpacing,
-                    onSkipToQueueItem = onSkipToQueueItem,
-                    onRemoveQueueItem = onRemoveQueueItem,
-                    onDismissed = { showQueueSheet = false },
-                )
-            }
-
             SnackbarHost(
                 hostState = playerSnackbarHostState,
                 modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 8.dp),
@@ -1177,6 +1162,19 @@ fun NowPlayingOverlay(
                 )
             }
         }
+    }
+
+    // Queue sheet renders at the overlay root (outside the status/nav-bar padding) so its scrim
+    // covers the full window including the status bar. It owns its own predictive back.
+    if (visible && showQueueSheet) {
+        PlayerQueueSheet(
+            queue = playbackState.queue,
+            currentIndex = playbackState.currentIndex,
+            serversById = serversById,
+            onSkipToQueueItem = onSkipToQueueItem,
+            onRemoveQueueItem = onRemoveQueueItem,
+            onDismissed = { showQueueSheet = false },
+        )
     }
 
     if (showDetails) {
@@ -1773,7 +1771,6 @@ private fun PlayerQueueSheet(
     queue: List<PlaybackQueueItem>,
     currentIndex: Int,
     serversById: Map<Long, ServerConfig>,
-    verticalSpacing: Dp,
     onSkipToQueueItem: (Int) -> Unit,
     onRemoveQueueItem: (Int) -> Unit,
     onDismissed: () -> Unit,
@@ -1785,6 +1782,7 @@ private fun PlayerQueueSheet(
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val density = LocalDensity.current
         val fullHeightPx = constraints.maxHeight.toFloat()
+        val verticalSpacing = if (maxHeight < 640.dp) 8.dp else 12.dp
         val expandedOffset = with(density) { 56.dp.toPx() }
         val partialOffset = fullHeightPx * 0.5f
         val hiddenOffset = fullHeightPx
@@ -1838,7 +1836,7 @@ private fun PlayerQueueSheet(
             motionJob?.cancel()
             val start = settledAnchor
             val target = if (start == QueueSheetAnchor.Expanded) QueueSheetAnchor.Partial else QueueSheetAnchor.Hidden
-            val from = offsetFor(start)
+            val from = offsetY
             val to = offsetFor(target)
             try {
                 events.collect { event -> offsetY = lerp(from, to, event.progress.coerceIn(0f, 1f)) }
@@ -1868,6 +1866,9 @@ private fun PlayerQueueSheet(
         val nestedScrollConnection = remember(expandedOffset, hiddenOffset) {
             object : NestedScrollConnection {
                 override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                    // Only user drags move the sheet; ignore momentum/fling so a leftover list
+                    // fling can't re-expand or dismiss the sheet during/after a back commit.
+                    if (source != NestedScrollSource.UserInput) return Offset.Zero
                     val delta = available.y
                     // Dragging up first expands the sheet until it reaches the top anchor.
                     if (delta < 0f && offsetY > expandedOffset) {
@@ -1881,6 +1882,7 @@ private fun PlayerQueueSheet(
                 }
 
                 override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+                    if (source != NestedScrollSource.UserInput) return Offset.Zero
                     val delta = available.y
                     // Dragging down once the list is at the top collapses the sheet.
                     if (delta > 0f) {

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -70,6 +70,15 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.PredictiveBackHandler
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.util.lerp
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -78,7 +87,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Snackbar
@@ -88,8 +96,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.SheetValue
-import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -466,7 +472,6 @@ fun NowPlayingOverlay(
     var showMenu by remember(track.songId) { mutableStateOf(false) }
     var showLyrics by remember { mutableStateOf(false) }
     var showEndpointStatus by remember { mutableStateOf(false) }
-    val queueSheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden)
     var showQueueSheet by remember { mutableStateOf(false) }
     val visualSnapshot = rememberNowPlayingVisualSnapshot(
         queue = playbackState.queue,
@@ -1144,44 +1149,19 @@ fun NowPlayingOverlay(
                 }
             }
 
-            // Queue BottomSheet
+            // Queue sheet (custom anchored surface — owns its own predictive back so the
+            // Expanded -> PartiallyExpanded -> Hidden transitions animate as sheet anchors,
+            // and the back-commit eases in without a rebound).
             if (showQueueSheet) {
-                ModalBottomSheet(
-                    onDismissRequest = { showQueueSheet = false },
-                    sheetState = queueSheetState,
-                    containerColor = MaterialTheme.colorScheme.surface,
-                ) {
-                    // Two-step back for the anchored queue sheet: Expanded collapses to
-                    // PartiallyExpanded; PartiallyExpanded falls through to the sheet's own dismiss.
-                    val queueScope = rememberCoroutineScope()
-                    BackHandler(enabled = queueSheetState.currentValue == SheetValue.Expanded) {
-                        queueScope.launch { queueSheetState.partialExpand() }
-                    }
-                    Text(
-                        text = stringResource(R.string.player_queue),
-                        style = MaterialTheme.typography.headlineSmall,
-                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
-                    )
-                    val queueListState = rememberLazyListState(
-                        initialFirstVisibleItemIndex = (playbackState.currentIndex - 2).coerceAtLeast(0),
-                    )
-                    LazyColumn(
-                        modifier = Modifier.fillMaxWidth(),
-                        state = queueListState,
-                        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 28.dp),
-                        verticalArrangement = Arrangement.spacedBy(verticalSpacing),
-                    ) {
-                        itemsIndexed(playbackState.queue) { index, item ->
-                            QueueRow(
-                                item = item,
-                                isCurrent = index == playbackState.currentIndex,
-                                currentServer = item.serverId?.let { serversById[it] },
-                                onClick = { onSkipToQueueItem(index) },
-                                onRemove = { onRemoveQueueItem(index) },
-                            )
-                        }
-                    }
-                }
+                PlayerQueueSheet(
+                    queue = playbackState.queue,
+                    currentIndex = playbackState.currentIndex,
+                    serversById = serversById,
+                    verticalSpacing = verticalSpacing,
+                    onSkipToQueueItem = onSkipToQueueItem,
+                    onRemoveQueueItem = onRemoveQueueItem,
+                    onDismissed = { showQueueSheet = false },
+                )
             }
 
             SnackbarHost(
@@ -1774,6 +1754,202 @@ private fun metadataLinkScrollDurationMillis(distancePx: Int, speedPxPerMs: Floa
     return (distancePx / speedPxPerMs)
         .roundToInt()
         .coerceAtLeast(METADATA_LINK_SCROLL_MIN_DURATION_MS)
+}
+
+private enum class QueueSheetAnchor { Hidden, Partial, Expanded }
+
+/**
+ * Custom anchored queue sheet (issue #317 phase 2).
+ *
+ * It owns a single [offsetY] (top inset of the sheet, in px) as the one source of truth for the
+ * gesture, the drag, the nested scroll and the animations. Because there is no hand-off between a
+ * "preview" value and a separate "commit" animation, the predictive back finishes by simply
+ * *continuing* from the current offset into the target anchor with a critically-damped
+ * (non-bouncy) spring — which is what removes the unnatural rebound on the Expanded -> Partial
+ * back commit.
+ */
+@Composable
+private fun PlayerQueueSheet(
+    queue: List<PlaybackQueueItem>,
+    currentIndex: Int,
+    serversById: Map<Long, ServerConfig>,
+    verticalSpacing: Dp,
+    onSkipToQueueItem: (Int) -> Unit,
+    onRemoveQueueItem: (Int) -> Unit,
+    onDismissed: () -> Unit,
+) {
+    // Critically damped: eases into the anchor, never overshoots -> never rebounds.
+    val settleSpec = remember {
+        spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow)
+    }
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val density = LocalDensity.current
+        val fullHeightPx = constraints.maxHeight.toFloat()
+        val expandedOffset = with(density) { 56.dp.toPx() }
+        val partialOffset = fullHeightPx * 0.5f
+        val hiddenOffset = fullHeightPx
+
+        fun offsetFor(anchor: QueueSheetAnchor): Float = when (anchor) {
+            QueueSheetAnchor.Expanded -> expandedOffset
+            QueueSheetAnchor.Partial -> partialOffset
+            QueueSheetAnchor.Hidden -> hiddenOffset
+        }
+
+        fun nearestAnchor(value: Float): QueueSheetAnchor = when {
+            value <= (expandedOffset + partialOffset) / 2f -> QueueSheetAnchor.Expanded
+            value <= (partialOffset + hiddenOffset) / 2f -> QueueSheetAnchor.Partial
+            else -> QueueSheetAnchor.Hidden
+        }
+
+        var offsetY by remember { mutableFloatStateOf(hiddenOffset) }
+        var settledAnchor by remember { mutableStateOf(QueueSheetAnchor.Hidden) }
+        val scope = rememberCoroutineScope()
+        var motionJob by remember { mutableStateOf<Job?>(null) }
+
+        fun settleTo(anchor: QueueSheetAnchor) {
+            settledAnchor = anchor
+            motionJob?.cancel()
+            motionJob = scope.launch {
+                animate(offsetY, offsetFor(anchor), animationSpec = settleSpec) { value, _ -> offsetY = value }
+                if (anchor == QueueSheetAnchor.Hidden) onDismissed()
+            }
+        }
+
+        // Animate in from the bottom to the half anchor on first show.
+        LaunchedEffect(Unit) { settleTo(QueueSheetAnchor.Partial) }
+
+        // Predictive back: Expanded -> Partial -> Hidden, with a live preview that follows the
+        // gesture and a non-bouncy commit so the half-screen settle does not rebound.
+        PredictiveBackHandler(enabled = settledAnchor != QueueSheetAnchor.Hidden) { events ->
+            motionJob?.cancel()
+            val start = settledAnchor
+            val target = if (start == QueueSheetAnchor.Expanded) QueueSheetAnchor.Partial else QueueSheetAnchor.Hidden
+            val from = offsetFor(start)
+            val to = offsetFor(target)
+            try {
+                events.collect { event -> offsetY = lerp(from, to, event.progress.coerceIn(0f, 1f)) }
+                // Committed: keep going from the current offset into the target anchor.
+                settledAnchor = target
+                animate(offsetY, to, animationSpec = settleSpec) { value, _ -> offsetY = value }
+                if (target == QueueSheetAnchor.Hidden) onDismissed()
+            } catch (_: CancellationException) {
+                // Cancelled: ease back to where the gesture started.
+                animate(offsetY, from, animationSpec = settleSpec) { value, _ -> offsetY = value }
+            }
+        }
+
+        // Scrim — alpha read deferred into the graphics layer so dragging does not recompose.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    alpha = ((hiddenOffset - offsetY) / (hiddenOffset - partialOffset)).coerceIn(0f, 1f) * 0.45f
+                }
+                .background(Color.Black)
+                .pointerInput(Unit) {
+                    detectTapGestures { settleTo(QueueSheetAnchor.Hidden) }
+                },
+        )
+
+        val nestedScrollConnection = remember(expandedOffset, hiddenOffset) {
+            object : NestedScrollConnection {
+                override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                    val delta = available.y
+                    // Dragging up first expands the sheet until it reaches the top anchor.
+                    if (delta < 0f && offsetY > expandedOffset) {
+                        motionJob?.cancel()
+                        val newOffset = (offsetY + delta).coerceAtLeast(expandedOffset)
+                        val consumed = newOffset - offsetY
+                        offsetY = newOffset
+                        return Offset(0f, consumed)
+                    }
+                    return Offset.Zero
+                }
+
+                override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+                    val delta = available.y
+                    // Dragging down once the list is at the top collapses the sheet.
+                    if (delta > 0f) {
+                        motionJob?.cancel()
+                        val newOffset = (offsetY + delta).coerceAtMost(hiddenOffset)
+                        val used = newOffset - offsetY
+                        offsetY = newOffset
+                        return Offset(0f, used)
+                    }
+                    return Offset.Zero
+                }
+
+                override suspend fun onPreFling(available: Velocity): Velocity {
+                    if (offsetY > expandedOffset) {
+                        settleTo(nearestAnchor(offsetY))
+                        return available
+                    }
+                    return Velocity.Zero
+                }
+            }
+        }
+
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight()
+                .graphicsLayer { translationY = offsetY }
+                .nestedScroll(nestedScrollConnection),
+            color = MaterialTheme.colorScheme.surface,
+            shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+            tonalElevation = 1.dp,
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .draggable(
+                            state = rememberDraggableState { delta ->
+                                offsetY = (offsetY + delta).coerceIn(expandedOffset, hiddenOffset)
+                            },
+                            orientation = Orientation.Vertical,
+                            onDragStarted = { motionJob?.cancel() },
+                            onDragStopped = { settleTo(nearestAnchor(offsetY)) },
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .padding(vertical = 12.dp)
+                            .size(width = 32.dp, height = 4.dp)
+                            .background(
+                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                RoundedCornerShape(2.dp),
+                            ),
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.player_queue),
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                )
+                val queueListState = rememberLazyListState(
+                    initialFirstVisibleItemIndex = (currentIndex - 2).coerceAtLeast(0),
+                )
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth(),
+                    state = queueListState,
+                    contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 28.dp),
+                    verticalArrangement = Arrangement.spacedBy(verticalSpacing),
+                ) {
+                    itemsIndexed(queue) { index, item ->
+                        QueueRow(
+                            item = item,
+                            isCurrent = index == currentIndex,
+                            currentServer = item.serverId?.let { serversById[it] },
+                            onClick = { onSkipToQueueItem(index) },
+                            onRemove = { onRemoveQueueItem(index) },
+                        )
+                    }
+                }
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/org/hdhmc/saki/presentation/serverconfig/ServerConfigScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/serverconfig/ServerConfigScreen.kt
@@ -72,6 +72,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.ServerEndpoint
 import org.hdhmc.saki.presentation.asString
+import org.hdhmc.saki.presentation.predictiveBackMotion
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.ui.theme.SakiTheme
 import org.hdhmc.saki.ui.theme.sakiCardContainerColor
@@ -98,18 +99,18 @@ fun ServerConfigRoute(
         }
     }
 
-    BackHandler(enabled = uiState.editor != null || onCloseManager != null) {
-        if (uiState.editor != null) {
-            viewModel.dismissEditor()
-        } else {
-            onCloseManager?.invoke()
-        }
-    }
+    // Editor sub-panel is a transient surface: plain back dismisses it (keeps its slide-out).
+    BackHandler(enabled = uiState.editor != null) { viewModel.dismissEditor() }
 
     ServerConfigScreen(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
-        modifier = modifier,
+        // Manager is a page surface: predictive back reveals Browse beneath. Stays inert during
+        // forced first-run setup (no onCloseManager) so the setup can't be swiped away.
+        modifier = modifier.predictiveBackMotion(
+            enabled = onCloseManager != null && uiState.editor == null,
+            onBack = { onCloseManager?.invoke() },
+        ),
         onAddServer = viewModel::startAddingServer,
         onEditServer = viewModel::editServer,
         onDeleteServer = viewModel::deleteServer,


### PR DESCRIPTION
## Summary
Implements the surface-role predictive-back model from #317 so every animated back gesture previews the same target the completed back will reach.

### Phase 1 — route back to the topmost surface (Now Playing)
- Page-level `predictiveBackMotion` now runs only when no higher-priority surface is consuming back: `enabled = visible && !(showQueueSheet || showDetails || showMenu || showLyrics || showEndpointStatus)`. Stops the page-scale motion firing under dialogs/menus/lyrics/the queue sheet.
- Lyrics is an inline panel with no back handling, so back used to dismiss the whole page — added `BackHandler(enabled = visible && showLyrics) { showLyrics = false }` (internal-state back).

### Phase 2 — custom anchored queue sheet (no rebound)
- Replaced the M3 `ModalBottomSheet` queue with a custom `PlayerQueueSheet`. M3's built-in predictive back is dismissal-only and `SheetState` exposes no fractional offset, so it can't preview Expanded→PartiallyExpanded.
- Single `offsetY` float is the one source of truth for gesture + drag + nested scroll + animation. The predictive back **continues from the current offset** into the target anchor with a **critically-damped (`DampingRatioNoBouncy`) spring** — no hand-off and no bouncy overshoot, which removes the unnatural rebound on the Expanded→half back commit.
- M3-style settling: a flick past the velocity threshold (~125.dp/s) moves to the next anchor regardless of distance; slow drags fall back to nearest (positional). The whole header (handle + title) plus list nested-scroll is the drag area, so it expands one-handed.
- Scrim alpha + sheet translation are read inside `graphicsLayer{}` (deferred) so dragging/animating doesn't recompose the list.

### Server manager predictive back
- The server manager was the only page surface with functional back but no predictive animation. Added `predictiveBackMotion` (reveals Browse), gated `onCloseManager != null && editor == null` so forced first-run setup can't be swiped away. The editor sub-panel stays a transient surface (plain back dismiss, keeps its slide-out).

### Cleanup + docs
- Removed two redundant `BackHandler`s in `BrowseScreen` (detail pop / search close) that were always shadowed by the deeper `predictiveBackMotion` surfaces — zero behaviour change, removes a latent LIFO fragility.
- Documented the surface-role model in `PredictiveBackSurface.kt` (Page / Anchored sheet / Transient / Internal state) so future surfaces pick the right treatment.

## Surface-role audit (all conforming after this PR)
| Surface | Role | Treatment |
|---|---|---|
| Now Playing, Settings, Search, Browse detail, Server manager | Page | `predictiveBackMotion` (reveal previous) |
| Queue sheet | Anchored sheet | custom anchored predictive (Expanded↔Partial↔Hidden) |
| Dialogs, dropdown menu, single-anchor action sheet, server editor | Transient | default dismiss |
| Lyrics panel, queue expanded state | Internal state | back undoes the state first |
| Browse root | Root | system back exits |

## Validation
- `./gradlew assembleDebug --no-daemon` — BUILD SUCCESSFUL
- Needs on-device verification:
  - Queue: Expanded → back settles to half with **no rebound**; cancel eases back; half → back dismisses; one-handed flick-up expands; list scroll + drag-to-collapse.
  - Lyrics back closes the panel before exiting; dialogs/menus don't scale the page under them.
  - Server manager: edge-back reveals Browse; editor back closes editor first; first-run setup can't be swiped away.
  - Browse detail pop / search close still animate as before.

Closes #317