### PR TITLE
fix(artist): reconcile split-artist album/song associations + opt-in hide merged artists

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
@@ -126,6 +126,10 @@ interface LibraryCacheDao {
         JOIN cached_song_metadata AS song
             ON song.serverId = artist.serverId AND song.songId = artist.songId
         WHERE artist.serverId = :serverId AND song.albumId IS NOT NULL
+            AND (
+                song.album IS NULL
+                OR LOWER(TRIM(REPLACE(REPLACE(song.album, '[', ''), ']', ''))) != 'unknown album'
+            )
         """,
     )
     suspend fun getArtistAlbumRefsFromSongs(serverId: Long): List<ArtistAlbumRef>

--- a/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/dao/LibraryCacheDao.kt
@@ -19,6 +19,7 @@ import org.hdhmc.saki.data.local.entity.CachedPlaylistDetailSongEntity
 import org.hdhmc.saki.data.local.entity.CachedPlaylistEntity
 import org.hdhmc.saki.data.local.entity.CachedSongMetadataEntity
 import org.hdhmc.saki.data.local.entity.CachedSongMetadataOrder
+import org.hdhmc.saki.data.local.entity.ArtistAlbumRef
 import org.hdhmc.saki.data.local.entity.CachedSongArtistEntity
 import org.hdhmc.saki.data.local.entity.CachedSongArtistSummary
 import kotlinx.coroutines.flow.Flow
@@ -111,6 +112,23 @@ interface LibraryCacheDao {
 
     @Query("SELECT * FROM cached_albums WHERE serverId = :serverId AND artistId = :artistId ORDER BY year DESC, name COLLATE NOCASE")
     suspend fun getAlbumSummariesByArtistId(serverId: Long, artistId: String): List<CachedAlbumEntity>
+
+    /**
+     * (artist, album) associations derived from the per-song artist relationships. Bridges the
+     * gap where the server attributes an album to a combined/composite artist while its tracks
+     * are credited to the individual (split) artists. Separator-agnostic: relies only on the
+     * server-provided per-song [cached_song_artists] rows, never on parsing artist names.
+     */
+    @Query(
+        """
+        SELECT DISTINCT artist.artistId AS artistId, song.albumId AS albumId
+        FROM cached_song_artists AS artist
+        JOIN cached_song_metadata AS song
+            ON song.serverId = artist.serverId AND song.songId = artist.songId
+        WHERE artist.serverId = :serverId AND song.albumId IS NOT NULL
+        """,
+    )
+    suspend fun getArtistAlbumRefsFromSongs(serverId: Long): List<ArtistAlbumRef>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAlbums(albums: List<CachedAlbumEntity>)

--- a/app/src/main/java/org/hdhmc/saki/data/local/entity/CachedSongArtistEntity.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/local/entity/CachedSongArtistEntity.kt
@@ -28,3 +28,9 @@ data class CachedSongArtistSummary(
     val albumCount: Int,
     val coverArtId: String?,
 )
+
+/** A (artist, album) association derived from the per-song artist relationships. */
+data class ArtistAlbumRef(
+    val artistId: String,
+    val albumId: String,
+)

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DataStoreAppPreferencesRepository.kt
@@ -2,6 +2,7 @@ package org.hdhmc.saki.data.repository
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
@@ -87,6 +88,10 @@ class DataStoreAppPreferencesRepository @Inject constructor(
         dataStore.edit { it[KEY_SONGS_PAGE_SIZE] = pageSize.normalizeSongsPageSize() }
     }
 
+    override suspend fun updateHideMergedArtists(enabled: Boolean) {
+        dataStore.edit { it[KEY_HIDE_MERGED_ARTISTS] = enabled }
+    }
+
     override suspend fun updateLastSelectedServerId(serverId: Long?) {
         dataStore.edit {
             if (serverId == null) {
@@ -143,6 +148,7 @@ class DataStoreAppPreferencesRepository @Inject constructor(
         val KEY_DEFAULT_BROWSE_TAB = stringPreferencesKey("default_browse_tab")
         val KEY_DEFAULT_ALBUM_FEED = stringPreferencesKey("default_album_feed")
         val KEY_SONGS_PAGE_SIZE = intPreferencesKey("songs_page_size")
+        val KEY_HIDE_MERGED_ARTISTS = booleanPreferencesKey("hide_merged_artists")
         val KEY_LAST_SELECTED_SERVER_ID = longPreferencesKey("last_selected_server_id")
         val KEY_RECENT_SEARCH_QUERIES = stringPreferencesKey("recent_search_queries")
     }
@@ -162,6 +168,7 @@ private fun Preferences.toAppPreferences() = AppPreferences(
     )?.takeIf { it in AlbumListType.defaultBrowseFeeds } ?: AlbumListType.NEWEST,
     songsPageSize = (this[DataStoreAppPreferencesRepository.KEY_SONGS_PAGE_SIZE] ?: DEFAULT_SONGS_PAGE_SIZE)
         .normalizeSongsPageSize(),
+    hideMergedArtists = this[DataStoreAppPreferencesRepository.KEY_HIDE_MERGED_ARTISTS] ?: false,
     lastSelectedServerId = this[DataStoreAppPreferencesRepository.KEY_LAST_SELECTED_SERVER_ID],
     recentSearchQueries = this[DataStoreAppPreferencesRepository.KEY_RECENT_SEARCH_QUERIES]
         .decodeRecentSearchQueries(),

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultAppPreferencesRepository.kt
@@ -77,6 +77,10 @@ class DefaultAppPreferencesRepository @Inject constructor(
         // Songs page size preference is only supported via DataStore; no-op here
     }
 
+    override suspend fun updateHideMergedArtists(enabled: Boolean) {
+        // Hide-merged-artists preference is only supported via DataStore; no-op here
+    }
+
     override suspend fun updateLastSelectedServerId(serverId: Long?) {
         // Last selected server is only supported via DataStore; no-op here
     }

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -66,11 +66,17 @@ class DefaultLibraryCacheRepository @Inject constructor(
         val detailAlbumsByArtistId = dao.getAllArtistDetailAlbums(serverId)
             .groupBy { it.artistId }
             .mapValues { (_, albums) -> albums.map { it.toDomain() } }
+        val derivedAlbumIdsByArtistId = dao.getArtistAlbumRefsFromSongs(serverId)
+            .groupBy({ it.artistId }, { it.albumId })
+            .mapValues { (_, albumIds) -> albumIds.toSet() }
         val artists = mergeArtistSummaries(
             serverArtists = entities.map { it.toDomain() },
             songArtists = songArtistSummaries.map { it.toDomain() },
         ).map { artist ->
-            artist.withDetailAlbumCount(detailAlbumsByArtistId[artist.id].orEmpty())
+            artist.withDetailAlbumCount(
+                albums = detailAlbumsByArtistId[artist.id].orEmpty(),
+                derivedAlbumIds = derivedAlbumIdsByArtistId[artist.id].orEmpty(),
+            )
         }
         LibraryIndexes(
             lastModified = null,
@@ -284,9 +290,16 @@ class DefaultLibraryCacheRepository @Inject constructor(
             val topSongRefs = dao.getArtistDetailSongs(serverId, artistId)
             val topSongs = resolveSongs(serverId, topSongRefs.map { it.songId })
             val relationshipSongs = resolveSongsByArtistId(serverId, artistId)
+            // Albums attributed to this artist via the server's artist detail (rawAlbums) are
+            // unioned with albums derived from the artist's related songs. This surfaces albums
+            // the server credits to a combined/composite artist while crediting tracks to the
+            // split artists — without parsing any names.
+            val cachedAlbumsByArtist = dao.getAlbumSummariesByArtistId(serverId, artistId).map { it.toDomain() }
+            val derivedAlbums = inferAlbumSummariesFromSongs(relationshipSongs)
+            val allAlbums = (rawAlbums + cachedAlbumsByArtist + derivedAlbums).distinctBy(AlbumSummary::id)
             val songArtistSummary = dao.getSongArtistSummaries(serverId)
                 .firstOrNull { it.artistId == artistId }
-            val artist = detail.toDomain(rawAlbums).let { cachedArtist ->
+            val artist = detail.toDomain(allAlbums).let { cachedArtist ->
                 songArtistSummary?.let { summary ->
                     cachedArtist.copy(
                         name = summary.name,
@@ -295,7 +308,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
                     )
                 } ?: cachedArtist
             }.withVisibleDetailAlbums()
-            val albumsById = rawAlbums.associateBy(AlbumSummary::id)
+            val albumsById = allAlbums.associateBy(AlbumSummary::id)
             val filteredTopSongs = topSongs.filter { song ->
                 val album = song.albumId?.let(albumsById::get)
                 if (album != null) {
@@ -432,17 +445,27 @@ class DefaultLibraryCacheRepository @Inject constructor(
             .sortedBy { it.name.lowercase() }
     }
 
-    private fun ArtistSummary.withDetailAlbumCount(albums: List<AlbumSummary>): ArtistSummary {
-        if (albums.isEmpty()) return this
-        val visibleAlbumCount = Artist(
-            id = id,
-            name = name,
-            coverArtId = coverArtId,
-            artistImageUrl = artistImageUrl,
-            albumCount = albumCount,
-            albums = albums,
-        ).visibleDetailAlbums().size
-        return copy(albumCount = visibleAlbumCount)
+    private fun ArtistSummary.withDetailAlbumCount(
+        albums: List<AlbumSummary>,
+        derivedAlbumIds: Set<String>,
+    ): ArtistSummary {
+        val visibleDetailAlbumIds = if (albums.isEmpty()) {
+            emptySet()
+        } else {
+            Artist(
+                id = id,
+                name = name,
+                coverArtId = coverArtId,
+                artistImageUrl = artistImageUrl,
+                albumCount = albumCount,
+                albums = albums,
+            ).visibleDetailAlbums().map(AlbumSummary::id).toSet()
+        }
+        val derivedCount = (visibleDetailAlbumIds + derivedAlbumIds).size
+        // Never downgrade a server-provided count (it can exceed what's locally cached); only
+        // raise it when the relationship-derived associations reveal more albums.
+        val merged = maxOf(albumCount ?: 0, derivedCount)
+        return if (merged > 0) copy(albumCount = merged) else this
     }
 
     private fun CachedAlbumEntity.toDomain() = AlbumSummary(

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -69,6 +69,21 @@ class DefaultLibraryCacheRepository @Inject constructor(
         val derivedAlbumIdsByArtistId = dao.getArtistAlbumRefsFromSongs(serverId)
             .groupBy({ it.artistId }, { it.albumId })
             .mapValues { (_, albumIds) -> albumIds.toSet() }
+        val claimedArtistIds = songArtistSummaries.map { it.artistId }.toSet()
+        // A server-index artist that no track credits, yet that still claims albums, is a
+        // server-side composite/variant "album artist" (e.g. "A/B", or a spelling variant like
+        // "安田 レイ" vs "安田レイ"). Its albums stay reachable through the artists the tracks
+        // actually credit (see the relationship-based album derivation above), so hiding it only
+        // removes the duplicate. Relationship-only: no name parsing, so it is agnostic to whatever
+        // separators the server is configured with. Decided purely from list-level data so the
+        // result is identical before and after opening the artist. Disabled when there are no song
+        // relationships at all, since composites are then indistinguishable from real artists.
+        val isMergedArtist: (String, Int?) -> Boolean = { artistId, albumCount ->
+            hideMergedArtists &&
+                claimedArtistIds.isNotEmpty() &&
+                artistId !in claimedArtistIds &&
+                (albumCount ?: 0) > 0
+        }
         val artists = mergeArtistSummaries(
             serverArtists = entities.map { it.toDomain() },
             songArtists = songArtistSummaries.map { it.toDomain() },
@@ -77,27 +92,14 @@ class DefaultLibraryCacheRepository @Inject constructor(
                 albums = detailAlbumsByArtistId[artist.id].orEmpty(),
                 derivedAlbumIds = derivedAlbumIdsByArtistId[artist.id].orEmpty(),
             )
-        }.let { merged ->
-            if (!hideMergedArtists) return@let merged
-            val claimedArtistIds = songArtistSummaries.map { it.artistId }.toSet()
-            // Without any song relationships we cannot distinguish composites from real artists,
-            // so never hide anything in that case.
-            if (claimedArtistIds.isEmpty()) return@let merged
-            // A server-index artist that no track credits, yet that still claims albums, is a
-            // server-side composite/variant "album artist" (e.g. "A/B", or a spelling variant
-            // like "安田 レイ" vs "安田レイ"). Its albums stay reachable through the artists the
-            // tracks actually credit (see the relationship-based album derivation above), so
-            // hiding it here only removes the duplicate. Relationship-only: no name parsing, so
-            // it is agnostic to whatever separators the server is configured with. Decided purely
-            // from list-level data so the result is identical before and after opening the artist.
-            merged.filterNot { artist ->
-                artist.id !in claimedArtistIds && (artist.albumCount ?: 0) > 0
-            }
-        }
+        }.filterNot { artist -> isMergedArtist(artist.id, artist.albumCount) }
+        // Apply the same predicate to the shortcuts row so hidden artists can't reappear there.
+        val shortcuts = shortcutEntities.map { it.toDomain() }
+            .filterNot { artist -> isMergedArtist(artist.id, artist.albumCount) }
         LibraryIndexes(
             lastModified = null,
             ignoredArticles = null,
-            shortcuts = shortcutEntities.map { it.toDomain() },
+            shortcuts = shortcuts,
             sections = listOf(ArtistSection(name = "#", artists = artists)),
         )
     }

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultLibraryCacheRepository.kt
@@ -58,7 +58,7 @@ class DefaultLibraryCacheRepository @Inject constructor(
     private val artistRefsAdapter: JsonAdapter<List<CachedArtistRefJsonDto>> =
         moshi.adapter(Types.newParameterizedType(List::class.java, CachedArtistRefJsonDto::class.java))
 
-    override suspend fun getArtists(serverId: Long): LibraryIndexes? = withContext(ioDispatcher) {
+    override suspend fun getArtists(serverId: Long, hideMergedArtists: Boolean): LibraryIndexes? = withContext(ioDispatcher) {
         val entities = dao.getArtists(serverId)
         val shortcutEntities = dao.getArtistShortcuts(serverId)
         val songArtistSummaries = dao.getSongArtistSummaries(serverId)
@@ -77,6 +77,22 @@ class DefaultLibraryCacheRepository @Inject constructor(
                 albums = detailAlbumsByArtistId[artist.id].orEmpty(),
                 derivedAlbumIds = derivedAlbumIdsByArtistId[artist.id].orEmpty(),
             )
+        }.let { merged ->
+            if (!hideMergedArtists) return@let merged
+            val claimedArtistIds = songArtistSummaries.map { it.artistId }.toSet()
+            // Without any song relationships we cannot distinguish composites from real artists,
+            // so never hide anything in that case.
+            if (claimedArtistIds.isEmpty()) return@let merged
+            // A server-index artist that no track credits, yet that still claims albums, is a
+            // server-side composite/variant "album artist" (e.g. "A/B", or a spelling variant
+            // like "安田 レイ" vs "安田レイ"). Its albums stay reachable through the artists the
+            // tracks actually credit (see the relationship-based album derivation above), so
+            // hiding it here only removes the duplicate. Relationship-only: no name parsing, so
+            // it is agnostic to whatever separators the server is configured with. Decided purely
+            // from list-level data so the result is identical before and after opening the artist.
+            merged.filterNot { artist ->
+                artist.id !in claimedArtistIds && (artist.albumCount ?: 0) > 0
+            }
         }
         LibraryIndexes(
             lastModified = null,
@@ -449,23 +465,26 @@ class DefaultLibraryCacheRepository @Inject constructor(
         albums: List<AlbumSummary>,
         derivedAlbumIds: Set<String>,
     ): ArtistSummary {
+        val artistWithDetailAlbums = Artist(
+            id = id,
+            name = name,
+            coverArtId = coverArtId,
+            artistImageUrl = artistImageUrl,
+            albumCount = albumCount,
+            albums = albums,
+        )
+        val allDetailAlbumIds = albums.map(AlbumSummary::id).toSet()
         val visibleDetailAlbumIds = if (albums.isEmpty()) {
             emptySet()
         } else {
-            Artist(
-                id = id,
-                name = name,
-                coverArtId = coverArtId,
-                artistImageUrl = artistImageUrl,
-                albumCount = albumCount,
-                albums = albums,
-            ).visibleDetailAlbums().map(AlbumSummary::id).toSet()
+            artistWithDetailAlbums.visibleDetailAlbums().map(AlbumSummary::id).toSet()
         }
-        val derivedCount = (visibleDetailAlbumIds + derivedAlbumIds).size
-        // Never downgrade a server-provided count (it can exceed what's locally cached); only
-        // raise it when the relationship-derived associations reveal more albums.
-        val merged = maxOf(albumCount ?: 0, derivedCount)
-        return if (merged > 0) copy(albumCount = merged) else this
+        // Mirror what the detail page shows: visible detail albums, plus relationship-derived
+        // albums that are entirely absent from the detail set. Derived ids are NOT allowed to
+        // re-introduce albums the detail already filtered out (e.g. "unknown album" placeholders),
+        // which is what previously made the list count exceed the detail count.
+        val knownAlbumIds = visibleDetailAlbumIds + (derivedAlbumIds - allDetailAlbumIds)
+        return if (knownAlbumIds.isNotEmpty()) copy(albumCount = knownAlbumIds.size) else this
     }
 
     private fun CachedAlbumEntity.toDomain() = AlbumSummary(

--- a/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/AppPreferences.kt
@@ -51,6 +51,7 @@ data class AppPreferences(
     val defaultBrowseTab: DefaultBrowseTab = DefaultBrowseTab.ARTISTS,
     val defaultAlbumFeed: AlbumListType = AlbumListType.NEWEST,
     val songsPageSize: Int = DEFAULT_SONGS_PAGE_SIZE,
+    val hideMergedArtists: Boolean = false,
     val lastSelectedServerId: Long? = null,
     val recentSearchQueries: List<String> = emptyList(),
 )

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/AppPreferencesRepository.kt
@@ -36,6 +36,8 @@ interface AppPreferencesRepository {
 
     suspend fun updateSongsPageSize(pageSize: Int)
 
+    suspend fun updateHideMergedArtists(enabled: Boolean)
+
     suspend fun updateLastSelectedServerId(serverId: Long?)
 
     suspend fun addRecentSearchQuery(query: String)

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/LibraryCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/LibraryCacheRepository.kt
@@ -12,7 +12,7 @@ import org.hdhmc.saki.domain.model.Song
 
 interface LibraryCacheRepository {
     suspend fun clearServer(serverId: Long)
-    suspend fun getArtists(serverId: Long): LibraryIndexes?
+    suspend fun getArtists(serverId: Long, hideMergedArtists: Boolean = false): LibraryIndexes?
     suspend fun saveArtists(serverId: Long, indexes: LibraryIndexes)
     suspend fun getAlbums(serverId: Long, type: AlbumListType): List<AlbumSummary>
     suspend fun saveAlbums(serverId: Long, type: AlbumListType, albums: List<AlbumSummary>)

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -300,6 +300,7 @@ private fun SettingsRoute(
         onUpdateImageCacheSizeMb = viewModel::updateImageCacheSizeMb,
         onClearImageCache = viewModel::clearImageCache,
         onUpdateSongMetadata = viewModel::updateAllSongMetadata,
+        onUpdateHideMergedArtists = viewModel::updateHideMergedArtists,
         onUpdateTextScale = viewModel::updateTextScale,
         onUpdateLanguage = viewModel::updateLanguage,
         onUpdateThemeMode = viewModel::updateThemeMode,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -908,6 +908,10 @@ class SakiAppViewModel @Inject constructor(
                         coverArtId = artist.coverArtId ?: localArtist.coverArtId,
                         artistImageUrl = artist.artistImageUrl ?: localArtist.artistImageUrl,
                         albumCount = artist.albumCount ?: localArtist.albumCount,
+                        // Union the server's albums with relationship-derived albums (e.g. albums
+                        // the server credits to a combined artist but whose tracks credit this
+                        // split artist) so the network refresh does not drop them.
+                        albums = (artist.albums + localArtist.albums).distinctBy(AlbumSummary::id),
                     )
                 } ?: artist).withVisibleDetailAlbums()
                 val songs = (topSongs + relationshipSongs).distinctBy(Song::id)

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -482,6 +482,21 @@ class SakiAppViewModel @Inject constructor(
         }
     }
 
+    fun updateHideMergedArtists(enabled: Boolean) {
+        viewModelScope.launch {
+            appPreferencesRepository.updateHideMergedArtists(enabled)
+            val serverId = uiState.value.selectedServerId ?: return@launch
+            val artists = runCatching {
+                libraryCacheRepository.getArtists(serverId, hideMergedArtists = enabled)
+            }.getOrNull()
+            if (artists != null && uiState.value.selectedServerId == serverId) {
+                mutableUiState.update {
+                    it.copy(libraryIndexes = artists.regroupByLocale(currentIndexingLocale()))
+                }
+            }
+        }
+    }
+
     fun openArtistFromPlayback(
         serverId: Long?,
         artistId: String?,
@@ -1835,7 +1850,7 @@ class SakiAppViewModel @Inject constructor(
                 null
             }
 
-            val artists = loadCachedOrNull { libraryCacheRepository.getArtists(serverId) }
+            val artists = loadCachedOrNull { libraryCacheRepository.getArtists(serverId, hideMergedArtists = uiState.value.appPreferences.hideMergedArtists) }
             if (artists != null && uiState.value.selectedServerId == serverId) {
                 mutableUiState.update { it.copy(libraryIndexes = artists.regroupByLocale(currentIndexingLocale())) }
             }
@@ -1915,7 +1930,7 @@ class SakiAppViewModel @Inject constructor(
             mutableUiState.update { it.copy(isArtistsLoading = true, artistsError = null) }
 
             if (!forceRefresh) {
-                val cached = runCatching { libraryCacheRepository.getArtists(serverId) }.getOrNull()
+                val cached = runCatching { libraryCacheRepository.getArtists(serverId, hideMergedArtists = uiState.value.appPreferences.hideMergedArtists) }.getOrNull()
                 if (cached != null && uiState.value.selectedServerId == serverId) {
                     mutableUiState.update { it.copy(libraryIndexes = cached.regroupByLocale(currentIndexingLocale())) }
                 }
@@ -1927,7 +1942,7 @@ class SakiAppViewModel @Inject constructor(
                 runCatching { libraryCacheRepository.saveArtists(serverId, indexes) }
                     .onFailure { Log.w("SakiApp", "Failed to cache artists", it) }
                 val mergedIndexes = runCatching {
-                    libraryCacheRepository.getArtists(serverId)
+                    libraryCacheRepository.getArtists(serverId, hideMergedArtists = uiState.value.appPreferences.hideMergedArtists)
                 }.getOrNull() ?: indexes
                 if (uiState.value.selectedServerId == serverId) {
                     mutableUiState.update {
@@ -2382,7 +2397,7 @@ class SakiAppViewModel @Inject constructor(
     }
 
     private suspend fun refreshCachedArtistIndex(serverId: Long) {
-        val artists = runCatching { libraryCacheRepository.getArtists(serverId) }.getOrNull() ?: return
+        val artists = runCatching { libraryCacheRepository.getArtists(serverId, hideMergedArtists = uiState.value.appPreferences.hideMergedArtists) }.getOrNull() ?: return
         if (uiState.value.selectedServerId == serverId) {
             mutableUiState.update {
                 it.copy(libraryIndexes = artists.regroupByLocale(currentIndexingLocale()))

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -123,6 +123,7 @@ fun SettingsScreen(
     onUpdateImageCacheSizeMb: (Int) -> Unit,
     onClearImageCache: () -> Unit,
     onUpdateSongMetadata: () -> Unit,
+    onUpdateHideMergedArtists: (Boolean) -> Unit,
     onUpdateTextScale: (TextScale) -> Unit,
     onUpdateLanguage: (AppLanguage) -> Unit,
     onUpdateThemeMode: (ThemeMode) -> Unit,
@@ -777,6 +778,27 @@ fun SettingsScreen(
                 ) {
                     Icon(Icons.Rounded.Storage, contentDescription = null)
                     Text(stringResource(R.string.settings_update_song_metadata), modifier = Modifier.padding(start = 8.dp))
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f).padding(end = 12.dp)) {
+                        Text(
+                            stringResource(R.string.settings_hide_merged_artists),
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Text(
+                            stringResource(R.string.settings_hide_merged_artists_body),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Switch(
+                        checked = uiState.appPreferences.hideMergedArtists,
+                        onCheckedChange = onUpdateHideMergedArtists,
+                    )
                 }
             }
         }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -33,6 +33,8 @@
     <string name="settings_song_metadata_body_server">更新 %1$s 的歌曲缓存索引。</string>
     <string name="settings_update_song_metadata">更新全部元数据</string>
     <string name="settings_song_metadata_syncing">正在更新元数据…已索引 %1$d 首歌曲</string>
+    <string name="settings_hide_merged_artists">尝试隐藏合并艺术家</string>
+    <string name="settings_hide_merged_artists_body">隐藏其曲目已归属到各独立艺术家的合并“专辑艺术家”(如“A/B”)。建议先执行“更新全部元数据”以获得最佳效果。</string>
     <string name="settings_cover_art_cache_title">封面缓存</string>
     <string name="settings_cover_art_cache_body">所有服务器的专辑封面缓存。</string>
     <string name="settings_clear_cover_art_cache">清除封面缓存</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="settings_song_metadata_body_server">Update the cached song index for %1$s.</string>
     <string name="settings_update_song_metadata">Update all metadata</string>
     <string name="settings_song_metadata_syncing">Updating metadata… %1$d songs indexed</string>
+    <string name="settings_hide_merged_artists">Try to hide merged artists</string>
+    <string name="settings_hide_merged_artists_body">Hide composite \"album artists\" (e.g. \"A/B\") whose tracks are already credited to the individual artists. Run \"Update all metadata\" first for the best result.</string>
     <string name="settings_cover_art_cache_title">Cover art cache</string>
     <string name="settings_cover_art_cache_body">Album artwork cached across all servers.</string>
     <string name="settings_clear_cover_art_cache">Clear cover art cache</string>


### PR DESCRIPTION
## Problem
When the music server (Navidrome/OpenSubsonic) attributes an **album** to a combined/composite artist while crediting the album's **tracks** to the individual (split) artists, the app's artist views diverged:

- The combined artist (e.g. `23.exe/初音ミク`) showed the album but **no songs**.
- Each split artist (e.g. `23.exe`) showed songs but **no album**.

This also covered spelling variants where the album-artist id differs from the track-artist id (e.g. `安田 レイ` with a space vs `安田レイ` without).

Root cause: the **main** `getArtistDetail` branch (used once an artist detail row is cached) took albums only from the server's artist-detail albums, while songs came from the per-song artist relationships (`cached_song_artists`). The two never reconciled. The network refresh in `openArtist` compounded it by rebuilding the artist from the server response and dropping any relationship-derived albums.

All detection here is **relationship-only and separator-agnostic** — it relies solely on the server-provided per-song artist rows, never on parsing artist names (the set of separators is configured server-side).

## Changes

**1 — Associate albums with split artists via song relationships**
- New DAO query `getArtistAlbumRefsFromSongs` derives `(artist, album)` pairs from `cached_song_artists` ⋈ `cached_song_metadata` (excluding `[Unknown Album]` placeholders).
- `getArtistDetail` (main branch) now unions server detail albums with albums derived from the artist's related songs.
- `openArtist`'s network refresh now merges relationship-derived albums into the displayed artist so they aren't dropped after the network result arrives.

**2 — Artist-list album count parity**
- The list album count now mirrors the detail page: visible detail albums ∪ relationship-derived albums that are absent from the detail set, with unknown-album placeholders excluded so the list no longer over-counts vs the detail (e.g. 初音ミク showed 101 in the list but 99 in the detail).

**3 — Opt-in "try to hide merged artists" toggle** (new switch in the song-metadata settings card)
- Hides server-side composite/variant album-artists that **no track credits** yet that **claim albums** — their albums remain reachable through the artists the tracks actually credit (via change 1).
- Decided purely from list-level data (`cached_song_artists` + the index's `albumCount`), so the result is identical before and after opening an artist (an earlier approach that relied on lazily-cached detail albums was inconsistent). No-op when there is no song relationship data. Best run after "Update all metadata".

## Testing
- `assembleDebug` + `testDebugUnitTest` pass.
- Verified on device against the live database:
  - `23.exe` and `初音ミク` now both show the `LIME` album.
  - Toggle hides `23.exe/初音ミク` and `安田 レイ` from the artist list (consistently, without needing to open them); off restores them.
  - 初音ミク list count now matches the detail (99), with the two `[Unknown Album]` placeholders correctly excluded.