### PR TITLE
fix: align Now Playing auto-scroll behavior

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -2186,13 +2186,22 @@ private fun PressScaleIconButton(
 
 
 @Composable
-private fun rememberNowPlayingAutoScrollState(scrollKey: Any?): ScrollState {
+private fun currentMotionDurationScaleFactor(): Float {
+    val compositionScope = rememberCoroutineScope()
+    return compositionScope.coroutineContext[MotionDurationScale.Key]?.scaleFactor ?: 1f
+}
+
+@Composable
+private fun rememberNowPlayingAutoScrollState(
+    scrollKey: Any?,
+    motionDurationScaleFactor: Float,
+): ScrollState {
     val scrollState = rememberScrollState()
     val density = LocalDensity.current
-    LaunchedEffect(scrollKey, scrollState.maxValue, density) {
+    LaunchedEffect(scrollKey, scrollState.maxValue, density, motionDurationScaleFactor) {
         scrollState.scrollTo(0)
         if (scrollState.maxValue <= 0 || scrollState.maxValue == Int.MAX_VALUE) return@LaunchedEffect
-        if (coroutineContext[MotionDurationScale.Key]?.scaleFactor == 0f) return@LaunchedEffect
+        if (!nowPlayingAutoScrollEnabled(motionDurationScaleFactor)) return@LaunchedEffect
 
         delay(NOW_PLAYING_AUTO_SCROLL_EDGE_PAUSE_MS)
         val speedPxPerMs = with(density) {
@@ -2235,7 +2244,23 @@ private fun NowPlayingAutoScrollingText(
     scrollKey: Any?,
     modifier: Modifier = Modifier,
 ) {
-    val scrollState = rememberNowPlayingAutoScrollState(scrollKey)
+    val motionDurationScaleFactor = currentMotionDurationScaleFactor()
+    if (!nowPlayingAutoScrollEnabled(motionDurationScaleFactor)) {
+        Text(
+            text = text,
+            style = style,
+            color = color,
+            modifier = modifier,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        return
+    }
+
+    val scrollState = rememberNowPlayingAutoScrollState(
+        scrollKey = scrollKey,
+        motionDurationScaleFactor = motionDurationScaleFactor,
+    )
     Box(modifier = modifier) {
         Row(
             modifier = Modifier.horizontalScroll(scrollState, enabled = false),
@@ -2285,7 +2310,11 @@ private fun MetadataLinkRow(
             append(track.albumId.orEmpty())
         }
     }
-    val scrollState = rememberNowPlayingAutoScrollState(scrollKey)
+    val motionDurationScaleFactor = currentMotionDurationScaleFactor()
+    val scrollState = rememberNowPlayingAutoScrollState(
+        scrollKey = scrollKey,
+        motionDurationScaleFactor = motionDurationScaleFactor,
+    )
 
     Box(modifier = Modifier.fillMaxWidth()) {
         Row(
@@ -2375,6 +2404,9 @@ private fun MetadataLinkText(
         overflow = TextOverflow.Clip,
     )
 }
+
+internal fun nowPlayingAutoScrollEnabled(motionDurationScaleFactor: Float): Boolean =
+    motionDurationScaleFactor > 0f
 
 internal fun nowPlayingAutoScrollDurationMillis(distancePx: Int, speedPxPerMs: Float): Int {
     if (speedPxPerMs <= 0f) return NOW_PLAYING_AUTO_SCROLL_MIN_DURATION_MS

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -19,9 +19,9 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -1173,32 +1173,35 @@ fun NowPlayingOverlay(
                         modifier = modifier.then(dismissSwipeModifier),
                         verticalArrangement = Arrangement.spacedBy(if (compact) 2.dp else verticalSpacing),
                     ) {
-                        Text(
-                            text = track.title,
-                            style = when {
-                                largeScreen -> MaterialTheme.typography.headlineMedium.copy(
-                                    fontSize = if (denseTitle) 26.sp else 28.sp,
-                                    lineHeight = if (denseTitle) 32.sp else 34.sp,
-                                )
-                                compact -> MaterialTheme.typography.titleLarge.copy(
-                                    fontSize = if (denseTitle) 22.sp else 24.sp,
-                                    lineHeight = 28.sp,
-                                )
-                                else -> titleStyle
-                            },
-                            color = onArtwork,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .then(
-                                    if (largeScreen) {
-                                        Modifier
-                                    } else {
-                                        Modifier.basicMarquee(iterations = Int.MAX_VALUE)
-                                    },
-                                ),
-                            maxLines = if (largeScreen) 2 else 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                        val trackTitleStyle = when {
+                            largeScreen -> MaterialTheme.typography.headlineMedium.copy(
+                                fontSize = if (denseTitle) 26.sp else 28.sp,
+                                lineHeight = if (denseTitle) 32.sp else 34.sp,
+                            )
+                            compact -> MaterialTheme.typography.titleLarge.copy(
+                                fontSize = if (denseTitle) 22.sp else 24.sp,
+                                lineHeight = 28.sp,
+                            )
+                            else -> titleStyle
+                        }
+                        if (largeScreen) {
+                            Text(
+                                text = track.title,
+                                style = trackTitleStyle,
+                                color = onArtwork,
+                                modifier = Modifier.fillMaxWidth(),
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        } else {
+                            NowPlayingAutoScrollingText(
+                                text = track.title,
+                                style = trackTitleStyle,
+                                color = onArtwork,
+                                scrollKey = "${track.mediaId}|${track.title}",
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
                         MetadataLinkRow(
                             track = track,
                             textStyle = when {
@@ -2183,6 +2186,72 @@ private fun PressScaleIconButton(
 
 
 @Composable
+private fun rememberNowPlayingAutoScrollState(scrollKey: Any?): ScrollState {
+    val scrollState = rememberScrollState()
+    val density = LocalDensity.current
+    LaunchedEffect(scrollKey, scrollState.maxValue, density) {
+        scrollState.scrollTo(0)
+        if (scrollState.maxValue <= 0 || scrollState.maxValue == Int.MAX_VALUE) return@LaunchedEffect
+        if (coroutineContext[MotionDurationScale.Key]?.scaleFactor == 0f) return@LaunchedEffect
+
+        delay(NOW_PLAYING_AUTO_SCROLL_EDGE_PAUSE_MS)
+        val speedPxPerMs = with(density) {
+            NOW_PLAYING_AUTO_SCROLL_SPEED_DP_PER_SECOND.dp.toPx()
+        } / 1000f
+        while (scrollState.maxValue > 0 && scrollState.maxValue != Int.MAX_VALUE) {
+            val forwardDistance = (scrollState.maxValue - scrollState.value).coerceAtLeast(0)
+            if (forwardDistance > 0) {
+                scrollState.animateScrollTo(
+                    scrollState.maxValue,
+                    animationSpec = tween(
+                        durationMillis = nowPlayingAutoScrollDurationMillis(forwardDistance, speedPxPerMs),
+                        easing = LinearEasing,
+                    ),
+                )
+            }
+            delay(NOW_PLAYING_AUTO_SCROLL_EDGE_PAUSE_MS)
+
+            val backwardDistance = scrollState.value.coerceAtLeast(0)
+            if (backwardDistance > 0) {
+                scrollState.animateScrollTo(
+                    0,
+                    animationSpec = tween(
+                        durationMillis = nowPlayingAutoScrollDurationMillis(backwardDistance, speedPxPerMs),
+                        easing = LinearEasing,
+                    ),
+                )
+            }
+            delay(NOW_PLAYING_AUTO_SCROLL_EDGE_PAUSE_MS)
+        }
+    }
+    return scrollState
+}
+
+@Composable
+private fun NowPlayingAutoScrollingText(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    scrollKey: Any?,
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberNowPlayingAutoScrollState(scrollKey)
+    Box(modifier = modifier) {
+        Row(
+            modifier = Modifier.horizontalScroll(scrollState, enabled = false),
+        ) {
+            Text(
+                text = text,
+                style = style,
+                color = color,
+                maxLines = 1,
+                overflow = TextOverflow.Clip,
+            )
+        }
+    }
+}
+
+@Composable
 private fun MetadataLinkRow(
     track: PlaybackQueueItem,
     textStyle: TextStyle,
@@ -2201,7 +2270,6 @@ private fun MetadataLinkRow(
             },
         )
     }
-    val scrollState = rememberScrollState()
     val scrollKey = remember(track.mediaId, artistLinks, track.album, track.albumId) {
         buildString {
             append(track.mediaId)
@@ -2217,42 +2285,7 @@ private fun MetadataLinkRow(
             append(track.albumId.orEmpty())
         }
     }
-    val density = LocalDensity.current
-    LaunchedEffect(scrollKey, scrollState.maxValue, density) {
-        scrollState.scrollTo(0)
-        if (scrollState.maxValue <= 0 || scrollState.maxValue == Int.MAX_VALUE) return@LaunchedEffect
-        if (coroutineContext[MotionDurationScale.Key]?.scaleFactor == 0f) return@LaunchedEffect
-
-        delay(METADATA_LINK_SCROLL_EDGE_PAUSE_MS)
-        val speedPxPerMs = with(density) {
-            METADATA_LINK_SCROLL_SPEED_DP_PER_SECOND.dp.toPx()
-        } / 1000f
-        while (scrollState.maxValue > 0 && scrollState.maxValue != Int.MAX_VALUE) {
-            val forwardDistance = (scrollState.maxValue - scrollState.value).coerceAtLeast(0)
-            if (forwardDistance > 0) {
-                scrollState.animateScrollTo(
-                    scrollState.maxValue,
-                    animationSpec = tween(
-                        durationMillis = metadataLinkScrollDurationMillis(forwardDistance, speedPxPerMs),
-                        easing = LinearEasing,
-                    ),
-                )
-            }
-            delay(METADATA_LINK_SCROLL_EDGE_PAUSE_MS)
-
-            val backwardDistance = scrollState.value.coerceAtLeast(0)
-            if (backwardDistance > 0) {
-                scrollState.animateScrollTo(
-                    0,
-                    animationSpec = tween(
-                        durationMillis = metadataLinkScrollDurationMillis(backwardDistance, speedPxPerMs),
-                        easing = LinearEasing,
-                    ),
-                )
-            }
-            delay(METADATA_LINK_SCROLL_EDGE_PAUSE_MS)
-        }
-    }
+    val scrollState = rememberNowPlayingAutoScrollState(scrollKey)
 
     Box(modifier = Modifier.fillMaxWidth()) {
         Row(
@@ -2343,11 +2376,11 @@ private fun MetadataLinkText(
     )
 }
 
-private fun metadataLinkScrollDurationMillis(distancePx: Int, speedPxPerMs: Float): Int {
-    if (speedPxPerMs <= 0f) return METADATA_LINK_SCROLL_MIN_DURATION_MS
+internal fun nowPlayingAutoScrollDurationMillis(distancePx: Int, speedPxPerMs: Float): Int {
+    if (speedPxPerMs <= 0f) return NOW_PLAYING_AUTO_SCROLL_MIN_DURATION_MS
     return (distancePx / speedPxPerMs)
         .roundToInt()
-        .coerceAtLeast(METADATA_LINK_SCROLL_MIN_DURATION_MS)
+        .coerceAtLeast(NOW_PLAYING_AUTO_SCROLL_MIN_DURATION_MS)
 }
 
 private enum class QueueSheetAnchor { Hidden, Partial, Expanded }
@@ -3466,9 +3499,9 @@ private const val ARTWORK_BUTTON_SKIP_INITIAL_VELOCITY_PAGES = 3.5f
 private const val COMPACT_TECH_INFO_SETTLE_MS = 700L
 private const val COMPACT_TECH_INFO_FADE_MS = 700
 private const val KARAOKE_PROGRESS_CORRECTION_THRESHOLD_MS = 1_200L
-private const val METADATA_LINK_SCROLL_EDGE_PAUSE_MS = 1_200L
-private const val METADATA_LINK_SCROLL_MIN_DURATION_MS = 350
-private const val METADATA_LINK_SCROLL_SPEED_DP_PER_SECOND = 32f
+private const val NOW_PLAYING_AUTO_SCROLL_EDGE_PAUSE_MS = 1_200L
+private const val NOW_PLAYING_AUTO_SCROLL_MIN_DURATION_MS = 350
+private const val NOW_PLAYING_AUTO_SCROLL_SPEED_DP_PER_SECOND = 32f
 private const val NOW_PLAYING_ARTWORK_BACKDROP_SCALE = 1.1f
 private const val NOW_PLAYING_ARTWORK_BACKDROP_BLUR_RADIUS_PX = 60f
 private const val PROGRAMMATIC_ARTWORK_SPRING_BASE_STIFFNESS = 140f

--- a/app/src/test/java/org/hdhmc/saki/presentation/library/PlayerChromeInteractionTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/presentation/library/PlayerChromeInteractionTest.kt
@@ -123,6 +123,13 @@ class PlayerChromeInteractionTest {
     }
 
     @Test
+    fun nowPlayingAutoScrollUsesSharedVelocityAndMinimumDuration() {
+        assertEquals(1_000, nowPlayingAutoScrollDurationMillis(distancePx = 32, speedPxPerMs = 0.032f))
+        assertEquals(350, nowPlayingAutoScrollDurationMillis(distancePx = 1, speedPxPerMs = 0.032f))
+        assertEquals(350, nowPlayingAutoScrollDurationMillis(distancePx = 32, speedPxPerMs = 0f))
+    }
+
+    @Test
     fun tooNarrowLandscapeFallsBackToControlPriorityLayout() {
         assertFalse(supportsLargeScreenNowPlayingLayout(450.dp, 400.dp))
         assertFalse(supportsCompactLandscapeNowPlayingLayout(450.dp, 400.dp))

--- a/app/src/test/java/org/hdhmc/saki/presentation/library/PlayerChromeInteractionTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/presentation/library/PlayerChromeInteractionTest.kt
@@ -123,6 +123,13 @@ class PlayerChromeInteractionTest {
     }
 
     @Test
+    fun nowPlayingAutoScrollTracksRuntimeMotionScale() {
+        assertTrue(nowPlayingAutoScrollEnabled(1f))
+        assertTrue(nowPlayingAutoScrollEnabled(0.5f))
+        assertFalse(nowPlayingAutoScrollEnabled(0f))
+    }
+
+    @Test
     fun nowPlayingAutoScrollUsesSharedVelocityAndMinimumDuration() {
         assertEquals(1_000, nowPlayingAutoScrollDurationMillis(distancePx = 32, speedPxPerMs = 0.032f))
         assertEquals(350, nowPlayingAutoScrollDurationMillis(distancePx = 1, speedPxPerMs = 0.032f))


### PR DESCRIPTION
## Summary
- replace the track title's one-way `basicMarquee` with the same edge-paused, bidirectional auto-scroll behavior used by artist and album metadata
- share overflow detection, motion-scale handling, velocity, pauses, and reset behavior between both rows while keeping independent scroll distances
- retain the static two-line title treatment on large screens

## Root cause
The title used Compose's repeating marquee while the adjacent clickable metadata row used a custom ping-pong `horizontalScroll`. Their different direction and loop behavior made long Now Playing metadata look inconsistent. The clickable metadata cannot safely use duplicated marquee content, so both rows now share the non-duplicating scroll controller instead.

## Validation
- `./gradlew testDebugUnitTest assembleDebug -q`
- `./gradlew assembleRelease --console=plain --max-workers=2`
- release APK installed on `10.111.111.90:34567`; Now Playing smoke test completed
- `git diff --check`