### PR TITLE
feat(navigation): add enter animations for page/route surfaces

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
@@ -81,6 +81,13 @@ fun Modifier.predictiveBackMotion(
  * button animates identically to the gesture (and to the system back button, which
  * [PredictiveBackHandler] already animates).
  */
+/**
+ * Holds the motion state for a page/route surface and exposes both the [modifier] that renders it
+ * and a programmatic [dismiss]. The predictive gesture — and the system back button, which
+ * [PredictiveBackHandler] drives — animate the follow-the-finger preview + commit. An in-app
+ * back/close button should instead go through [dismiss], which plays a quick reverse-of-open
+ * (slide down + fade out) before invoking `onBack`.
+ */
 @Stable
 class PredictiveBackMotionState internal constructor(
     private val scope: CoroutineScope,
@@ -98,18 +105,26 @@ class PredictiveBackMotionState internal constructor(
 ) {
     internal var swipeEdge by mutableIntStateOf(BackEventCompat.EDGE_LEFT)
     internal var touchY by mutableFloatStateOf(0f)
+    private var isDismissing = false
 
     /**
      * Programmatic close for an in-app back/close button. This is NOT the predictive follow-finger
      * commit — a tap has no gesture to track. Instead it plays a quick reverse-of-open (slide down
-     * + fade out), then invokes onBack.
+     * + fade out), then invokes onBack. Ignores re-entrant calls so a double-tap can't invoke
+     * onBack more than once.
      */
     fun dismiss() {
+        if (isDismissing) return
+        isDismissing = true
         scope.launch {
-            if (dismissProgress.value < 1f) {
-                dismissProgress.animateTo(1f, animationSpec = spring(dampingRatio = 1f, stiffness = 900f))
+            try {
+                if (dismissProgress.value < 1f) {
+                    dismissProgress.animateTo(1f, animationSpec = spring(dampingRatio = 1f, stiffness = 900f))
+                }
+                onBack()
+            } finally {
+                isDismissing = false
             }
-            onBack()
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
@@ -109,3 +109,36 @@ fun Modifier.predictiveBackMotion(
         clip = true
     }
 }
+
+/**
+ * Enter motion for a hierarchical child **page/route** (e.g. a Browse detail pushed onto the
+ * stack). Open is a discrete action, not a gesture, so this is NOT the inverse of the back
+ * preview — it is a crisp, confident forward "cover": the incoming page rises a short distance
+ * and fades in over its parent, then settles. Pairs coherently with the shrink-away back without
+ * trying to rewind it.
+ *
+ * The animation runs once per composition; wrap the page in a `key(route)` (as Browse does) so a
+ * freshly pushed route re-triggers it. Independent of the back gesture's progress.
+ */
+@Composable
+fun Modifier.pageEnterMotion(
+    initialOffsetFraction: Float = 0.06f,
+): Modifier {
+    // 1f = just entered (shifted down + transparent), 0f = settled at rest.
+    val progress = remember { Animatable(1f) }
+    LaunchedEffect(Unit) {
+        progress.animateTo(
+            targetValue = 0f,
+            animationSpec = spring(dampingRatio = 1f, stiffness = 500f),
+        )
+    }
+    val displayProgress = progress.value
+    val interpolated = if (displayProgress <= 0f) 0f
+    else PredictiveBackInterpolator.getInterpolation(displayProgress.coerceIn(0f, 1f))
+
+    return if (interpolated <= 0f) this
+    else this.graphicsLayer {
+        alpha = 1f - interpolated
+        translationY = interpolated * size.height * initialOffsetFraction
+    }
+}

--- a/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
@@ -4,22 +4,26 @@ import android.view.animation.PathInterpolator
 import androidx.activity.BackEventCompat
 import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 private val PredictiveBackInterpolator = PathInterpolator(0.1f, 0.1f, 0f, 1f)
 
@@ -56,13 +60,127 @@ fun Modifier.predictiveBackMotion(
     maxCornerRadius: Dp = 28.dp,
     targetAlpha: Float = 1f,
 ): Modifier {
+    val state = rememberPredictiveBackMotion(
+        enabled = enabled,
+        onBack = onBack,
+        maxScaleReduction = maxScaleReduction,
+        maxHorizontalShiftFraction = maxHorizontalShiftFraction,
+        horizontalShiftInset = horizontalShiftInset,
+        maxVerticalShiftFraction = maxVerticalShiftFraction,
+        verticalShiftInset = verticalShiftInset,
+        maxCornerRadius = maxCornerRadius,
+        targetAlpha = targetAlpha,
+    )
+    return this.then(state.modifier)
+}
+
+/**
+ * Holds the progress of a page/route's predictive-back motion and exposes both the [modifier] that
+ * renders it and a programmatic [dismiss] that replays the same commit animation a completed back
+ * gesture would, then invokes `onBack`. Route an in-app back/close button through [dismiss] so the
+ * button animates identically to the gesture (and to the system back button, which
+ * [PredictiveBackHandler] already animates).
+ */
+@Stable
+class PredictiveBackMotionState internal constructor(
+    private val scope: CoroutineScope,
+    internal val progress: Animatable<Float, AnimationVector1D>,
+    internal val dismissProgress: Animatable<Float, AnimationVector1D>,
+    private val onBack: () -> Unit,
+    private val maxScaleReduction: Float,
+    private val maxHorizontalShiftFraction: Float,
+    private val horizontalShiftInset: Dp,
+    private val maxVerticalShiftFraction: Float,
+    private val verticalShiftInset: Dp,
+    private val maxCornerRadius: Dp,
+    private val targetAlpha: Float,
+    private val dismissOffsetFraction: Float,
+) {
+    internal var swipeEdge by mutableIntStateOf(BackEventCompat.EDGE_LEFT)
+    internal var touchY by mutableFloatStateOf(0f)
+
+    /**
+     * Programmatic close for an in-app back/close button. This is NOT the predictive follow-finger
+     * commit — a tap has no gesture to track. Instead it plays a quick reverse-of-open (slide down
+     * + fade out), then invokes onBack.
+     */
+    fun dismiss() {
+        scope.launch {
+            if (dismissProgress.value < 1f) {
+                dismissProgress.animateTo(1f, animationSpec = spring(dampingRatio = 1f, stiffness = 900f))
+            }
+            onBack()
+        }
+    }
+
+    val modifier: Modifier = Modifier.graphicsLayer {
+        val gestureProgress = progress.value
+        val gestureInterpolated = if (gestureProgress <= 0f) 0f
+        else PredictiveBackInterpolator.getInterpolation(gestureProgress.coerceIn(0f, 1f))
+        val exit = dismissProgress.value.coerceIn(0f, 1f)
+        if (gestureInterpolated <= 0f && exit <= 0f) return@graphicsLayer
+
+        var ty = 0f
+        if (gestureInterpolated > 0f) {
+            // Predictive gesture: scale + rounded corners + slight follow-the-finger translate.
+            val scale = 1f - (gestureInterpolated * maxScaleReduction)
+            scaleX = scale
+            scaleY = scale
+            val maxShiftX = (size.width * maxHorizontalShiftFraction - horizontalShiftInset.toPx()).coerceAtLeast(0f)
+            translationX = gestureInterpolated * maxShiftX * if (swipeEdge == BackEventCompat.EDGE_LEFT) 1f else -1f
+            val centerY = size.height / 2f
+            val maxShiftY = (size.height * maxVerticalShiftFraction - verticalShiftInset.toPx()).coerceAtLeast(0f)
+            val yOffset = if (centerY > 0f) (touchY - centerY) / centerY else 0f
+            ty += gestureInterpolated * maxShiftY * yOffset
+            shape = RoundedCornerShape((gestureInterpolated * maxCornerRadius.value).dp)
+            clip = true
+        }
+        if (exit > 0f) {
+            // Button close: quick reverse of the open cover — slide down + fade out.
+            ty += exit * size.height * dismissOffsetFraction
+        }
+        translationY = ty
+        alpha = (1f - (gestureInterpolated * (1f - targetAlpha))) * (1f - exit)
+    }
+}
+
+@Composable
+fun rememberPredictiveBackMotion(
+    enabled: Boolean,
+    onBack: () -> Unit,
+    maxScaleReduction: Float = 0.1f,
+    maxHorizontalShiftFraction: Float = 1f / 20f,
+    horizontalShiftInset: Dp = 8.dp,
+    maxVerticalShiftFraction: Float = 1f / 20f,
+    verticalShiftInset: Dp = 8.dp,
+    maxCornerRadius: Dp = 28.dp,
+    targetAlpha: Float = 1f,
+    dismissOffsetFraction: Float = 0.06f,
+): PredictiveBackMotionState {
+    val scope = rememberCoroutineScope()
     val progress = remember { Animatable(0f) }
-    var swipeEdge by remember { mutableIntStateOf(BackEventCompat.EDGE_LEFT) }
-    var touchY by remember { mutableFloatStateOf(0f) }
-    val latestOnBack by rememberUpdatedState(onBack)
+    val dismissProgress = remember { Animatable(0f) }
+    val latestOnBack = rememberUpdatedState(onBack)
+    val state = remember {
+        PredictiveBackMotionState(
+            scope = scope,
+            progress = progress,
+            dismissProgress = dismissProgress,
+            onBack = { latestOnBack.value() },
+            maxScaleReduction = maxScaleReduction,
+            maxHorizontalShiftFraction = maxHorizontalShiftFraction,
+            horizontalShiftInset = horizontalShiftInset,
+            maxVerticalShiftFraction = maxVerticalShiftFraction,
+            verticalShiftInset = verticalShiftInset,
+            maxCornerRadius = maxCornerRadius,
+            targetAlpha = targetAlpha,
+            dismissOffsetFraction = dismissOffsetFraction,
+        )
+    }
     LaunchedEffect(enabled) {
         if (enabled) {
             progress.snapTo(0f)
+            dismissProgress.snapTo(0f)
         }
     }
     PredictiveBackHandler(enabled = enabled) { backEvents ->
@@ -70,12 +188,12 @@ fun Modifier.predictiveBackMotion(
         try {
             backEvents.collect { event ->
                 progress.snapTo(event.progress)
-                swipeEdge = event.swipeEdge
-                touchY = event.touchY
+                state.swipeEdge = event.swipeEdge
+                state.touchY = event.touchY
             }
             completed = true
             progress.animateTo(1f, animationSpec = spring(stiffness = 400f))
-            latestOnBack()
+            latestOnBack.value()
         } catch (_: CancellationException) {
             if (!completed) {
                 // User cancelled — animate back from the exact gesture position.
@@ -83,31 +201,7 @@ fun Modifier.predictiveBackMotion(
             }
         }
     }
-
-    val displayProgress = progress.value
-    val interpolated = if (displayProgress <= 0f) 0f
-    else PredictiveBackInterpolator.getInterpolation(displayProgress.coerceIn(0f, 1f))
-    val density = LocalDensity.current
-    val horizontalShiftInsetPx = with(density) { horizontalShiftInset.toPx() }
-    val verticalShiftInsetPx = with(density) { verticalShiftInset.toPx() }
-    val currentSwipeEdge = swipeEdge
-    val currentTouchY = touchY
-
-    return if (interpolated <= 0f) this
-    else this.graphicsLayer {
-        val scale = 1f - (interpolated * maxScaleReduction)
-        scaleX = scale
-        scaleY = scale
-        alpha = 1f - (interpolated * (1f - targetAlpha))
-        val maxShiftX = (size.width * maxHorizontalShiftFraction - horizontalShiftInsetPx).coerceAtLeast(0f)
-        translationX = interpolated * maxShiftX * if (currentSwipeEdge == BackEventCompat.EDGE_LEFT) 1f else -1f
-        val centerY = size.height / 2f
-        val maxShiftY = (size.height * maxVerticalShiftFraction - verticalShiftInsetPx).coerceAtLeast(0f)
-        val yOffset = if (centerY > 0f) (currentTouchY - centerY) / centerY else 0f
-        translationY = interpolated * maxShiftY * yOffset
-        shape = RoundedCornerShape((interpolated * maxCornerRadius.value).dp)
-        clip = true
-    }
+    return state
 }
 
 /**

--- a/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/PredictiveBackSurface.kt
@@ -75,13 +75,6 @@ fun Modifier.predictiveBackMotion(
 }
 
 /**
- * Holds the progress of a page/route's predictive-back motion and exposes both the [modifier] that
- * renders it and a programmatic [dismiss] that replays the same commit animation a completed back
- * gesture would, then invokes `onBack`. Route an in-app back/close button through [dismiss] so the
- * button animates identically to the gesture (and to the system back button, which
- * [PredictiveBackHandler] already animates).
- */
-/**
  * Holds the motion state for a page/route surface and exposes both the [modifier] that renders it
  * and a programmatic [dismiss]. The predictive gesture — and the system back button, which
  * [PredictiveBackHandler] drives — animate the follow-the-finger preview + commit. An in-app

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -1,11 +1,6 @@
 package org.hdhmc.saki.presentation
 
 import android.content.Intent
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -135,7 +130,7 @@ fun SakiApp(
             if (showServerManager) {
                 CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
                     ServerConfigRoute(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier.fillMaxSize().pageEnterMotion(),
                         onCloseManager = { showServerManager = false },
                     )
                 }
@@ -183,12 +178,8 @@ private fun RootShell(
                     onOpenSettings = { onShowSettingsChange(true) },
                 )
 
-                AnimatedVisibility(
-                    visible = showSettings,
-                    enter = fadeIn(spring(stiffness = Spring.StiffnessMediumLow)),
-                    exit = fadeOut(spring(stiffness = Spring.StiffnessMediumLow)),
-                ) {
-                    Box(modifier = Modifier.fillMaxSize().then(settingsBackModifier)) {
+                if (showSettings) {
+                    Box(modifier = Modifier.fillMaxSize().pageEnterMotion().then(settingsBackModifier)) {
                         SettingsRoute(
                             viewModel = viewModel,
                             contentPadding = PaddingValues(),

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -156,7 +156,7 @@ private fun RootShell(
     var capsuleHeightPx by remember { mutableIntStateOf(defaultCapsuleHeightPx) }
     val capsuleOverlayPadding = with(density) { capsuleHeightPx.toDp() }
 
-    val settingsBackModifier = Modifier.predictiveBackMotion(
+    val settingsBackMotion = rememberPredictiveBackMotion(
         enabled = showSettings && !showNowPlaying,
         onBack = { onShowSettingsChange(false) },
         targetAlpha = 0.35f,
@@ -179,12 +179,12 @@ private fun RootShell(
                 )
 
                 if (showSettings) {
-                    Box(modifier = Modifier.fillMaxSize().pageEnterMotion().then(settingsBackModifier)) {
+                    Box(modifier = Modifier.fillMaxSize().pageEnterMotion().then(settingsBackMotion.modifier)) {
                         SettingsRoute(
                             viewModel = viewModel,
                             contentPadding = PaddingValues(),
                             bottomOverlayPadding = capsuleOverlayPadding,
-                            onClose = { onShowSettingsChange(false) },
+                            onClose = { settingsBackMotion.dismiss() },
                             onManageServers = onManageServers,
                         )
                     }

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -122,6 +122,7 @@ import org.hdhmc.saki.presentation.BrowseSection
 import org.hdhmc.saki.presentation.AlbumFeedState
 import org.hdhmc.saki.presentation.labelRes
 import org.hdhmc.saki.presentation.bottomContentPadding
+import org.hdhmc.saki.presentation.pageEnterMotion
 import org.hdhmc.saki.presentation.predictiveBackMotion
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.presentation.SakiBrowseAvailabilityUiState
@@ -354,6 +355,7 @@ fun BrowseScreen(
                             route is BrowseNavRoute.Root -> Modifier.fillMaxSize()
                             else -> Modifier
                                 .fillMaxSize()
+                                .pageEnterMotion()
                                 .predictiveBackMotion(
                                     enabled = backHandlersEnabled,
                                     onBack = onPopDetail,
@@ -884,6 +886,7 @@ private fun BrowsePager(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .pageEnterMotion()
                     .predictiveBackMotion(
                         enabled = backHandlersEnabled,
                         onBack = { onSetSearchActive(false) },

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -123,7 +123,7 @@ import org.hdhmc.saki.presentation.AlbumFeedState
 import org.hdhmc.saki.presentation.labelRes
 import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.pageEnterMotion
-import org.hdhmc.saki.presentation.predictiveBackMotion
+import org.hdhmc.saki.presentation.rememberPredictiveBackMotion
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.presentation.SakiBrowseAvailabilityUiState
 import org.hdhmc.saki.presentation.SakiBrowsePlaybackUiState
@@ -225,7 +225,7 @@ fun BrowseScreen(
                 val below = stack.getOrNull(stack.size - 2)
 
                 @Composable
-                fun BrowsePage(route: BrowseNavRoute, pageModifier: Modifier) {
+                fun BrowsePage(route: BrowseNavRoute, pageModifier: Modifier, onBack: () -> Unit) {
                     Box(modifier = pageModifier) {
                         when (route) {
                             BrowseNavRoute.Root -> BrowsePager(
@@ -275,7 +275,7 @@ fun BrowseScreen(
                                         onOfflineSongUnavailable = onOfflineSongUnavailable,
                                         onPlaySongs = offlineAwarePlaySongs,
                                         onShowActions = { actionSong = it },
-                                        onBack = onPopDetail,
+                                        onBack = onBack,
                                     )
                                 } else {
                                     BrowseDetailPlaceholder(
@@ -303,7 +303,7 @@ fun BrowseScreen(
                                         onOpenAlbum = onOpenAlbum,
                                         onPlaySongs = offlineAwarePlaySongs,
                                         onShowActions = { actionSong = it },
-                                        onBack = onPopDetail,
+                                        onBack = onBack,
                                     )
                                 } else {
                                     BrowseDetailPlaceholder(
@@ -329,7 +329,7 @@ fun BrowseScreen(
                                         onOfflineSongUnavailable = onOfflineSongUnavailable,
                                         onPlaySongs = offlineAwarePlaySongs,
                                         onShowActions = { actionSong = it },
-                                        onBack = onPopDetail,
+                                        onBack = onBack,
                                     )
                                 } else {
                                     BrowseDetailPlaceholder(
@@ -347,22 +347,33 @@ fun BrowseScreen(
                 pages.forEachIndexed { index, route ->
                     val isTop = index == pages.lastIndex
                     key(route) {
-                        val pageModifier = when {
-                            !isTop && route !is BrowseNavRoute.Root -> Modifier
-                                .fillMaxSize()
-                                .background(background)
-                            !isTop -> Modifier.fillMaxSize()
-                            route is BrowseNavRoute.Root -> Modifier.fillMaxSize()
-                            else -> Modifier
-                                .fillMaxSize()
-                                .pageEnterMotion()
-                                .predictiveBackMotion(
-                                    enabled = backHandlersEnabled,
-                                    onBack = onPopDetail,
-                                )
-                                .background(background)
+                        if (isTop && route !is BrowseNavRoute.Root) {
+                            // Detail page: a shared back-motion state drives both the predictive
+                            // gesture and the in-app back button (via dismiss), so the button
+                            // animates the same commit instead of snapping away.
+                            val backMotion = rememberPredictiveBackMotion(
+                                enabled = backHandlersEnabled,
+                                onBack = onPopDetail,
+                            )
+                            BrowsePage(
+                                route = route,
+                                pageModifier = Modifier
+                                    .fillMaxSize()
+                                    .pageEnterMotion()
+                                    .then(backMotion.modifier)
+                                    .background(background),
+                                onBack = backMotion::dismiss,
+                            )
+                        } else {
+                            val pageModifier = when {
+                                !isTop && route !is BrowseNavRoute.Root -> Modifier
+                                    .fillMaxSize()
+                                    .background(background)
+                                !isTop -> Modifier.fillMaxSize()
+                                else -> Modifier.fillMaxSize()
+                            }
+                            BrowsePage(route = route, pageModifier = pageModifier, onBack = onPopDetail)
                         }
-                        BrowsePage(route, pageModifier)
                     }
                 }
             }
@@ -883,28 +894,31 @@ private fun BrowsePager(
         }
 
         if (uiState.isSearchActive) {
+            val searchBackMotion = rememberPredictiveBackMotion(
+                enabled = backHandlersEnabled,
+                onBack = { onSetSearchActive(false) },
+                maxScaleReduction = 0.02f,
+                maxHorizontalShiftFraction = 0.12f,
+                horizontalShiftInset = 0.dp,
+                maxVerticalShiftFraction = 0f,
+                verticalShiftInset = 0.dp,
+                maxCornerRadius = 18.dp,
+                targetAlpha = 0f,
+            )
             Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .pageEnterMotion()
-                    .predictiveBackMotion(
-                        enabled = backHandlersEnabled,
-                        onBack = { onSetSearchActive(false) },
-                        maxScaleReduction = 0.02f,
-                        maxHorizontalShiftFraction = 0.12f,
-                        horizontalShiftInset = 0.dp,
-                        maxVerticalShiftFraction = 0f,
-                        verticalShiftInset = 0.dp,
-                        maxCornerRadius = 18.dp,
-                        targetAlpha = 0f,
-                    )
+                    .then(searchBackMotion.modifier)
                     .background(background),
             ) {
                 BrowseHeroCard(
                     currentServer = currentServer,
                     isSearchActive = true,
                     searchQuery = uiState.searchQuery,
-                    onSearchActiveChange = onSetSearchActive,
+                    onSearchActiveChange = { active ->
+                        if (active) onSetSearchActive(true) else searchBackMotion.dismiss()
+                    },
                     onSearchQueryChange = onUpdateSearchQuery,
                     onOpenSettings = onOpenSettings,
                 )


### PR DESCRIPTION
## Summary
- Add `Modifier.pageEnterMotion()` — a crisp forward "cover" open (rise ~6% + fade in, ~250ms) for page/route surfaces; applied to Browse detail pages, the search overlay, the server manager, and Settings (replacing its plain fade so all page opens match).
- Refactor `predictiveBackMotion` into a shared `PredictiveBackMotionState` (`rememberPredictiveBackMotion`) exposing both the `modifier` and a `dismiss()`; keep `Modifier.predictiveBackMotion()` as a thin wrapper for gesture-only call sites.
- Make in-app back/close buttons animate via `dismiss()`: a tap has no gesture to track, so it plays a quick reverse-of-open (slide down + fade out, ~160ms) rather than the predictive follow-finger commit. Wired through Browse detail pages, the Settings close button (restoring an animated close), and the search overlay close.
- Leave already-animated roles unchanged: Now Playing (rise from the bottom capsule), anchored sheets (queue / song actions), dialogs / menus (system default), and the server-manager close (system back only, already animated).

## Validation
- `./gradlew assembleDebug --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon`
- On-device: detail / search / server-manager / settings open with the rise-and-fade; back arrows and close buttons animate with a fast slide-down + fade; predictive gesture and system back are unchanged.