### PR TITLE
[codex] Improve landscape mini player layout

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -78,6 +78,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -104,6 +105,8 @@ import org.hdhmc.saki.ui.theme.SakiTheme
 
 private val LibraryDetailWideHeroMinWidth = 720.dp
 private val LibraryDetailWideHeroArtworkWidth = 320.dp
+private val LibraryDetailWideHeroCompactArtworkWidth = 220.dp
+private const val LibraryDetailWideHeroCompactMaxHeightDp = 520
 
 @Composable
 fun ArtistDetailScreen(
@@ -506,11 +509,21 @@ private fun AlbumDetailHeroCard(
     onBack: () -> Unit,
     accentColor: Color,
 ) {
+    val configuration = LocalConfiguration.current
+    val useCompactLandscapeHero = configuration.screenWidthDp > configuration.screenHeightDp &&
+        configuration.screenHeightDp < LibraryDetailWideHeroCompactMaxHeightDp
+    val wideHeroArtworkWidth = if (useCompactLandscapeHero) {
+        LibraryDetailWideHeroCompactArtworkWidth
+    } else {
+        LibraryDetailWideHeroArtworkWidth
+    }
+
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         if (maxWidth >= LibraryDetailWideHeroMinWidth) {
             WideAlbumDetailHeroCard(
                 title = title,
                 artwork = artwork,
+                artworkWidth = wideHeroArtworkWidth,
                 metaItems = metaItems,
                 canPlay = canPlay,
                 onPlay = onPlay,
@@ -535,6 +548,7 @@ private fun AlbumDetailHeroCard(
 private fun WideAlbumDetailHeroCard(
     title: String,
     artwork: Any?,
+    artworkWidth: Dp,
     metaItems: List<String>,
     canPlay: Boolean,
     onPlay: () -> Unit,
@@ -562,13 +576,13 @@ private fun WideAlbumDetailHeroCard(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = LibraryDetailWideHeroArtworkWidth)
+                .heightIn(min = artworkWidth)
                 .padding(18.dp),
             horizontalArrangement = Arrangement.spacedBy(24.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Box(
-                modifier = Modifier.width(LibraryDetailWideHeroArtworkWidth),
+                modifier = Modifier.width(artworkWidth),
             ) {
                 AdaptiveBlurArtwork(
                     model = artwork,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -78,7 +78,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -106,7 +105,7 @@ import org.hdhmc.saki.ui.theme.SakiTheme
 private val LibraryDetailWideHeroMinWidth = 720.dp
 private val LibraryDetailWideHeroArtworkWidth = 320.dp
 private val LibraryDetailWideHeroCompactArtworkWidth = 220.dp
-private const val LibraryDetailWideHeroCompactMaxHeightDp = 520
+private val LibraryDetailWideHeroCompactMaxHeight = 520.dp
 
 @Composable
 fun ArtistDetailScreen(
@@ -509,16 +508,15 @@ private fun AlbumDetailHeroCard(
     onBack: () -> Unit,
     accentColor: Color,
 ) {
-    val configuration = LocalConfiguration.current
-    val useCompactLandscapeHero = configuration.screenWidthDp > configuration.screenHeightDp &&
-        configuration.screenHeightDp < LibraryDetailWideHeroCompactMaxHeightDp
-    val wideHeroArtworkWidth = if (useCompactLandscapeHero) {
-        LibraryDetailWideHeroCompactArtworkWidth
-    } else {
-        LibraryDetailWideHeroArtworkWidth
-    }
-
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val useCompactLandscapeHero = maxWidth > maxHeight &&
+            maxHeight < LibraryDetailWideHeroCompactMaxHeight
+        val wideHeroArtworkWidth = if (useCompactLandscapeHero) {
+            LibraryDetailWideHeroCompactArtworkWidth
+        } else {
+            LibraryDetailWideHeroArtworkWidth
+        }
+
         if (maxWidth >= LibraryDetailWideHeroMinWidth) {
             WideAlbumDetailHeroCard(
                 title = title,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -48,6 +48,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -224,150 +225,166 @@ fun NowPlayingCapsule(
     )
     val onExpandState = rememberUpdatedState(onExpand)
 
-    Card(
-        onClick = onExpand,
-        enabled = track != null,
+    BoxWithConstraints(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 14.dp, end = 14.dp, top = 4.dp, bottom = 8.dp)
-            .pointerInput(track != null) {
-                if (track == null) return@pointerInput
-                val distanceThresholdPx = 72.dp.toPx()
-                val velocityThresholdDpPerSecond = 300f
-                var upwardDistance = 0f
-                var dragStartedAtNanos = 0L
-                var didOpen = false
+            .padding(start = 14.dp, end = 14.dp, top = 4.dp, bottom = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        val constrainLandscapeCapsuleWidth = maxWidth > maxHeight &&
+            maxHeight < MINI_PLAYER_LANDSCAPE_WIDTH_LIMIT_HEIGHT
 
-                fun openFromSwipe() {
-                    if (!didOpen) {
-                        didOpen = true
-                        onExpandState.value()
-                    }
-                }
-
-                detectVerticalDragGestures(
-                    onDragStart = {
-                        upwardDistance = 0f
-                        dragStartedAtNanos = System.nanoTime()
-                        didOpen = false
+        Card(
+            onClick = onExpand,
+            enabled = track != null,
+            modifier = Modifier
+                .then(
+                    if (constrainLandscapeCapsuleWidth) {
+                        Modifier.widthIn(max = MINI_PLAYER_LANDSCAPE_MAX_WIDTH)
+                    } else {
+                        Modifier
                     },
-                    onVerticalDrag = { _, dragAmount ->
-                        if (dragAmount < 0f) {
-                            upwardDistance -= dragAmount
-                            if (upwardDistance >= distanceThresholdPx) {
+                )
+                .fillMaxWidth()
+                .pointerInput(track != null) {
+                    if (track == null) return@pointerInput
+                    val distanceThresholdPx = 72.dp.toPx()
+                    val velocityThresholdDpPerSecond = 300f
+                    var upwardDistance = 0f
+                    var dragStartedAtNanos = 0L
+                    var didOpen = false
+
+                    fun openFromSwipe() {
+                        if (!didOpen) {
+                            didOpen = true
+                            onExpandState.value()
+                        }
+                    }
+
+                    detectVerticalDragGestures(
+                        onDragStart = {
+                            upwardDistance = 0f
+                            dragStartedAtNanos = System.nanoTime()
+                            didOpen = false
+                        },
+                        onVerticalDrag = { _, dragAmount ->
+                            if (dragAmount < 0f) {
+                                upwardDistance -= dragAmount
+                                if (upwardDistance >= distanceThresholdPx) {
+                                    openFromSwipe()
+                                }
+                            } else {
+                                upwardDistance = (upwardDistance - dragAmount).coerceAtLeast(0f)
+                            }
+                        },
+                        onDragEnd = {
+                            val elapsedSeconds = (System.nanoTime() - dragStartedAtNanos) / 1_000_000_000f
+                            val upwardVelocityDpPerSecond = if (elapsedSeconds > 0f) {
+                                (upwardDistance / elapsedSeconds).toDp().value
+                            } else {
+                                0f
+                            }
+                            if (elapsedSeconds > 0f &&
+                                upwardVelocityDpPerSecond >= velocityThresholdDpPerSecond
+                            ) {
                                 openFromSwipe()
                             }
-                        } else {
-                            upwardDistance = (upwardDistance - dragAmount).coerceAtLeast(0f)
-                        }
-                    },
-                    onDragEnd = {
-                        val elapsedSeconds = (System.nanoTime() - dragStartedAtNanos) / 1_000_000_000f
-                        val upwardVelocityDpPerSecond = if (elapsedSeconds > 0f) {
-                            (upwardDistance / elapsedSeconds).toDp().value
-                        } else {
-                            0f
-                        }
-                        if (elapsedSeconds > 0f &&
-                            upwardVelocityDpPerSecond >= velocityThresholdDpPerSecond
-                        ) {
-                            openFromSwipe()
-                        }
-                    },
-                    onDragCancel = {
-                        upwardDistance = 0f
-                        didOpen = false
-                    },
-                )
-            },
-        shape = RoundedCornerShape(visuals.miniPlayerContainerCornerRadius),
-        colors = CardDefaults.cardColors(
-            containerColor = capsuleContainerColor,
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = elevation),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+                        },
+                        onDragCancel = {
+                            upwardDistance = 0f
+                            didOpen = false
+                        },
+                    )
+                },
+            shape = RoundedCornerShape(visuals.miniPlayerContainerCornerRadius),
+            colors = CardDefaults.cardColors(
+                containerColor = capsuleContainerColor,
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = elevation),
         ) {
-            AnimatedVisibility(visible = track != null) {
-                Box(
-                    modifier = Modifier
-                        .size(width = visuals.miniPlayerHandleWidth, height = 3.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                                alpha = visuals.miniPlayerHandleAlpha,
-                            ),
-                            shape = RoundedCornerShape(100),
-                        ),
-                )
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalAlignment = Alignment.CenterVertically,
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                AnimatedContent(
-                    targetState = Pair(
-                        track?.queueArtworkModel(currentServer),
-                        track?.title,
-                    ),
-                    transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(300)) },
-                    label = "capsule-artwork",
-                ) { (model, title) ->
-                    ArtworkCard(
-                        model = model,
-                        contentDescription = title,
-                        modifier = Modifier.size(46.dp),
-                        cornerRadiusDp = visuals.miniPlayerArtworkCornerRadius.value.roundToInt(),
-                        requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
+                AnimatedVisibility(visible = track != null) {
+                    Box(
+                        modifier = Modifier
+                            .size(width = visuals.miniPlayerHandleWidth, height = 3.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                                    alpha = visuals.miniPlayerHandleAlpha,
+                                ),
+                                shape = RoundedCornerShape(100),
+                            ),
                     )
                 }
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = track?.title ?: stringResource(R.string.player_nothing_playing),
-                        style = MaterialTheme.typography.titleMedium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+                    AnimatedContent(
+                        targetState = Pair(
+                            track?.queueArtworkModel(currentServer),
+                            track?.title,
+                        ),
+                        transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(300)) },
+                        label = "capsule-artwork",
+                    ) { (model, title) ->
+                        ArtworkCard(
+                            model = model,
+                            contentDescription = title,
+                            modifier = Modifier.size(46.dp),
+                            cornerRadiusDp = visuals.miniPlayerArtworkCornerRadius.value.roundToInt(),
+                            requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
+                        )
+                    }
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        Text(
+                            text = track?.title ?: stringResource(R.string.player_nothing_playing),
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = track?.let { listOfNotNull(it.artist, it.album).joinToString(" • ") }
+                                ?: stringResource(R.string.player_start_from_browse),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    MiniPlayerIconButton(
+                        icon = Icons.Rounded.SkipPrevious,
+                        contentDescription = stringResource(R.string.player_previous),
+                        onClick = onSkipToPrevious,
+                        enabled = track != null,
                     )
-                    Text(
-                        text = track?.let { listOfNotNull(it.artist, it.album).joinToString(" • ") }
-                            ?: stringResource(R.string.player_start_from_browse),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+                    MiniPlayerIconButton(
+                        icon = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                        contentDescription = if (isPlaying) {
+                            stringResource(R.string.player_pause)
+                        } else {
+                            stringResource(R.string.player_play)
+                        },
+                        onClick = onPlayPause,
+                        enabled = track != null,
+                        primary = true,
+                    )
+                    MiniPlayerIconButton(
+                        icon = Icons.Rounded.SkipNext,
+                        contentDescription = stringResource(R.string.player_next),
+                        onClick = onSkipToNext,
+                        enabled = track != null,
                     )
                 }
-                MiniPlayerIconButton(
-                    icon = Icons.Rounded.SkipPrevious,
-                    contentDescription = stringResource(R.string.player_previous),
-                    onClick = onSkipToPrevious,
-                    enabled = track != null,
-                )
-                MiniPlayerIconButton(
-                    icon = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                    contentDescription = if (isPlaying) {
-                        stringResource(R.string.player_pause)
-                    } else {
-                        stringResource(R.string.player_play)
-                    },
-                    onClick = onPlayPause,
-                    enabled = track != null,
-                    primary = true,
-                )
-                MiniPlayerIconButton(
-                    icon = Icons.Rounded.SkipNext,
-                    contentDescription = stringResource(R.string.player_next),
-                    onClick = onSkipToNext,
-                    enabled = track != null,
-                )
             }
         }
     }
@@ -2700,6 +2717,8 @@ private const val NOW_PLAYING_ARTWORK_BACKDROP_BLUR_RADIUS_PX = 60f
 private const val PROGRAMMATIC_ARTWORK_SPRING_BASE_STIFFNESS = 140f
 private const val PROGRAMMATIC_ARTWORK_SPRING_DISTANCE_STIFFNESS = 60f
 private const val PROGRAMMATIC_ARTWORK_MAX_INITIAL_VELOCITY_PAGES = 8f
+private val MINI_PLAYER_LANDSCAPE_MAX_WIDTH = 520.dp
+private val MINI_PLAYER_LANDSCAPE_WIDTH_LIMIT_HEIGHT = 480.dp
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
 
 private object FixedArtworkMotionDurationScale : MotionDurationScale {


### PR DESCRIPTION
## Summary
- Constrain the mini player capsule width on compact-height landscape screens so it behaves like a centered floating surface instead of a full-width bottom bar.
- Compact wide album/playlist detail heroes in compact landscape to keep the hero content visible above the mini player overlay.

## Validation
- `./gradlew assembleDebug -q`
- Installed debug build on `10.111.111.90:34567`
- Captured and reviewed landscape screenshots for songs, albums list/grid, album detail, playlist detail, settings, search, and Now Playing.

Refs #324