### PR TITLE
fix(nowplaying): stop transport controls shifting when there is no queue

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -1128,12 +1129,15 @@ fun NowPlayingOverlay(
                                 maxLines = 1,
                             )
                         }
-                        // Queue toggle
-                        if (showQueueAffordance) {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.Center,
-                            ) {
+                        // Queue toggle — always reserves a constant-height slot so the transport
+                        // deck does not reflow (shift down) when there is no queue to expand.
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(24.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            if (showQueueAffordance) {
                                 Icon(
                                     Icons.Rounded.KeyboardArrowUp,
                                     contentDescription = stringResource(R.string.player_show_queue),


### PR DESCRIPTION
## Problem
On the Now Playing screen, when there is **no queue** (`queue.size <= 1`) the bottom "expand queue" chevron is conditionally removed, which makes the lower cluster (title / progress bar / play controls) shift downward.

## Root cause
The cover art is the only flexible region (`Modifier.weight(1f)`), while the chevron is conditionally rendered *inside* the bottom transport block. With no queue, the chevron plus one `verticalSpacing` gap disappears, the bottom block gets shorter, and the `weight(1f)` cover absorbs that slack by growing taller — pushing the whole control cluster below it down to the bottom edge. In short: the presence/absence of one optional widget changes the column's height distribution.

## Fix
Replace the conditionally-rendered chevron `Row` with an **always-present constant-height `Box(height = 24.dp)` slot** — it holds the `KeyboardArrowUp` icon when a queue exists and is an equal-height empty slot otherwise. The transport deck height and `spacedBy` gaps stay constant, the slack absorbed by the cover doesn't change, and **the lower controls sit in exactly the same position with or without a queue**.

Anchoring model: top header (top-anchored) → cover art (the single `weight(1f)` flexible band) → bottom transport deck (fixed height, includes the queue-affordance slot, bottom-anchored).

## Testing
- `assembleDebug` passes.
- Verified on device: switching between a single track (no queue) and a track with a queue no longer shifts the play button / progress bar.