### PR TITLE
feat(theme): system dynamic color option with palette-style support and pokeball swatches

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -44,6 +44,7 @@ import org.hdhmc.saki.presentation.library.NowPlayingOverlay
 import org.hdhmc.saki.presentation.serverconfig.ServerConfigRoute
 import org.hdhmc.saki.presentation.settings.SettingsScreen
 import org.hdhmc.saki.ui.theme.seedColorForKey
+import org.hdhmc.saki.ui.theme.isSystemDynamicSeed
 import org.hdhmc.saki.ui.theme.SakiAndroidTheme
 
 @Composable
@@ -100,6 +101,7 @@ fun SakiApp(
         themeStyle = rootUiState.appPreferences.themeStyle,
         seedColor = seedColorForKey(rootUiState.appPreferences.themeSeedKey),
         paletteStyle = rootUiState.appPreferences.paletteStyle,
+        useSystemColor = isSystemDynamicSeed(rootUiState.appPreferences.themeSeedKey),
     ) {
         CompositionLocalProvider(LocalDensity provides appDensity) {
         Box(modifier = modifier.fillMaxSize()) {

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package org.hdhmc.saki.presentation.settings
 
+import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -7,9 +8,10 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,11 +26,13 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.CloudDownload
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.DeleteOutline
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Smartphone
 import androidx.compose.material.icons.rounded.Storage
 import androidx.compose.material.icons.rounded.Upload
 import androidx.compose.material.icons.rounded.TextFields
@@ -36,6 +40,7 @@ import androidx.compose.material.icons.rounded.WifiTethering
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -44,12 +49,12 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -59,6 +64,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -98,10 +104,13 @@ import org.hdhmc.saki.presentation.bottomContentPadding
 import org.hdhmc.saki.presentation.rememberBrowseBackgroundBrush
 import org.hdhmc.saki.ui.theme.SakiChromeIconButton
 import org.hdhmc.saki.ui.theme.SakiThemePresets
+import org.hdhmc.saki.ui.theme.SYSTEM_DYNAMIC_THEME_SEED_KEY
+import org.hdhmc.saki.ui.theme.isSystemDynamicSeed
+import org.hdhmc.saki.ui.theme.systemDynamicSeedColor
+import org.hdhmc.saki.ui.theme.sakiExpressiveColorScheme
 import org.hdhmc.saki.ui.theme.sakiCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiSelectedContainerColor
 import org.hdhmc.saki.ui.theme.sakiTonalContainerColor
-import com.materialkolor.hct.Hct
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -164,6 +173,44 @@ fun SettingsScreen(
     var songsPageSizeSliderValue by remember(configuredSongsPageSize) {
         mutableFloatStateOf(configuredSongsPageSize.toFloat())
     }
+
+    // Precompute the theme-color swatch palette once, off the scroll path. Otherwise the theme
+    // LazyColumn item generates 8 full color schemes the instant it composes mid-scroll (a frame
+    // drop) and recomputes them every time it is recycled and scrolled back into view.
+    val swatchPreviewDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
+    val swatchPaletteStyle = uiState.appPreferences.paletteStyle
+    val swatchThemeStyle = uiState.appPreferences.themeStyle
+    val swatchContext = LocalContext.current
+    val supportsSystemColor = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val themeSwatchColors: Map<String, ThemeSeedSwatchColors> =
+        remember(swatchPreviewDark, swatchPaletteStyle, swatchThemeStyle) {
+            if (swatchThemeStyle != ThemeStyle.MATERIAL_EXPRESSIVE) {
+                emptyMap()
+            } else {
+                buildMap {
+                    SakiThemePresets.forEach { preset ->
+                        put(
+                            preset.key,
+                            themeSeedSwatchColors(
+                                sakiExpressiveColorScheme(preset.seed, swatchPreviewDark, swatchPaletteStyle),
+                            ),
+                        )
+                    }
+                    if (supportsSystemColor) {
+                        put(
+                            SYSTEM_DYNAMIC_THEME_SEED_KEY,
+                            themeSeedSwatchColors(
+                                sakiExpressiveColorScheme(
+                                    systemDynamicSeedColor(swatchContext),
+                                    swatchPreviewDark,
+                                    swatchPaletteStyle,
+                                ),
+                            ),
+                        )
+                    }
+                }
+            }
+        }
 
     LazyColumn(
         modifier = Modifier
@@ -533,18 +580,6 @@ fun SettingsScreen(
                         )
                     }
                     val currentSeedKey = uiState.appPreferences.themeSeedKey
-                    // Preview follows the current light/dark mode and uses the container roles, so the
-                    // swatches stay pleasant pastels in light and deep tones in dark (KSU-style).
-                    val previewDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
-                    val swatchColors = remember(previewDark, currentPaletteStyle) {
-                        SakiThemePresets.associate { preset ->
-                            preset.key to themeSeedSwatchColors(
-                                seed = preset.seed,
-                                isDark = previewDark,
-                                paletteStyle = currentPaletteStyle,
-                            )
-                        }
-                    }
                     Text(
                         text = stringResource(R.string.settings_theme_seed_label),
                         style = MaterialTheme.typography.labelLarge,
@@ -554,35 +589,22 @@ fun SettingsScreen(
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
+                        themeSwatchColors[SYSTEM_DYNAMIC_THEME_SEED_KEY]?.let { systemColors ->
+                            ThemeSeedSwatch(
+                                colors = systemColors,
+                                isSelected = isSystemDynamicSeed(currentSeedKey),
+                                description = stringResource(R.string.settings_theme_seed_system),
+                                onClick = { onUpdateThemeSeed(SYSTEM_DYNAMIC_THEME_SEED_KEY) },
+                                centerIcon = Icons.Rounded.Smartphone,
+                            )
+                        }
                         SakiThemePresets.forEach { preset ->
-                            val selected = preset.key == currentSeedKey
-                            val presetName = stringResource(preset.nameRes)
-                            val colors = swatchColors.getValue(preset.key)
-                            Box(
-                                modifier = Modifier
-                                    .size(44.dp)
-                                    .clip(CircleShape)
-                                    .border(
-                                        width = if (selected) 3.dp else 1.dp,
-                                        color = if (selected) {
-                                            MaterialTheme.colorScheme.onSurface
-                                        } else {
-                                            MaterialTheme.colorScheme.outlineVariant
-                                        },
-                                        shape = CircleShape,
-                                    )
-                                    .selectable(
-                                        selected = selected,
-                                        role = Role.RadioButton,
-                                        onClick = { onUpdateThemeSeed(preset.key) },
-                                    )
-                                    .semantics { contentDescription = presetName },
-                            ) {
-                                Canvas(modifier = Modifier.fillMaxSize()) {
-                                    drawArc(color = colors.top, startAngle = 180f, sweepAngle = 180f, useCenter = true)
-                                    drawArc(color = colors.bottom, startAngle = 0f, sweepAngle = 180f, useCenter = true)
-                                }
-                            }
+                            ThemeSeedSwatch(
+                                colors = themeSwatchColors.getValue(preset.key),
+                                isSelected = preset.key == currentSeedKey,
+                                description = stringResource(preset.nameRes),
+                                onClick = { onUpdateThemeSeed(preset.key) },
+                            )
                         }
                     }
                 }
@@ -1233,31 +1255,88 @@ private fun formatStorageSize(bytes: Long): String {
 private data class ThemeSeedSwatchColors(
     val top: Color,
     val bottom: Color,
+    val center: Color,
+    val onCenter: Color,
 )
 
-private fun themeSeedSwatchColors(
-    seed: Color,
-    isDark: Boolean,
-    paletteStyle: SakiPaletteStyle,
-): ThemeSeedSwatchColors {
-    val hct = Hct.fromInt(seed.toArgb())
-    val hueShift = when (paletteStyle) {
-        SakiPaletteStyle.TONAL_SPOT -> 24.0
-        SakiPaletteStyle.VIBRANT -> 36.0
-        SakiPaletteStyle.EXPRESSIVE -> 58.0
+/** Maps a generated scheme to the swatch's roles, using the roles the app actually renders. */
+private fun themeSeedSwatchColors(scheme: ColorScheme) = ThemeSeedSwatchColors(
+    top = scheme.primaryContainer,
+    bottom = scheme.secondaryContainer,
+    center = scheme.primary,
+    onCenter = scheme.onPrimary,
+)
+
+/**
+ * "Pokéball" theme swatch (KernelSU-style, scaled down for Settings): a rounded surfaceContainer
+ * tile holding a two-tone ball (top = primaryContainer, bottom = secondaryContainer) with a small
+ * primary center button; selection grows the button into a ringed, checked badge.
+ */
+@Composable
+private fun ThemeSeedSwatch(
+    colors: ThemeSeedSwatchColors,
+    isSelected: Boolean,
+    description: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    centerIcon: ImageVector? = null,
+) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = modifier
+            .size(52.dp)
+            .semantics { contentDescription = description },
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Canvas(modifier = Modifier.size(34.dp)) {
+                drawArc(color = colors.top, startAngle = 180f, sweepAngle = 180f, useCenter = true)
+                drawArc(color = colors.bottom, startAngle = 0f, sweepAngle = 180f, useCenter = true)
+            }
+            if (isSelected) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .border(2.dp, colors.center, CircleShape),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(18.dp)
+                            .clip(CircleShape)
+                            .background(colors.center),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.Check,
+                            contentDescription = null,
+                            tint = colors.onCenter,
+                            modifier = Modifier.size(12.dp),
+                        )
+                    }
+                }
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(15.dp)
+                        .clip(CircleShape)
+                        .background(colors.center),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    // System/Material You marker inside the center button when unselected.
+                    if (centerIcon != null) {
+                        Icon(
+                            imageVector = centerIcon,
+                            contentDescription = null,
+                            tint = colors.onCenter,
+                            modifier = Modifier.size(10.dp),
+                        )
+                    }
+                }
+            }
+        }
     }
-    val primaryTone = if (isDark) 70.0 else 88.0
-    val secondaryTone = if (isDark) 62.0 else 92.0
-    val primaryChroma = (hct.chroma * 0.70).coerceIn(18.0, if (isDark) 42.0 else 32.0)
-    val secondaryChroma = (hct.chroma * when (paletteStyle) {
-        SakiPaletteStyle.TONAL_SPOT -> 0.42
-        SakiPaletteStyle.VIBRANT -> 0.58
-        SakiPaletteStyle.EXPRESSIVE -> 0.70
-    }).coerceIn(12.0, if (isDark) 34.0 else 26.0)
-    return ThemeSeedSwatchColors(
-        top = Color(Hct.from(hct.hue, primaryChroma, primaryTone).toInt()),
-        bottom = Color(Hct.from((hct.hue + hueShift) % 360.0, secondaryChroma, secondaryTone).toInt()),
-    )
 }
 
 private const val STREAM_CACHE_SLIDER_STEPS =

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -75,6 +76,7 @@ import org.hdhmc.saki.domain.model.AlbumListType
 import org.hdhmc.saki.domain.model.AppLanguage
 import org.hdhmc.saki.domain.model.CachedSong
 import org.hdhmc.saki.domain.model.DefaultBrowseTab
+import org.hdhmc.saki.domain.model.DEFAULT_THEME_SEED_KEY
 import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.domain.model.SakiPaletteStyle
 import org.hdhmc.saki.domain.model.ThemeStyle
@@ -580,6 +582,13 @@ fun SettingsScreen(
                         )
                     }
                     val currentSeedKey = uiState.appPreferences.themeSeedKey
+                    // Below Android 12 a stored "system" seed falls back to the brand seed, so show
+                    // that preset as selected rather than leaving nothing highlighted.
+                    val effectiveSeedKey = if (!supportsSystemColor && isSystemDynamicSeed(currentSeedKey)) {
+                        DEFAULT_THEME_SEED_KEY
+                    } else {
+                        currentSeedKey
+                    }
                     Text(
                         text = stringResource(R.string.settings_theme_seed_label),
                         style = MaterialTheme.typography.labelLarge,
@@ -601,7 +610,7 @@ fun SettingsScreen(
                         SakiThemePresets.forEach { preset ->
                             ThemeSeedSwatch(
                                 colors = themeSwatchColors.getValue(preset.key),
-                                isSelected = preset.key == currentSeedKey,
+                                isSelected = preset.key == effectiveSeedKey,
                                 description = stringResource(preset.nameRes),
                                 onClick = { onUpdateThemeSeed(preset.key) },
                             )
@@ -1282,11 +1291,16 @@ private fun ThemeSeedSwatch(
     centerIcon: ImageVector? = null,
 ) {
     Surface(
-        onClick = onClick,
         shape = RoundedCornerShape(16.dp),
         color = MaterialTheme.colorScheme.surfaceContainer,
         modifier = modifier
             .size(52.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .selectable(
+                selected = isSelected,
+                role = Role.RadioButton,
+                onClick = onClick,
+            )
             .semantics { contentDescription = description },
     ) {
         Box(contentAlignment = Alignment.Center) {

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/Theme.kt
@@ -11,11 +11,13 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.dynamicColorScheme
 import com.materialkolor.hct.Hct
 import com.materialkolor.rememberDynamicColorScheme
 import org.hdhmc.saki.domain.model.SakiPaletteStyle
@@ -35,6 +37,9 @@ fun SakiAndroidTheme(
     seedColor: Color? = null,
     // Palette style for the Material Expressive theme.
     paletteStyle: SakiPaletteStyle = SakiPaletteStyle.TONAL_SPOT,
+    // Source the Material Expressive scheme from the system (Material You) palette instead of
+    // [seedColor]. Honored only on Android 12+; ignored otherwise.
+    useSystemColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(
@@ -52,8 +57,15 @@ fun SakiAndroidTheme(
             }
 
             ThemeStyle.MATERIAL_EXPRESSIVE -> {
+                // System color is fed in as a seed (not the platform scheme) so the selected
+                // palette style still applies and the app's calm tuning stays consistent.
+                val seed = if (useSystemColor) {
+                    systemDynamicSeedColor(LocalContext.current)
+                } else {
+                    seedColor ?: BrandSeedColor
+                }
                 val scheme = rememberSakiExpressiveColorScheme(
-                    seedColor = seedColor ?: BrandSeedColor,
+                    seedColor = seed,
                     isDark = darkTheme,
                     paletteStyle = paletteStyle,
                 )
@@ -99,7 +111,21 @@ fun rememberSakiExpressiveColorScheme(
     seedColor: Color,
     isDark: Boolean,
     paletteStyle: SakiPaletteStyle,
-): ColorScheme = rememberDynamicColorScheme(
+): ColorScheme = remember(seedColor, isDark, paletteStyle) {
+    sakiExpressiveColorScheme(seedColor, isDark, paletteStyle)
+}
+
+/**
+ * Non-composable counterpart to [rememberSakiExpressiveColorScheme]. Exposed so previews — notably
+ * the Settings color picker, which needs every preset's scheme at once — can compute and memoize
+ * them inside a single `remember` block, keeping the expensive desaturation off the recomposition
+ * path (the jank #299 addressed) while still previewing the real generated primary/secondary pair.
+ */
+fun sakiExpressiveColorScheme(
+    seedColor: Color,
+    isDark: Boolean,
+    paletteStyle: SakiPaletteStyle,
+): ColorScheme = dynamicColorScheme(
     seedColor = seedColor,
     isDark = isDark,
     style = paletteStyle.toMaterialKolor(),

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/ThemePresets.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/ThemePresets.kt
@@ -1,5 +1,7 @@
 package org.hdhmc.saki.ui.theme
 
+import android.content.Context
+import android.os.Build
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.Color
 import org.hdhmc.saki.R
@@ -36,3 +38,26 @@ val SakiThemePresets: List<SakiThemePreset> = listOf(
 /** Resolves a stored preset key to its seed color, falling back to the brand seed. */
 fun seedColorForKey(key: String?): Color =
     SakiThemePresets.firstOrNull { it.key == key }?.seed ?: HarborBlue
+
+/**
+ * Sentinel seed key for "follow the system" / Material You dynamic color (Android 12+). When this
+ * is the active [org.hdhmc.saki.domain.model.AppPreferences.themeSeedKey], the theme sources its
+ * colors from the platform dynamic scheme instead of a fixed preset seed.
+ */
+const val SYSTEM_DYNAMIC_THEME_SEED_KEY = "system"
+
+/** True when [key] selects the system dynamic (Material You) color source. */
+fun isSystemDynamicSeed(key: String?): Boolean = key == SYSTEM_DYNAMIC_THEME_SEED_KEY
+
+/**
+ * The system (Material You) accent used as a MaterialKolor seed, so the system color source still
+ * flows through the same palette-style pipeline as the curated presets (and therefore honors the
+ * selected [SakiPaletteStyle]). Falls back to the brand seed below Android 12, where dynamic color
+ * is unavailable.
+ */
+fun systemDynamicSeedColor(context: Context): Color =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        Color(context.getColor(android.R.color.system_accent1_500))
+    } else {
+        HarborBlue
+    }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -72,6 +72,7 @@
     <string name="settings_palette_style_vibrant">鲜艳</string>
     <string name="settings_palette_style_expressive">张扬</string>
     <string name="settings_theme_seed_label">主题颜色</string>
+    <string name="settings_theme_seed_system">跟随系统</string>
     <string name="settings_theme_seed_harbor_blue">港湾蓝</string>
     <string name="settings_theme_seed_sakura">樱花粉</string>
     <string name="settings_theme_seed_wisteria">紫藤</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="settings_palette_style_vibrant">Vibrant</string>
     <string name="settings_palette_style_expressive">Expressive</string>
     <string name="settings_theme_seed_label">Theme color</string>
+    <string name="settings_theme_seed_system">System</string>
     <string name="settings_theme_seed_harbor_blue">Harbor blue</string>
     <string name="settings_theme_seed_sakura">Sakura</string>
     <string name="settings_theme_seed_wisteria">Wisteria</string>


### PR DESCRIPTION
## Summary
- Add a **System** (Material You) option to the Material Expressive theme-color picker, shown only on Android 12+. Selecting it sources the app's colors from the system/wallpaper palette.
- Route the system color through the same MaterialKolor seed pipeline as the presets (seeded from `system_accent1_500`), so all three palette styles (Tonal Spot / Vibrant / Expressive) still apply and the app's calm desaturation stays consistent — previously the platform scheme ignored palette style.
- Redesign the theme swatches as KernelSU-style "pokéball" tiles (scaled down for Settings): a `surfaceContainer` tile with a two-tone ball (top = `primaryContainer`, bottom = `secondaryContainer`) and a `primary` center button; selection shows a ringed check. Roles chosen to match what the app actually renders (dropped `tertiaryContainer`, which is effectively unused). The system swatch shows the phone marker in its center button.
- Fix a scroll frame drop: the theme swatch colors (8 generated schemes) were computed the moment the Settings theme item composed mid-scroll and recomputed on every recycle. They are now precomputed once in a hoisted `remember` keyed on `(dark, paletteStyle, themeStyle)`, off the scroll path.

## Validation
- `./gradlew assembleDebug --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon`
- On-device: Material Expressive → theme color → System follows the wallpaper; Tonal Spot / Vibrant / Expressive each render distinctly under System; scrolling to the theme section is smooth; picker unavailable below Android 12.

## Notes
The default **Saki** style already used system dynamic color on Android 12+; this exposes the choice explicitly for the Expressive style, consistent with that style being the only one with a color picker.