### PR TITLE
[codex] Adapt album grid columns

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -148,6 +148,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 private val BrowseAdaptiveNavigationMinWidth = 600.dp
+private val AlbumAdaptiveGridMinContentWidth = 520.dp
+private val AlbumAdaptiveGridMinCellWidth = 168.dp
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -1798,11 +1800,12 @@ private fun AlbumFeedPageContent(
                     .collect { onLoadMore() }
             }
 
-            Box(modifier = Modifier.fillMaxSize()) {
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                val gridColumns = albumGridCells(maxWidth)
                 LazyVerticalGrid(
                     state = gridState,
                     modifier = Modifier.fillMaxSize(),
-                    columns = GridCells.Fixed(2),
+                    columns = gridColumns,
                     contentPadding = contentPadding,
                 ) {
                     when {
@@ -1913,6 +1916,14 @@ private fun albumFeedContentPadding(
 }
 
 private val AlbumFastScrollContentEndPadding = 24.dp
+
+private fun albumGridCells(maxWidth: Dp): GridCells {
+    return if (maxWidth < AlbumAdaptiveGridMinContentWidth) {
+        GridCells.Fixed(2)
+    } else {
+        GridCells.Adaptive(AlbumAdaptiveGridMinCellWidth)
+    }
+}
 
 @Composable
 private fun AlbumFastScrollOverlay(


### PR DESCRIPTION
## Summary
- Keep compact album grid behavior at two columns.
- Switch album grid to adaptive columns once content width reaches 520dp.
- Use a 168dp adaptive album cell target for landscape, foldable, tablet, and desktop-sized Browse layouts.

## Scope
Implements the album grid portion of #324. This does not change list mode, album cards, fast-scroll behavior, or detail-page layout.

## Validation
- `git diff --check`
- `./gradlew assembleDebug -q`

Related: #251
Related: #324