### PR TITLE
fix: refine adaptive browse layout

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,7 +142,6 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material3.adaptive.navigation.suite)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -17,12 +17,14 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -46,6 +48,7 @@ import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -98,6 +101,9 @@ import org.hdhmc.saki.ui.theme.sakiCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiSubtleCardContainerColor
 import org.hdhmc.saki.ui.theme.sakiTonalContainerColor
 import org.hdhmc.saki.ui.theme.SakiTheme
+
+private val LibraryDetailWideHeroMinWidth = 720.dp
+private val LibraryDetailWideHeroArtworkWidth = 320.dp
 
 @Composable
 fun ArtistDetailScreen(
@@ -492,6 +498,152 @@ fun AlbumDetailScreen(
 
 @Composable
 private fun AlbumDetailHeroCard(
+    title: String,
+    artwork: Any?,
+    metaItems: List<String>,
+    canPlay: Boolean,
+    onPlay: () -> Unit,
+    onBack: () -> Unit,
+    accentColor: Color,
+) {
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        if (maxWidth >= LibraryDetailWideHeroMinWidth) {
+            WideAlbumDetailHeroCard(
+                title = title,
+                artwork = artwork,
+                metaItems = metaItems,
+                canPlay = canPlay,
+                onPlay = onPlay,
+                onBack = onBack,
+                accentColor = accentColor,
+            )
+        } else {
+            CompactAlbumDetailHeroCard(
+                title = title,
+                artwork = artwork,
+                metaItems = metaItems,
+                canPlay = canPlay,
+                onPlay = onPlay,
+                onBack = onBack,
+                accentColor = accentColor,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WideAlbumDetailHeroCard(
+    title: String,
+    artwork: Any?,
+    metaItems: List<String>,
+    canPlay: Boolean,
+    onPlay: () -> Unit,
+    onBack: () -> Unit,
+    accentColor: Color,
+) {
+    val playContainer = accentColor.ensureContrast(
+        MaterialTheme.colorScheme.surfaceContainerHighest,
+        MaterialTheme.colorScheme.primary,
+    )
+    val onPlayAccent = if (playContainer.contrastRatio(Color.White) >= playContainer.contrastRatio(Color.Black)) {
+        Color.White
+    } else {
+        Color.Black
+    }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp, bottom = 18.dp),
+        shape = MaterialTheme.shapes.extraLarge,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = LibraryDetailWideHeroArtworkWidth)
+                .padding(18.dp),
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier.width(LibraryDetailWideHeroArtworkWidth),
+            ) {
+                AdaptiveBlurArtwork(
+                    model = artwork,
+                    contentDescription = title,
+                    modifier = Modifier.fillMaxWidth(),
+                    cornerRadiusDp = 28,
+                )
+                Surface(
+                    onClick = onBack,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(10.dp)
+                        .minimumInteractiveComponentSize()
+                        .size(40.dp),
+                    shape = CircleShape,
+                    color = Color.Black.copy(alpha = 0.32f),
+                    contentColor = Color.White,
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                        contentDescription = stringResource(R.string.library_back),
+                        modifier = Modifier.padding(9.dp),
+                    )
+                }
+            }
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                val metaLine = metaItems.joinToString(" • ")
+                if (metaLine.isNotBlank()) {
+                    Text(
+                        text = metaLine,
+                        modifier = Modifier
+                            .padding(top = 8.dp)
+                            .basicMarquee(iterations = Int.MAX_VALUE, velocity = 20.dp),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        softWrap = false,
+                    )
+                }
+                FilledTonalButton(
+                    onClick = onPlay,
+                    enabled = canPlay,
+                    modifier = Modifier.padding(top = 22.dp),
+                    shape = MaterialTheme.shapes.small,
+                    colors = ButtonDefaults.filledTonalButtonColors(
+                        containerColor = playContainer,
+                        contentColor = onPlayAccent,
+                    ),
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.PlayArrow,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(stringResource(R.string.library_play))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompactAlbumDetailHeroCard(
     title: String,
     artwork: Any?,
     metaItems: List<String>,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
@@ -55,9 +56,6 @@ import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Search
-import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
-import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Card
@@ -148,6 +146,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 private val BrowseAdaptiveNavigationMinWidth = 600.dp
+private val BrowseAdaptiveNavigationRailWidth = 104.dp
+private val BrowseAdaptiveNavigationRailItemWidth = 88.dp
+private val BrowseAdaptiveNavigationRailItemHeight = 76.dp
+private val BrowseAdaptiveNavigationRailIndicatorWidth = 64.dp
+private val BrowseAdaptiveNavigationRailIndicatorHeight = 36.dp
+private val BrowseAdaptiveNavigationContentGap = 12.dp
 private val AlbumAdaptiveGridMinContentWidth = 520.dp
 private val AlbumAdaptiveGridMinCellWidth = 168.dp
 
@@ -711,7 +715,6 @@ private fun OfflineModeBanner(modifier: Modifier = Modifier) {
 
 @OptIn(
     ExperimentalFoundationApi::class,
-    ExperimentalMaterial3AdaptiveApi::class,
     ExperimentalMaterial3ExpressiveApi::class,
 )
 @Composable
@@ -916,27 +919,23 @@ private fun BrowsePager(
         }
 
         if (useAdaptiveNavigation) {
-            NavigationSuiteScaffold(
-                navigationSuiteItems = {
-                    sections.forEach { section ->
-                        item(
-                            icon = {
-                                Icon(
-                                    imageVector = section.navigationIcon(),
-                                    contentDescription = null,
-                                )
-                            },
-                            label = { Text(section.localizedLabel()) },
-                            selected = uiState.selectedBrowseSection == section,
-                            onClick = { onSelectBrowseSection(section) },
-                        )
-                    }
-                },
-                layoutType = NavigationSuiteType.NavigationRail,
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.onBackground,
-            ) {
-                content()
+            Row(modifier = Modifier.fillMaxSize()) {
+                BrowseAdaptiveNavigationRail(
+                    sections = sections,
+                    selectedSection = uiState.selectedBrowseSection,
+                    onSelectBrowseSection = onSelectBrowseSection,
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .width(BrowseAdaptiveNavigationRailWidth),
+                )
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .padding(start = BrowseAdaptiveNavigationContentGap),
+                ) {
+                    content()
+                }
             }
         } else {
             content()
@@ -993,6 +992,80 @@ private fun BrowsePager(
                     onOfflineSongUnavailable = onOfflineSongUnavailable,
                     onShowSongActions = onShowSongActions,
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BrowseAdaptiveNavigationRail(
+    sections: List<BrowseSection>,
+    selectedSection: BrowseSection,
+    onSelectBrowseSection: (BrowseSection) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(top = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        sections.forEach { section ->
+            val selected = section == selectedSection
+            Surface(
+                modifier = Modifier
+                    .width(BrowseAdaptiveNavigationRailItemWidth)
+                    .height(BrowseAdaptiveNavigationRailItemHeight)
+                    .selectable(
+                        selected = selected,
+                        onClick = { onSelectBrowseSection(section) },
+                        role = Role.Tab,
+                    ),
+                shape = MaterialTheme.shapes.large,
+                color = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Surface(
+                        modifier = Modifier
+                            .width(BrowseAdaptiveNavigationRailIndicatorWidth)
+                            .height(BrowseAdaptiveNavigationRailIndicatorHeight),
+                        shape = MaterialTheme.shapes.extraLarge,
+                        color = if (selected) {
+                            MaterialTheme.colorScheme.secondaryContainer
+                        } else {
+                            Color.Transparent
+                        },
+                        contentColor = if (selected) {
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = section.navigationIcon(),
+                                contentDescription = null,
+                                modifier = Modifier.size(26.dp),
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = section.localizedLabel(),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = if (selected) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,6 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
-androidx-compose-material3-adaptive-navigation-suite = { group = "androidx.compose.material3", name = "material3-adaptive-navigation-suite", version.ref = "material3" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }


### PR DESCRIPTION
## Summary
- Replace the default adaptive navigation rail treatment with a lighter custom rail indicator so the left rail no longer reads as a heavy slab.
- Add a wide-screen album/playlist detail hero layout that keeps artwork bounded and places metadata/actions beside it.
- Remove the now-unused adaptive navigation suite dependency.

## Validation
- `./gradlew assembleDebug -q`
- Installed on `10.233.233.69:34567` and checked screenshots for Browse rail, album grid, album detail, and playlist detail.

Refs #324