### PR TITLE
feat: adapt library details for landscape

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -119,6 +119,12 @@ private val LibraryDetailTwoPaneGap = 20.dp
 private val ArtistDetailAlbumGridMinCellWidth = 128.dp
 private val LibraryDetailHeroOuterVerticalPadding = 26.dp
 
+private data class LibraryDetailArtworkVisuals(
+    val artworkModel: Any?,
+    val accentColor: Color,
+    val trackAccentColor: Color,
+)
+
 internal data class LibraryDetailTwoPaneMetrics(
     val infoPaneWidth: Dp,
     val contentPaneWidth: Dp,
@@ -160,8 +166,7 @@ internal fun shouldUseCompactArtistDetailHeader(availableHeight: Dp): Boolean =
 private fun AdaptiveLibraryDetailLayout(
     modifier: Modifier = Modifier,
     singlePane: @Composable () -> Unit,
-    infoPane: @Composable (Modifier) -> Unit,
-    contentPane: @Composable (Modifier) -> Unit,
+    twoPane: @Composable (infoModifier: Modifier, contentModifier: Modifier) -> Unit,
 ) {
     BoxWithConstraints(modifier = modifier) {
         if (!supportsLibraryDetailTwoPane(maxWidth, maxHeight)) {
@@ -177,12 +182,10 @@ private fun AdaptiveLibraryDetailLayout(
                 .align(Alignment.Center),
             horizontalArrangement = Arrangement.spacedBy(LibraryDetailTwoPaneGap),
         ) {
-            infoPane(
+            twoPane(
                 Modifier
                     .width(metrics.infoPaneWidth)
                     .fillMaxHeight(),
-            )
-            contentPane(
                 Modifier
                     .width(metrics.contentPaneWidth)
                     .fillMaxHeight(),
@@ -237,20 +240,32 @@ fun ArtistDetailScreen(
         visibleAlbums.isNotEmpty() -> visibleAlbums.size
         else -> null
     }
-    val heroArtwork = visibleAlbums.firstOrNull()?.let { resolveArtworkModel(server, it.coverArtId, null) }
-        ?: songs.firstOrNull()?.let { resolveArtworkModel(server, it.coverArtId, cachedSongsBySongId[it.id]) }
-    val accent = animateColorAsState(
-        rememberArtworkAccentColor(
-            heroArtwork,
-            fallback = MaterialTheme.colorScheme.secondaryContainer,
-            harmonizeTarget = MaterialTheme.colorScheme.primary,
-        ),
-        label = "artistAccent",
-    ).value
-    val trackAccent = accent.ensureContrast(
-        MaterialTheme.colorScheme.surfaceContainerHighest,
-        MaterialTheme.colorScheme.primary,
-    )
+
+    @Composable
+    fun rememberDetailVisuals(): LibraryDetailArtworkVisuals {
+        val artworkModel = visibleAlbums.firstOrNull()?.let {
+            resolveArtworkModel(server, it.coverArtId, null)
+        } ?: songs.firstOrNull()?.let {
+            resolveArtworkModel(server, it.coverArtId, cachedSongsBySongId[it.id])
+        }
+        val accentColor = animateColorAsState(
+            rememberArtworkAccentColor(
+                artworkModel,
+                fallback = MaterialTheme.colorScheme.secondaryContainer,
+                harmonizeTarget = MaterialTheme.colorScheme.primary,
+            ),
+            label = "artistAccent",
+        ).value
+        return LibraryDetailArtworkVisuals(
+            artworkModel = artworkModel,
+            accentColor = accentColor,
+            trackAccentColor = accentColor.ensureContrast(
+                MaterialTheme.colorScheme.surfaceContainerHighest,
+                MaterialTheme.colorScheme.primary,
+            ),
+        )
+    }
+
     val artistMetaItems = listOfNotNull(
         albumCount?.let { albumCountText(it) },
         songs.size.takeIf { it > 0 }?.let { songCountText(it) },
@@ -260,6 +275,7 @@ fun ArtistDetailScreen(
         modifier = Modifier.fillMaxSize(),
         singlePane = {
             if (useExpressiveSinglePane) {
+                val visuals = rememberDetailVisuals()
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = bottomContentPadding(bottomOverlayPadding),
@@ -267,8 +283,8 @@ fun ArtistDetailScreen(
                     item {
                         ArtistDetailHeader(
                             title = artist.name,
-                            artwork = heroArtwork,
-                            accentColor = accent,
+                            artwork = visuals.artworkModel,
+                            accentColor = visuals.accentColor,
                             metaItems = artistMetaItems,
                             canPlay = songs.isNotEmpty(),
                             onPlay = { if (songs.isNotEmpty()) onPlaySongs(songs, 0) },
@@ -291,7 +307,7 @@ fun ArtistDetailScreen(
                                         isOfflineDegraded = isOfflineDegraded,
                                         currentPlaybackSongId = currentPlaybackSongId,
                                         isPlaying = isPlaying,
-                                        accentColor = trackAccent,
+                                        accentColor = visuals.trackAccentColor,
                                         albumArtistLabel = artist.name,
                                         collapsedCount = 5,
                                         useSequentialNumbers = true,
@@ -375,7 +391,8 @@ fun ArtistDetailScreen(
                 }
             }
         },
-        infoPane = { infoModifier ->
+        twoPane = { infoModifier, contentModifier ->
+            val visuals = rememberDetailVisuals()
             BoxWithConstraints(modifier = infoModifier) {
                 val useCompactHeader = shouldUseCompactArtistDetailHeader(maxHeight)
                 LazyVerticalGrid(
@@ -389,8 +406,8 @@ fun ArtistDetailScreen(
                     ) {
                         ArtistDetailHeader(
                             title = artist.name,
-                            artwork = heroArtwork,
-                            accentColor = accent,
+                            artwork = visuals.artworkModel,
+                            accentColor = visuals.accentColor,
                             metaItems = artistMetaItems,
                             canPlay = songs.isNotEmpty(),
                             onPlay = { if (songs.isNotEmpty()) onPlaySongs(songs, 0) },
@@ -419,8 +436,6 @@ fun ArtistDetailScreen(
                     }
                 }
             }
-        },
-        contentPane = { contentModifier ->
             LibraryDetailTrackPane(
                 modifier = contentModifier,
                 server = server,
@@ -436,7 +451,7 @@ fun ArtistDetailScreen(
                 isOfflineDegraded = isOfflineDegraded,
                 currentPlaybackSongId = currentPlaybackSongId,
                 isPlaying = isPlaying,
-                accentColor = trackAccent,
+                accentColor = visuals.trackAccentColor,
                 albumArtistLabel = artist.name,
                 useSequentialNumbers = true,
                 showArtwork = true,
@@ -732,21 +747,30 @@ fun AlbumDetailScreen(
         }
     }
 
-    val artworkModel = resolveArtworkModel(server, album.coverArtId, null)
-    val albumAccent = rememberArtworkAccentColor(
-        artworkModel,
-        fallback = MaterialTheme.colorScheme.primary,
-        harmonizeTarget = MaterialTheme.colorScheme.primary,
-    )
-    val trackAccent = albumAccent.ensureContrast(
-        MaterialTheme.colorScheme.surfaceContainerHighest,
-        MaterialTheme.colorScheme.primary,
-    )
+    @Composable
+    fun rememberDetailVisuals(): LibraryDetailArtworkVisuals {
+        val artworkModel = resolveArtworkModel(server, album.coverArtId, null)
+        val accentColor = rememberArtworkAccentColor(
+            artworkModel,
+            fallback = MaterialTheme.colorScheme.primary,
+            harmonizeTarget = MaterialTheme.colorScheme.primary,
+        )
+        return LibraryDetailArtworkVisuals(
+            artworkModel = artworkModel,
+            accentColor = accentColor,
+            trackAccentColor = accentColor.ensureContrast(
+                MaterialTheme.colorScheme.surfaceContainerHighest,
+                MaterialTheme.colorScheme.primary,
+            ),
+        )
+    }
+
     val useExpressiveSinglePane = SakiTheme.visuals.useExpressiveSurfaceContainers
     AdaptiveLibraryDetailLayout(
         modifier = Modifier.fillMaxSize(),
         singlePane = {
             if (useExpressiveSinglePane) {
+                val visuals = rememberDetailVisuals()
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = bottomContentPadding(bottomOverlayPadding),
@@ -754,8 +778,8 @@ fun AlbumDetailScreen(
                     item {
                         AlbumDetailHeroCard(
                             title = album.name,
-                            artwork = artworkModel,
-                            accentColor = albumAccent,
+                            artwork = visuals.artworkModel,
+                            accentColor = visuals.accentColor,
                             metaItems = artistYearSongCount,
                             canPlay = album.songs.isNotEmpty(),
                             onPlay = playAlbum,
@@ -778,7 +802,7 @@ fun AlbumDetailScreen(
                                 isOfflineDegraded = isOfflineDegraded,
                                 currentPlaybackSongId = currentPlaybackSongId,
                                 isPlaying = isPlaying,
-                                accentColor = trackAccent,
+                                accentColor = visuals.trackAccentColor,
                                 albumArtistLabel = album.artistDisplayLabel(),
                                 onPlaySongs = onPlaySongs,
                                 onShowActions = onShowActions,
@@ -824,15 +848,16 @@ fun AlbumDetailScreen(
                 }
             }
         },
-        infoPane = { infoModifier ->
+        twoPane = { infoModifier, contentModifier ->
+            val visuals = rememberDetailVisuals()
             LibraryDetailCenteredInfoPane(
                 modifier = infoModifier,
                 bottomOverlayPadding = bottomOverlayPadding,
             ) {
                 AlbumDetailHeroCard(
                     title = album.name,
-                    artwork = artworkModel,
-                    accentColor = albumAccent,
+                    artwork = visuals.artworkModel,
+                    accentColor = visuals.accentColor,
                     metaItems = artistYearSongCount,
                     canPlay = album.songs.isNotEmpty(),
                     onPlay = playAlbum,
@@ -840,8 +865,6 @@ fun AlbumDetailScreen(
                     playContentDescription = stringResource(R.string.library_play_album),
                 )
             }
-        },
-        contentPane = { contentModifier ->
             LibraryDetailTrackPane(
                 modifier = contentModifier,
                 server = server,
@@ -857,7 +880,7 @@ fun AlbumDetailScreen(
                 isOfflineDegraded = isOfflineDegraded,
                 currentPlaybackSongId = currentPlaybackSongId,
                 isPlaying = isPlaying,
-                accentColor = trackAccent,
+                accentColor = visuals.trackAccentColor,
                 albumArtistLabel = album.artistDisplayLabel(),
                 useSequentialNumbers = false,
                 showArtwork = false,
@@ -1540,16 +1563,24 @@ fun PlaylistDetailScreen(
         }
     }
 
-    val artworkModel = resolveArtworkModel(server, playlist.coverArtId, null)
-    val accent = rememberArtworkAccentColor(
-        artworkModel,
-        fallback = MaterialTheme.colorScheme.primary,
-        harmonizeTarget = MaterialTheme.colorScheme.primary,
-    )
-    val trackAccent = accent.ensureContrast(
-        MaterialTheme.colorScheme.surfaceContainerHighest,
-        MaterialTheme.colorScheme.primary,
-    )
+    @Composable
+    fun rememberDetailVisuals(): LibraryDetailArtworkVisuals {
+        val artworkModel = resolveArtworkModel(server, playlist.coverArtId, null)
+        val accentColor = rememberArtworkAccentColor(
+            artworkModel,
+            fallback = MaterialTheme.colorScheme.primary,
+            harmonizeTarget = MaterialTheme.colorScheme.primary,
+        )
+        return LibraryDetailArtworkVisuals(
+            artworkModel = artworkModel,
+            accentColor = accentColor,
+            trackAccentColor = accentColor.ensureContrast(
+                MaterialTheme.colorScheme.surfaceContainerHighest,
+                MaterialTheme.colorScheme.primary,
+            ),
+        )
+    }
+
     val playlistMetaItems = listOfNotNull(
         playlist.owner,
         songCount?.let { songCountText(it) },
@@ -1559,6 +1590,7 @@ fun PlaylistDetailScreen(
         modifier = Modifier.fillMaxSize(),
         singlePane = {
             if (useExpressiveSinglePane) {
+                val visuals = rememberDetailVisuals()
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = bottomContentPadding(bottomOverlayPadding),
@@ -1566,8 +1598,8 @@ fun PlaylistDetailScreen(
                     item {
                         AlbumDetailHeroCard(
                             title = playlist.name,
-                            artwork = artworkModel,
-                            accentColor = accent,
+                            artwork = visuals.artworkModel,
+                            accentColor = visuals.accentColor,
                             metaItems = playlistMetaItems,
                             canPlay = playlist.songs.isNotEmpty(),
                             onPlay = playPlaylist,
@@ -1600,7 +1632,7 @@ fun PlaylistDetailScreen(
                                 isOfflinePlayable = isOfflinePlayable,
                                 isCurrent = currentPlaybackSongId == song.id,
                                 isPlaying = isPlaying,
-                                accentColor = trackAccent,
+                                accentColor = visuals.trackAccentColor,
                                 artworkModel = resolveArtworkModel(
                                     server,
                                     song.coverArtId,
@@ -1654,15 +1686,16 @@ fun PlaylistDetailScreen(
                 }
             }
         },
-        infoPane = { infoModifier ->
+        twoPane = { infoModifier, contentModifier ->
+            val visuals = rememberDetailVisuals()
             LibraryDetailCenteredInfoPane(
                 modifier = infoModifier,
                 bottomOverlayPadding = bottomOverlayPadding,
             ) {
                 AlbumDetailHeroCard(
                     title = playlist.name,
-                    artwork = artworkModel,
-                    accentColor = accent,
+                    artwork = visuals.artworkModel,
+                    accentColor = visuals.accentColor,
                     metaItems = playlistMetaItems,
                     canPlay = playlist.songs.isNotEmpty(),
                     onPlay = playPlaylist,
@@ -1670,8 +1703,6 @@ fun PlaylistDetailScreen(
                     playContentDescription = stringResource(R.string.library_play_playlist),
                 )
             }
-        },
-        contentPane = { contentModifier ->
             LibraryDetailTrackPane(
                 modifier = contentModifier,
                 server = server,
@@ -1687,7 +1718,7 @@ fun PlaylistDetailScreen(
                 isOfflineDegraded = isOfflineDegraded,
                 currentPlaybackSongId = currentPlaybackSongId,
                 isPlaying = isPlaying,
-                accentColor = trackAccent,
+                accentColor = visuals.trackAccentColor,
                 albumArtistLabel = null,
                 useSequentialNumbers = true,
                 showArtwork = true,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -155,6 +155,7 @@ internal fun calculateLibraryDetailHeroWidth(paneWidth: Dp, usableHeight: Dp): D
 internal fun shouldUseCompactArtistDetailHeader(availableHeight: Dp): Boolean =
     availableHeight < LibraryDetailWideHeroCompactMaxHeight
 
+// Window-size adaptation is structural and intentionally independent of visual theme style.
 @Composable
 private fun AdaptiveLibraryDetailLayout(
     modifier: Modifier = Modifier,
@@ -236,60 +237,6 @@ fun ArtistDetailScreen(
         visibleAlbums.isNotEmpty() -> visibleAlbums.size
         else -> null
     }
-    if (!SakiTheme.visuals.useExpressiveSurfaceContainers) {
-        LibraryDetailScaffold(
-            title = artist.name,
-            subtitle = if (albumCount != null) albumCountText(albumCount) else null,
-            artwork = null,
-            bottomOverlayPadding = bottomOverlayPadding,
-        ) {
-            when {
-                isLoading && songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_artist)) }
-                error != null && songs.isEmpty() -> item { ErrorStateCard(error) }
-                else -> {
-                    if (songs.isNotEmpty()) {
-                        item {
-                            SectionTitle(
-                                stringResource(R.string.library_artist_songs),
-                                stringResource(R.string.library_artist_songs_subtitle, artist.name),
-                            )
-                        }
-                        itemsIndexed(songs, key = { _, s -> s.id }) { index, song ->
-                            val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
-                            SongRow(
-                                song = song,
-                                server = server,
-                                cachedSong = cachedSongsBySongId[song.id],
-                                isStreamCached = song.id in streamCachedSongIds,
-                                isDownloading = song.id in downloadingSongIds,
-                                isOfflineDegraded = isOfflineDegraded,
-                                isOfflinePlayable = isOfflinePlayable,
-                                onClick = { onPlaySongs(songs, index) },
-                                onMore = { onShowActions(song) },
-                            )
-                        }
-                    }
-                    if (visibleAlbums.isNotEmpty()) {
-                        item {
-                            SectionTitle(
-                                stringResource(R.string.library_albums),
-                                stringResource(R.string.library_albums_subtitle_full_release),
-                            )
-                        }
-                        item {
-                            LazyRow {
-                                items(visibleAlbums, key = { it.id }) { album ->
-                                    AlbumMiniCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return
-    }
-
     val heroArtwork = visibleAlbums.firstOrNull()?.let { resolveArtworkModel(server, it.coverArtId, null) }
         ?: songs.firstOrNull()?.let { resolveArtworkModel(server, it.coverArtId, cachedSongsBySongId[it.id]) }
     val accent = animateColorAsState(
@@ -712,7 +659,6 @@ fun AlbumDetailScreen(
         album.year?.toString(),
         if (songCount != null) songCountText(songCount) else null,
     )
-    val subtitle = artistYearSongCount.joinToString(" • ")
     val playAlbum: () -> Unit = {
         if (album.songs.isNotEmpty()) {
             if (isOfflineDegraded) {
@@ -729,45 +675,6 @@ fun AlbumDetailScreen(
                 onPlaySongs(album.songs, 0)
             }
         }
-    }
-
-    if (!SakiTheme.visuals.useExpressiveSurfaceContainers) {
-        LibraryDetailScaffold(
-            title = album.name,
-            subtitle = subtitle,
-            artwork = resolveArtworkModel(server, album.coverArtId, null),
-            bottomOverlayPadding = bottomOverlayPadding,
-        ) {
-            when {
-                isLoading && album.songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_album)) }
-                error != null && album.songs.isEmpty() -> item { ErrorStateCard(error) }
-                else -> {
-                    item {
-                        SectionTitle(
-                            title = stringResource(R.string.library_track_list),
-                            subtitle = album.genre ?: stringResource(R.string.library_album_details),
-                            actionLabel = stringResource(R.string.library_play_album),
-                            onAction = playAlbum,
-                        )
-                    }
-                    itemsIndexed(album.songs, key = { _, s -> s.id }) { index, song ->
-                        val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
-                        SongRow(
-                            song = song,
-                            server = server,
-                            cachedSong = cachedSongsBySongId[song.id],
-                            isStreamCached = song.id in streamCachedSongIds,
-                            isDownloading = song.id in downloadingSongIds,
-                            isOfflineDegraded = isOfflineDegraded,
-                            isOfflinePlayable = isOfflinePlayable,
-                            onClick = { onPlaySongs(album.songs, index) },
-                            onMore = { onShowActions(song) },
-                        )
-                    }
-                }
-            }
-        }
-        return
     }
 
     val artworkModel = resolveArtworkModel(server, album.coverArtId, null)
@@ -1539,49 +1446,6 @@ fun PlaylistDetailScreen(
         }
     }
 
-    if (!SakiTheme.visuals.useExpressiveSurfaceContainers) {
-        val subtitle = listOfNotNull(
-            playlist.owner,
-            if (songCount != null) songCountText(songCount) else null,
-        ).joinToString(" • ")
-        LibraryDetailScaffold(
-            title = playlist.name,
-            subtitle = subtitle,
-            artwork = resolveArtworkModel(server, playlist.coverArtId, null),
-            bottomOverlayPadding = bottomOverlayPadding,
-        ) {
-            when {
-                isLoading && playlist.songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_playlist)) }
-                error != null && playlist.songs.isEmpty() -> item { ErrorStateCard(error) }
-                else -> {
-                    item {
-                        SectionTitle(
-                            title = stringResource(R.string.library_tracks),
-                            subtitle = stringResource(R.string.library_playlist_sequence),
-                            actionLabel = stringResource(R.string.library_play_playlist),
-                            onAction = playPlaylist,
-                        )
-                    }
-                    itemsIndexed(playlist.songs, key = { index, s -> "${s.id}_$index" }) { index, song ->
-                        val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
-                        SongRow(
-                            song = song,
-                            server = server,
-                            cachedSong = cachedSongsBySongId[song.id],
-                            isStreamCached = song.id in streamCachedSongIds,
-                            isDownloading = song.id in downloadingSongIds,
-                            isOfflineDegraded = isOfflineDegraded,
-                            isOfflinePlayable = isOfflinePlayable,
-                            onClick = { onPlaySongs(playlist.songs, index) },
-                            onMore = { onShowActions(song) },
-                        )
-                    }
-                }
-            }
-        }
-        return
-    }
-
     val artworkModel = resolveArtworkModel(server, playlist.coverArtId, null)
     val accent = rememberArtworkAccentColor(
         artworkModel,
@@ -1697,49 +1561,6 @@ fun PlaylistDetailScreen(
             )
         },
     )
-}
-
-@Composable
-private fun LibraryDetailScaffold(
-    title: String,
-    subtitle: String?,
-    artwork: Any?,
-    bottomOverlayPadding: Dp,
-    content: androidx.compose.foundation.lazy.LazyListScope.() -> Unit,
-) {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = bottomContentPadding(bottomOverlayPadding),
-    ) {
-        item {
-            Column(modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp, bottom = 20.dp)) {
-                if (artwork != null) {
-                    ArtworkCard(
-                        model = artwork,
-                        contentDescription = title,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(320.dp),
-                        cornerRadiusDp = 34,
-                    )
-                }
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.displaySmall,
-                    modifier = Modifier.padding(top = if (artwork != null) 14.dp else 0.dp),
-                )
-                if (!subtitle.isNullOrBlank()) {
-                    Text(
-                        text = subtitle,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 6.dp),
-                    )
-                }
-            }
-        }
-        content()
-    }
 }
 
 @Composable

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -30,6 +30,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
@@ -106,6 +110,105 @@ private val LibraryDetailWideHeroMinWidth = 720.dp
 private val LibraryDetailWideHeroArtworkWidth = 320.dp
 private val LibraryDetailWideHeroCompactArtworkWidth = 220.dp
 private val LibraryDetailWideHeroCompactMaxHeight = 520.dp
+private val LibraryDetailTwoPaneMinWidth = 720.dp
+private val LibraryDetailTwoPaneMinHeight = 320.dp
+private val LibraryDetailTwoPaneInfoMinWidth = 264.dp
+private val LibraryDetailTwoPaneInfoMaxWidth = 320.dp
+private val LibraryDetailTwoPaneContentMaxWidth = 640.dp
+private val LibraryDetailTwoPaneGap = 20.dp
+private val ArtistDetailAlbumGridMinCellWidth = 128.dp
+private val LibraryDetailHeroOuterVerticalPadding = 26.dp
+
+internal data class LibraryDetailTwoPaneMetrics(
+    val infoPaneWidth: Dp,
+    val contentPaneWidth: Dp,
+) {
+    val stageWidth: Dp
+        get() = infoPaneWidth + LibraryDetailTwoPaneGap + contentPaneWidth
+}
+
+internal fun supportsLibraryDetailTwoPane(width: Dp, height: Dp): Boolean =
+    width > height &&
+        width >= LibraryDetailTwoPaneMinWidth &&
+        height >= LibraryDetailTwoPaneMinHeight
+
+internal fun calculateLibraryDetailTwoPaneMetrics(width: Dp): LibraryDetailTwoPaneMetrics {
+    val infoPaneWidth = (width * 0.34f).coerceIn(
+        LibraryDetailTwoPaneInfoMinWidth,
+        LibraryDetailTwoPaneInfoMaxWidth,
+    )
+    val contentPaneWidth = minOf(
+        LibraryDetailTwoPaneContentMaxWidth,
+        (width - infoPaneWidth - LibraryDetailTwoPaneGap).coerceAtLeast(0.dp),
+    )
+    return LibraryDetailTwoPaneMetrics(
+        infoPaneWidth = infoPaneWidth,
+        contentPaneWidth = contentPaneWidth,
+    )
+}
+
+internal fun calculateLibraryDetailHeroWidth(paneWidth: Dp, usableHeight: Dp): Dp = minOf(
+    paneWidth,
+    (usableHeight - LibraryDetailHeroOuterVerticalPadding).coerceAtLeast(0.dp),
+)
+
+internal fun shouldUseCompactArtistDetailHeader(availableHeight: Dp): Boolean =
+    availableHeight < LibraryDetailWideHeroCompactMaxHeight
+
+@Composable
+private fun AdaptiveLibraryDetailLayout(
+    modifier: Modifier = Modifier,
+    singlePane: @Composable () -> Unit,
+    infoPane: @Composable (Modifier) -> Unit,
+    contentPane: @Composable (Modifier) -> Unit,
+) {
+    BoxWithConstraints(modifier = modifier) {
+        if (!supportsLibraryDetailTwoPane(maxWidth, maxHeight)) {
+            singlePane()
+            return@BoxWithConstraints
+        }
+
+        val metrics = calculateLibraryDetailTwoPaneMetrics(maxWidth)
+        Row(
+            modifier = Modifier
+                .width(metrics.stageWidth)
+                .fillMaxHeight()
+                .align(Alignment.Center),
+            horizontalArrangement = Arrangement.spacedBy(LibraryDetailTwoPaneGap),
+        ) {
+            infoPane(
+                Modifier
+                    .width(metrics.infoPaneWidth)
+                    .fillMaxHeight(),
+            )
+            contentPane(
+                Modifier
+                    .width(metrics.contentPaneWidth)
+                    .fillMaxHeight(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LibraryDetailCenteredInfoPane(
+    modifier: Modifier,
+    bottomOverlayPadding: Dp,
+    content: @Composable () -> Unit,
+) {
+    BoxWithConstraints(
+        modifier = modifier.padding(bottom = 24.dp + bottomOverlayPadding),
+        contentAlignment = Alignment.Center,
+    ) {
+        val heroWidth = calculateLibraryDetailHeroWidth(
+            paneWidth = maxWidth,
+            usableHeight = maxHeight,
+        )
+        Box(modifier = Modifier.width(heroWidth)) {
+            content()
+        }
+    }
+}
 
 @Composable
 fun ArtistDetailScreen(
@@ -201,65 +304,148 @@ fun ArtistDetailScreen(
         MaterialTheme.colorScheme.surfaceContainerHighest,
         MaterialTheme.colorScheme.primary,
     )
-    LazyColumn(
+    val artistMetaItems = listOfNotNull(
+        albumCount?.let { albumCountText(it) },
+        songs.size.takeIf { it > 0 }?.let { songCountText(it) },
+    )
+    AdaptiveLibraryDetailLayout(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = bottomContentPadding(bottomOverlayPadding),
-    ) {
-        item {
-            ArtistDetailHeader(
-                title = artist.name,
-                artwork = heroArtwork,
-                accentColor = accent,
-                metaItems = listOfNotNull(
-                    albumCount?.let { albumCountText(it) },
-                    songs.size.takeIf { it > 0 }?.let { songCountText(it) },
-                ),
-                canPlay = songs.isNotEmpty(),
-                onPlay = { if (songs.isNotEmpty()) onPlaySongs(songs, 0) },
-                onBack = onBack,
-            )
-        }
-        when {
-            isLoading && songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_artist)) }
-            error != null && songs.isEmpty() -> item { ErrorStateCard(error) }
-            else -> {
-                if (songs.isNotEmpty()) {
-                    item {
-                        AlbumTrackListCard(
-                            songs = songs,
-                            cachedSongsBySongId = cachedSongsBySongId,
-                            streamCachedSongIds = streamCachedSongIds,
-                            downloadingSongIds = downloadingSongIds,
-                            isOfflineDegraded = isOfflineDegraded,
-                            currentPlaybackSongId = currentPlaybackSongId,
-                            isPlaying = isPlaying,
-                            accentColor = trackAccent,
-                            albumArtistLabel = artist.name,
-                            collapsedCount = 5,
-                            useSequentialNumbers = true,
-                            onPlaySongs = onPlaySongs,
-                            onShowActions = onShowActions,
-                        )
-                    }
+        singlePane = {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = bottomContentPadding(bottomOverlayPadding),
+            ) {
+                item {
+                    ArtistDetailHeader(
+                        title = artist.name,
+                        artwork = heroArtwork,
+                        accentColor = accent,
+                        metaItems = artistMetaItems,
+                        canPlay = songs.isNotEmpty(),
+                        onPlay = { if (songs.isNotEmpty()) onPlaySongs(songs, 0) },
+                        onBack = onBack,
+                    )
                 }
-                if (visibleAlbums.isNotEmpty()) {
-                    item {
-                        SectionTitle(
-                            stringResource(R.string.library_albums),
-                            stringResource(R.string.library_albums_subtitle_full_release),
-                        )
+                when {
+                    isLoading && songs.isEmpty() -> item {
+                        LoadingStateCard(stringResource(R.string.library_loading_artist))
                     }
-                    item {
-                        LazyRow {
-                            items(visibleAlbums, key = { it.id }) { album ->
-                                AlbumMiniCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
+                    error != null && songs.isEmpty() -> item { ErrorStateCard(error) }
+                    else -> {
+                        if (songs.isNotEmpty()) {
+                            item {
+                                AlbumTrackListCard(
+                                    songs = songs,
+                                    cachedSongsBySongId = cachedSongsBySongId,
+                                    streamCachedSongIds = streamCachedSongIds,
+                                    downloadingSongIds = downloadingSongIds,
+                                    isOfflineDegraded = isOfflineDegraded,
+                                    currentPlaybackSongId = currentPlaybackSongId,
+                                    isPlaying = isPlaying,
+                                    accentColor = trackAccent,
+                                    albumArtistLabel = artist.name,
+                                    collapsedCount = 5,
+                                    useSequentialNumbers = true,
+                                    onPlaySongs = onPlaySongs,
+                                    onShowActions = onShowActions,
+                                )
+                            }
+                        }
+                        if (visibleAlbums.isNotEmpty()) {
+                            item {
+                                SectionTitle(
+                                    stringResource(R.string.library_albums),
+                                    stringResource(R.string.library_albums_subtitle_full_release),
+                                )
+                            }
+                            item {
+                                LazyRow {
+                                    items(visibleAlbums, key = { it.id }) { album ->
+                                        AlbumMiniCard(
+                                            album = album,
+                                            server = server,
+                                            onOpenAlbum = onOpenAlbum,
+                                        )
+                                    }
+                                }
                             }
                         }
                     }
                 }
             }
-        }
-    }
+        },
+        infoPane = { infoModifier ->
+            BoxWithConstraints(modifier = infoModifier) {
+                val useCompactHeader = shouldUseCompactArtistDetailHeader(maxHeight)
+                LazyVerticalGrid(
+                    modifier = Modifier.fillMaxSize(),
+                    columns = GridCells.Adaptive(ArtistDetailAlbumGridMinCellWidth),
+                    contentPadding = bottomContentPadding(bottomOverlayPadding),
+                ) {
+                    item(
+                        key = "artist-detail-header",
+                        span = { GridItemSpan(maxLineSpan) },
+                    ) {
+                        ArtistDetailHeader(
+                            title = artist.name,
+                            artwork = heroArtwork,
+                            accentColor = accent,
+                            metaItems = artistMetaItems,
+                            canPlay = songs.isNotEmpty(),
+                            onPlay = { if (songs.isNotEmpty()) onPlaySongs(songs, 0) },
+                            onBack = onBack,
+                            useContainer = true,
+                            compact = useCompactHeader,
+                        )
+                    }
+                    if (visibleAlbums.isNotEmpty()) {
+                        item(
+                            key = "artist-detail-albums-heading",
+                            span = { GridItemSpan(maxLineSpan) },
+                        ) {
+                            SectionTitle(
+                                stringResource(R.string.library_albums),
+                                stringResource(R.string.library_albums_subtitle_full_release),
+                            )
+                        }
+                        items(visibleAlbums, key = { it.id }) { album ->
+                            AlbumCard(
+                                album = album,
+                                server = server,
+                                onOpenAlbum = onOpenAlbum,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        contentPane = { contentModifier ->
+            LibraryDetailTrackPane(
+                modifier = contentModifier,
+                server = server,
+                songs = songs,
+                title = stringResource(R.string.library_artist_songs),
+                subtitle = stringResource(R.string.library_artist_songs_subtitle, artist.name),
+                loadingLabel = stringResource(R.string.library_loading_artist),
+                isLoading = isLoading,
+                error = error,
+                cachedSongsBySongId = cachedSongsBySongId,
+                streamCachedSongIds = streamCachedSongIds,
+                downloadingSongIds = downloadingSongIds,
+                isOfflineDegraded = isOfflineDegraded,
+                currentPlaybackSongId = currentPlaybackSongId,
+                isPlaying = isPlaying,
+                accentColor = trackAccent,
+                albumArtistLabel = artist.name,
+                useSequentialNumbers = true,
+                showArtwork = true,
+                showAlbumLabel = true,
+                bottomOverlayPadding = bottomOverlayPadding,
+                onPlaySongs = onPlaySongs,
+                onShowActions = onShowActions,
+            )
+        },
+    )
 }
 
 @Composable
@@ -271,16 +457,153 @@ private fun ArtistDetailHeader(
     canPlay: Boolean,
     onPlay: () -> Unit,
     onBack: () -> Unit,
+    useContainer: Boolean = false,
+    compact: Boolean = false,
+) {
+    if (useContainer) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp, bottom = 12.dp),
+            shape = MaterialTheme.shapes.extraLarge,
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        ) {
+            ArtistDetailHeaderContent(
+                title = title,
+                artwork = artwork,
+                accentColor = accentColor,
+                metaItems = metaItems,
+                canPlay = canPlay,
+                onPlay = onPlay,
+                onBack = onBack,
+                compact = compact,
+                modifier = Modifier.padding(if (compact) 12.dp else 16.dp),
+            )
+        }
+    } else {
+        ArtistDetailHeaderContent(
+            title = title,
+            artwork = artwork,
+            accentColor = accentColor,
+            metaItems = metaItems,
+            canPlay = canPlay,
+            onPlay = onPlay,
+            onBack = onBack,
+            compact = false,
+            modifier = Modifier.padding(top = 8.dp, bottom = 16.dp),
+        )
+    }
+}
+
+@Composable
+private fun ArtistDetailHeaderContent(
+    title: String,
+    artwork: Any?,
+    accentColor: Color,
+    metaItems: List<String>,
+    canPlay: Boolean,
+    onPlay: () -> Unit,
+    onBack: () -> Unit,
+    compact: Boolean,
+    modifier: Modifier = Modifier,
 ) {
     val onAccent = if (accentColor.contrastRatio(Color.White) >= accentColor.contrastRatio(Color.Black)) {
         Color.White
     } else {
         Color.Black
     }
+    val metaLine = metaItems.joinToString(" • ")
+    if (compact) {
+        Row(
+            modifier = modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(88.dp)
+                    .clip(MaterialTheme.shapes.extraLarge)
+                    .background(accentColor),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (artwork != null) {
+                    ArtworkCard(
+                        model = artwork,
+                        contentDescription = title,
+                        modifier = Modifier.fillMaxSize(),
+                        cornerRadiusDp = 24,
+                        requestSizePx = THUMBNAIL_COVER_ART_SIZE_PX,
+                    )
+                } else {
+                    Text(
+                        text = title.trim().firstOrNull()?.uppercase() ?: "?",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = onAccent,
+                    )
+                }
+                Surface(
+                    onClick = onBack,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(6.dp)
+                        .minimumInteractiveComponentSize()
+                        .size(40.dp),
+                    shape = CircleShape,
+                    color = Color.Black.copy(alpha = 0.32f),
+                    contentColor = Color.White,
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                        contentDescription = stringResource(R.string.library_back),
+                        modifier = Modifier.padding(9.dp),
+                    )
+                }
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = metaLine,
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    FilledIconButton(
+                        onClick = onPlay,
+                        enabled = canPlay,
+                        modifier = Modifier.size(40.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.PlayArrow,
+                            contentDescription = stringResource(R.string.library_play),
+                        )
+                    }
+                }
+            }
+        }
+        return
+    }
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 8.dp, bottom = 16.dp),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Surface(
             onClick = onBack,
@@ -336,7 +659,6 @@ private fun ArtistDetailHeader(
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
-                val metaLine = metaItems.joinToString(" • ")
                 if (metaLine.isNotBlank()) {
                     Text(
                         text = metaLine,
@@ -458,27 +780,32 @@ fun AlbumDetailScreen(
         MaterialTheme.colorScheme.surfaceContainerHighest,
         MaterialTheme.colorScheme.primary,
     )
-    LazyColumn(
+    AdaptiveLibraryDetailLayout(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = bottomContentPadding(bottomOverlayPadding),
-    ) {
-        item {
-            AlbumDetailHeroCard(
-                title = album.name,
-                artwork = artworkModel,
-                accentColor = albumAccent,
-                metaItems = artistYearSongCount,
-                canPlay = album.songs.isNotEmpty(),
-                onPlay = playAlbum,
-                onBack = onBack,
-            )
-        }
-
-        when {
-            isLoading && album.songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_album)) }
-            error != null && album.songs.isEmpty() -> item { ErrorStateCard(error) }
-            else -> {
+        singlePane = {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = bottomContentPadding(bottomOverlayPadding),
+            ) {
                 item {
+                    AlbumDetailHeroCard(
+                        title = album.name,
+                        artwork = artworkModel,
+                        accentColor = albumAccent,
+                        metaItems = artistYearSongCount,
+                        canPlay = album.songs.isNotEmpty(),
+                        onPlay = playAlbum,
+                        onBack = onBack,
+                        playContentDescription = stringResource(R.string.library_play_album),
+                    )
+                }
+
+                when {
+                    isLoading && album.songs.isEmpty() -> item {
+                        LoadingStateCard(stringResource(R.string.library_loading_album))
+                    }
+                    error != null && album.songs.isEmpty() -> item { ErrorStateCard(error) }
+                    else -> item {
                         AlbumTrackListCard(
                             songs = album.songs,
                             cachedSongsBySongId = cachedSongsBySongId,
@@ -492,10 +819,53 @@ fun AlbumDetailScreen(
                             onPlaySongs = onPlaySongs,
                             onShowActions = onShowActions,
                         )
+                    }
                 }
             }
-        }
-    }
+        },
+        infoPane = { infoModifier ->
+            LibraryDetailCenteredInfoPane(
+                modifier = infoModifier,
+                bottomOverlayPadding = bottomOverlayPadding,
+            ) {
+                AlbumDetailHeroCard(
+                    title = album.name,
+                    artwork = artworkModel,
+                    accentColor = albumAccent,
+                    metaItems = artistYearSongCount,
+                    canPlay = album.songs.isNotEmpty(),
+                    onPlay = playAlbum,
+                    onBack = onBack,
+                    playContentDescription = stringResource(R.string.library_play_album),
+                )
+            }
+        },
+        contentPane = { contentModifier ->
+            LibraryDetailTrackPane(
+                modifier = contentModifier,
+                server = server,
+                songs = album.songs,
+                title = stringResource(R.string.library_track_list),
+                subtitle = album.genre ?: stringResource(R.string.library_album_details),
+                loadingLabel = stringResource(R.string.library_loading_album),
+                isLoading = isLoading,
+                error = error,
+                cachedSongsBySongId = cachedSongsBySongId,
+                streamCachedSongIds = streamCachedSongIds,
+                downloadingSongIds = downloadingSongIds,
+                isOfflineDegraded = isOfflineDegraded,
+                currentPlaybackSongId = currentPlaybackSongId,
+                isPlaying = isPlaying,
+                accentColor = trackAccent,
+                albumArtistLabel = album.artistDisplayLabel(),
+                useSequentialNumbers = false,
+                showArtwork = false,
+                bottomOverlayPadding = bottomOverlayPadding,
+                onPlaySongs = onPlaySongs,
+                onShowActions = onShowActions,
+            )
+        },
+    )
 }
 
 @Composable
@@ -507,6 +877,7 @@ private fun AlbumDetailHeroCard(
     onPlay: () -> Unit,
     onBack: () -> Unit,
     accentColor: Color,
+    playContentDescription: String,
 ) {
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         val useCompactLandscapeHero = maxWidth > maxHeight &&
@@ -537,6 +908,7 @@ private fun AlbumDetailHeroCard(
                 onPlay = onPlay,
                 onBack = onBack,
                 accentColor = accentColor,
+                playContentDescription = playContentDescription,
             )
         }
     }
@@ -663,6 +1035,7 @@ private fun CompactAlbumDetailHeroCard(
     onPlay: () -> Unit,
     onBack: () -> Unit,
     accentColor: Color,
+    playContentDescription: String,
 ) {
     val playContainer = accentColor.ensureContrast(Color.Black, MaterialTheme.colorScheme.primary)
     val onPlayAccent = if (playContainer.contrastRatio(Color.White) >= playContainer.contrastRatio(Color.Black)) {
@@ -736,7 +1109,7 @@ private fun CompactAlbumDetailHeroCard(
             ) {
                 Icon(
                     imageVector = Icons.Rounded.PlayArrow,
-                    contentDescription = stringResource(R.string.library_play_album),
+                    contentDescription = playContentDescription,
                 )
             }
         }
@@ -756,6 +1129,104 @@ private fun CompactAlbumDetailHeroCard(
                 contentDescription = stringResource(R.string.library_back),
                 modifier = Modifier.padding(9.dp),
             )
+        }
+    }
+}
+
+@Composable
+private fun LibraryDetailTrackPane(
+    modifier: Modifier,
+    server: ServerConfig,
+    songs: List<Song>,
+    title: String,
+    subtitle: String,
+    loadingLabel: String,
+    isLoading: Boolean,
+    error: String?,
+    cachedSongsBySongId: Map<String, CachedSong>,
+    streamCachedSongIds: Set<String>,
+    downloadingSongIds: Set<String>,
+    isOfflineDegraded: Boolean,
+    currentPlaybackSongId: String?,
+    isPlaying: Boolean,
+    accentColor: Color,
+    albumArtistLabel: String?,
+    useSequentialNumbers: Boolean,
+    showArtwork: Boolean,
+    showAlbumLabel: Boolean = false,
+    allowDuplicateSongs: Boolean = false,
+    bottomOverlayPadding: Dp,
+    onPlaySongs: (List<Song>, Int) -> Unit,
+    onShowActions: (Song) -> Unit,
+) {
+    val useTrackNumbers = !useSequentialNumbers && songs.all { (it.track ?: 0) > 0 }
+    Card(
+        modifier = modifier.padding(top = 8.dp, bottom = 12.dp),
+        shape = MaterialTheme.shapes.extraLarge,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                start = 16.dp,
+                top = 8.dp,
+                end = 16.dp,
+                bottom = 24.dp + bottomOverlayPadding,
+            ),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            item(key = "detail-track-heading") {
+                SectionTitle(title = title, subtitle = subtitle)
+            }
+            when {
+                isLoading && songs.isEmpty() -> item(key = "detail-track-loading") {
+                    LoadingStateCard(loadingLabel)
+                }
+                error != null && songs.isEmpty() -> item(key = "detail-track-error") {
+                    ErrorStateCard(error)
+                }
+                songs.isEmpty() -> item(key = "detail-track-empty") {
+                    EmptyStateCard(
+                        title = stringResource(R.string.browse_no_songs),
+                        body = stringResource(R.string.browse_no_songs_body),
+                    )
+                }
+                else -> itemsIndexed(
+                    items = songs,
+                    key = { index, song ->
+                        if (allowDuplicateSongs) "${song.id}_$index" else song.id
+                    },
+                ) { index, song ->
+                    val isOfflinePlayable = song.isOfflinePlayable(
+                        cachedSongsBySongId,
+                        streamCachedSongIds,
+                    )
+                    AlbumTrackRow(
+                        song = song,
+                        index = index,
+                        useTrackNumbers = useTrackNumbers,
+                        albumArtistLabel = albumArtistLabel,
+                        cachedSong = cachedSongsBySongId[song.id],
+                        isStreamCached = song.id in streamCachedSongIds,
+                        isDownloading = song.id in downloadingSongIds,
+                        isOfflineDegraded = isOfflineDegraded,
+                        isOfflinePlayable = isOfflinePlayable,
+                        isCurrent = currentPlaybackSongId == song.id,
+                        isPlaying = isPlaying,
+                        accentColor = accentColor,
+                        artworkModel = if (showArtwork) {
+                            resolveArtworkModel(server, song.coverArtId, cachedSongsBySongId[song.id])
+                        } else {
+                            null
+                        },
+                        secondaryLabel = if (showAlbumLabel) song.album?.takeIf { it.isNotBlank() } else null,
+                        onClick = { onPlaySongs(songs, index) },
+                        onMore = { onShowActions(song) },
+                    )
+                }
+            }
         }
     }
 }
@@ -845,6 +1316,7 @@ internal fun AlbumTrackRow(
     isPlaying: Boolean,
     accentColor: Color,
     artworkModel: Any? = null,
+    secondaryLabel: String? = null,
     onClick: () -> Unit,
     onMore: () -> Unit,
 ) {
@@ -914,10 +1386,10 @@ internal fun AlbumTrackRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            val artistLine = song.artistLabel()?.takeIf { it != albumArtistLabel }
-            if (artistLine != null) {
+            val supportingLine = secondaryLabel ?: song.artistLabel()?.takeIf { it != albumArtistLabel }
+            if (supportingLine != null) {
                 Text(
-                    text = artistLine,
+                    text = supportingLine,
                     modifier = Modifier.padding(top = 2.dp),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1120,51 +1592,111 @@ fun PlaylistDetailScreen(
         MaterialTheme.colorScheme.surfaceContainerHighest,
         MaterialTheme.colorScheme.primary,
     )
-    LazyColumn(
+    val playlistMetaItems = listOfNotNull(
+        playlist.owner,
+        songCount?.let { songCountText(it) },
+    )
+    AdaptiveLibraryDetailLayout(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = bottomContentPadding(bottomOverlayPadding),
-    ) {
-        item {
-            AlbumDetailHeroCard(
-                title = playlist.name,
-                artwork = artworkModel,
-                accentColor = accent,
-                metaItems = listOfNotNull(
-                    playlist.owner,
-                    songCount?.let { songCountText(it) },
-                ),
-                canPlay = playlist.songs.isNotEmpty(),
-                onPlay = playPlaylist,
-                onBack = onBack,
-            )
-        }
-        when {
-            isLoading && playlist.songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_playlist)) }
-            error != null && playlist.songs.isEmpty() -> item { ErrorStateCard(error) }
-            else -> {
-                itemsIndexed(playlist.songs, key = { index, s -> "${s.id}_$index" }) { index, song ->
-                    val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
-                    AlbumTrackRow(
-                        song = song,
-                        index = index,
-                        useTrackNumbers = false,
-                        albumArtistLabel = null,
-                        cachedSong = cachedSongsBySongId[song.id],
-                        isStreamCached = song.id in streamCachedSongIds,
-                        isDownloading = song.id in downloadingSongIds,
-                        isOfflineDegraded = isOfflineDegraded,
-                        isOfflinePlayable = isOfflinePlayable,
-                        isCurrent = currentPlaybackSongId == song.id,
-                        isPlaying = isPlaying,
-                        accentColor = trackAccent,
-                        artworkModel = resolveArtworkModel(server, song.coverArtId, cachedSongsBySongId[song.id]),
-                        onClick = { onPlaySongs(playlist.songs, index) },
-                        onMore = { onShowActions(song) },
+        singlePane = {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = bottomContentPadding(bottomOverlayPadding),
+            ) {
+                item {
+                    AlbumDetailHeroCard(
+                        title = playlist.name,
+                        artwork = artworkModel,
+                        accentColor = accent,
+                        metaItems = playlistMetaItems,
+                        canPlay = playlist.songs.isNotEmpty(),
+                        onPlay = playPlaylist,
+                        onBack = onBack,
+                        playContentDescription = stringResource(R.string.library_play_playlist),
                     )
                 }
+                when {
+                    isLoading && playlist.songs.isEmpty() -> item {
+                        LoadingStateCard(stringResource(R.string.library_loading_playlist))
+                    }
+                    error != null && playlist.songs.isEmpty() -> item { ErrorStateCard(error) }
+                    else -> itemsIndexed(
+                        playlist.songs,
+                        key = { index, song -> "${song.id}_$index" },
+                    ) { index, song ->
+                        val isOfflinePlayable = song.isOfflinePlayable(
+                            cachedSongsBySongId,
+                            streamCachedSongIds,
+                        )
+                        AlbumTrackRow(
+                            song = song,
+                            index = index,
+                            useTrackNumbers = false,
+                            albumArtistLabel = null,
+                            cachedSong = cachedSongsBySongId[song.id],
+                            isStreamCached = song.id in streamCachedSongIds,
+                            isDownloading = song.id in downloadingSongIds,
+                            isOfflineDegraded = isOfflineDegraded,
+                            isOfflinePlayable = isOfflinePlayable,
+                            isCurrent = currentPlaybackSongId == song.id,
+                            isPlaying = isPlaying,
+                            accentColor = trackAccent,
+                            artworkModel = resolveArtworkModel(
+                                server,
+                                song.coverArtId,
+                                cachedSongsBySongId[song.id],
+                            ),
+                            onClick = { onPlaySongs(playlist.songs, index) },
+                            onMore = { onShowActions(song) },
+                        )
+                    }
+                }
             }
-        }
-    }
+        },
+        infoPane = { infoModifier ->
+            LibraryDetailCenteredInfoPane(
+                modifier = infoModifier,
+                bottomOverlayPadding = bottomOverlayPadding,
+            ) {
+                AlbumDetailHeroCard(
+                    title = playlist.name,
+                    artwork = artworkModel,
+                    accentColor = accent,
+                    metaItems = playlistMetaItems,
+                    canPlay = playlist.songs.isNotEmpty(),
+                    onPlay = playPlaylist,
+                    onBack = onBack,
+                    playContentDescription = stringResource(R.string.library_play_playlist),
+                )
+            }
+        },
+        contentPane = { contentModifier ->
+            LibraryDetailTrackPane(
+                modifier = contentModifier,
+                server = server,
+                songs = playlist.songs,
+                title = stringResource(R.string.library_tracks),
+                subtitle = stringResource(R.string.library_playlist_sequence),
+                loadingLabel = stringResource(R.string.library_loading_playlist),
+                isLoading = isLoading,
+                error = error,
+                cachedSongsBySongId = cachedSongsBySongId,
+                streamCachedSongIds = streamCachedSongIds,
+                downloadingSongIds = downloadingSongIds,
+                isOfflineDegraded = isOfflineDegraded,
+                currentPlaybackSongId = currentPlaybackSongId,
+                isPlaying = isPlaying,
+                accentColor = trackAccent,
+                albumArtistLabel = null,
+                useSequentialNumbers = true,
+                showArtwork = true,
+                allowDuplicateSongs = true,
+                bottomOverlayPadding = bottomOverlayPadding,
+                onPlaySongs = onPlaySongs,
+                onShowActions = onShowActions,
+            )
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseComponents.kt
@@ -255,64 +255,118 @@ fun ArtistDetailScreen(
         albumCount?.let { albumCountText(it) },
         songs.size.takeIf { it > 0 }?.let { songCountText(it) },
     )
+    val useExpressiveSinglePane = SakiTheme.visuals.useExpressiveSurfaceContainers
     AdaptiveLibraryDetailLayout(
         modifier = Modifier.fillMaxSize(),
         singlePane = {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = bottomContentPadding(bottomOverlayPadding),
-            ) {
-                item {
-                    ArtistDetailHeader(
-                        title = artist.name,
-                        artwork = heroArtwork,
-                        accentColor = accent,
-                        metaItems = artistMetaItems,
-                        canPlay = songs.isNotEmpty(),
-                        onPlay = { if (songs.isNotEmpty()) onPlaySongs(songs, 0) },
-                        onBack = onBack,
-                    )
-                }
-                when {
-                    isLoading && songs.isEmpty() -> item {
-                        LoadingStateCard(stringResource(R.string.library_loading_artist))
+            if (useExpressiveSinglePane) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = bottomContentPadding(bottomOverlayPadding),
+                ) {
+                    item {
+                        ArtistDetailHeader(
+                            title = artist.name,
+                            artwork = heroArtwork,
+                            accentColor = accent,
+                            metaItems = artistMetaItems,
+                            canPlay = songs.isNotEmpty(),
+                            onPlay = { if (songs.isNotEmpty()) onPlaySongs(songs, 0) },
+                            onBack = onBack,
+                        )
                     }
-                    error != null && songs.isEmpty() -> item { ErrorStateCard(error) }
-                    else -> {
-                        if (songs.isNotEmpty()) {
-                            item {
-                                AlbumTrackListCard(
-                                    songs = songs,
-                                    cachedSongsBySongId = cachedSongsBySongId,
-                                    streamCachedSongIds = streamCachedSongIds,
-                                    downloadingSongIds = downloadingSongIds,
-                                    isOfflineDegraded = isOfflineDegraded,
-                                    currentPlaybackSongId = currentPlaybackSongId,
-                                    isPlaying = isPlaying,
-                                    accentColor = trackAccent,
-                                    albumArtistLabel = artist.name,
-                                    collapsedCount = 5,
-                                    useSequentialNumbers = true,
-                                    onPlaySongs = onPlaySongs,
-                                    onShowActions = onShowActions,
-                                )
+                    when {
+                        isLoading && songs.isEmpty() -> item {
+                            LoadingStateCard(stringResource(R.string.library_loading_artist))
+                        }
+                        error != null && songs.isEmpty() -> item { ErrorStateCard(error) }
+                        else -> {
+                            if (songs.isNotEmpty()) {
+                                item {
+                                    AlbumTrackListCard(
+                                        songs = songs,
+                                        cachedSongsBySongId = cachedSongsBySongId,
+                                        streamCachedSongIds = streamCachedSongIds,
+                                        downloadingSongIds = downloadingSongIds,
+                                        isOfflineDegraded = isOfflineDegraded,
+                                        currentPlaybackSongId = currentPlaybackSongId,
+                                        isPlaying = isPlaying,
+                                        accentColor = trackAccent,
+                                        albumArtistLabel = artist.name,
+                                        collapsedCount = 5,
+                                        useSequentialNumbers = true,
+                                        onPlaySongs = onPlaySongs,
+                                        onShowActions = onShowActions,
+                                    )
+                                }
+                            }
+                            if (visibleAlbums.isNotEmpty()) {
+                                item {
+                                    SectionTitle(
+                                        stringResource(R.string.library_albums),
+                                        stringResource(R.string.library_albums_subtitle_full_release),
+                                    )
+                                }
+                                item {
+                                    LazyRow {
+                                        items(visibleAlbums, key = { it.id }) { album ->
+                                            AlbumMiniCard(
+                                                album = album,
+                                                server = server,
+                                                onOpenAlbum = onOpenAlbum,
+                                            )
+                                        }
+                                    }
+                                }
                             }
                         }
-                        if (visibleAlbums.isNotEmpty()) {
-                            item {
-                                SectionTitle(
-                                    stringResource(R.string.library_albums),
-                                    stringResource(R.string.library_albums_subtitle_full_release),
-                                )
+                    }
+                }
+            } else {
+                LibraryDetailScaffold(
+                    title = artist.name,
+                    subtitle = if (albumCount != null) albumCountText(albumCount) else null,
+                    artwork = null,
+                    bottomOverlayPadding = bottomOverlayPadding,
+                ) {
+                    when {
+                        isLoading && songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_artist)) }
+                        error != null && songs.isEmpty() -> item { ErrorStateCard(error) }
+                        else -> {
+                            if (songs.isNotEmpty()) {
+                                item {
+                                    SectionTitle(
+                                        stringResource(R.string.library_artist_songs),
+                                        stringResource(R.string.library_artist_songs_subtitle, artist.name),
+                                    )
+                                }
+                                itemsIndexed(songs, key = { _, s -> s.id }) { index, song ->
+                                    val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
+                                    SongRow(
+                                        song = song,
+                                        server = server,
+                                        cachedSong = cachedSongsBySongId[song.id],
+                                        isStreamCached = song.id in streamCachedSongIds,
+                                        isDownloading = song.id in downloadingSongIds,
+                                        isOfflineDegraded = isOfflineDegraded,
+                                        isOfflinePlayable = isOfflinePlayable,
+                                        onClick = { onPlaySongs(songs, index) },
+                                        onMore = { onShowActions(song) },
+                                    )
+                                }
                             }
-                            item {
-                                LazyRow {
-                                    items(visibleAlbums, key = { it.id }) { album ->
-                                        AlbumMiniCard(
-                                            album = album,
-                                            server = server,
-                                            onOpenAlbum = onOpenAlbum,
-                                        )
+                            if (visibleAlbums.isNotEmpty()) {
+                                item {
+                                    SectionTitle(
+                                        stringResource(R.string.library_albums),
+                                        stringResource(R.string.library_albums_subtitle_full_release),
+                                    )
+                                }
+                                item {
+                                    LazyRow {
+                                        items(visibleAlbums, key = { it.id }) { album ->
+                                            AlbumMiniCard(album = album, server = server, onOpenAlbum = onOpenAlbum)
+                                        }
                                     }
                                 }
                             }
@@ -659,6 +713,7 @@ fun AlbumDetailScreen(
         album.year?.toString(),
         if (songCount != null) songCountText(songCount) else null,
     )
+    val subtitle = artistYearSongCount.joinToString(" • ")
     val playAlbum: () -> Unit = {
         if (album.songs.isNotEmpty()) {
             if (isOfflineDegraded) {
@@ -687,45 +742,84 @@ fun AlbumDetailScreen(
         MaterialTheme.colorScheme.surfaceContainerHighest,
         MaterialTheme.colorScheme.primary,
     )
+    val useExpressiveSinglePane = SakiTheme.visuals.useExpressiveSurfaceContainers
     AdaptiveLibraryDetailLayout(
         modifier = Modifier.fillMaxSize(),
         singlePane = {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = bottomContentPadding(bottomOverlayPadding),
-            ) {
-                item {
-                    AlbumDetailHeroCard(
-                        title = album.name,
-                        artwork = artworkModel,
-                        accentColor = albumAccent,
-                        metaItems = artistYearSongCount,
-                        canPlay = album.songs.isNotEmpty(),
-                        onPlay = playAlbum,
-                        onBack = onBack,
-                        playContentDescription = stringResource(R.string.library_play_album),
-                    )
-                }
-
-                when {
-                    isLoading && album.songs.isEmpty() -> item {
-                        LoadingStateCard(stringResource(R.string.library_loading_album))
-                    }
-                    error != null && album.songs.isEmpty() -> item { ErrorStateCard(error) }
-                    else -> item {
-                        AlbumTrackListCard(
-                            songs = album.songs,
-                            cachedSongsBySongId = cachedSongsBySongId,
-                            streamCachedSongIds = streamCachedSongIds,
-                            downloadingSongIds = downloadingSongIds,
-                            isOfflineDegraded = isOfflineDegraded,
-                            currentPlaybackSongId = currentPlaybackSongId,
-                            isPlaying = isPlaying,
-                            accentColor = trackAccent,
-                            albumArtistLabel = album.artistDisplayLabel(),
-                            onPlaySongs = onPlaySongs,
-                            onShowActions = onShowActions,
+            if (useExpressiveSinglePane) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = bottomContentPadding(bottomOverlayPadding),
+                ) {
+                    item {
+                        AlbumDetailHeroCard(
+                            title = album.name,
+                            artwork = artworkModel,
+                            accentColor = albumAccent,
+                            metaItems = artistYearSongCount,
+                            canPlay = album.songs.isNotEmpty(),
+                            onPlay = playAlbum,
+                            onBack = onBack,
+                            playContentDescription = stringResource(R.string.library_play_album),
                         )
+                    }
+
+                    when {
+                        isLoading && album.songs.isEmpty() -> item {
+                            LoadingStateCard(stringResource(R.string.library_loading_album))
+                        }
+                        error != null && album.songs.isEmpty() -> item { ErrorStateCard(error) }
+                        else -> item {
+                            AlbumTrackListCard(
+                                songs = album.songs,
+                                cachedSongsBySongId = cachedSongsBySongId,
+                                streamCachedSongIds = streamCachedSongIds,
+                                downloadingSongIds = downloadingSongIds,
+                                isOfflineDegraded = isOfflineDegraded,
+                                currentPlaybackSongId = currentPlaybackSongId,
+                                isPlaying = isPlaying,
+                                accentColor = trackAccent,
+                                albumArtistLabel = album.artistDisplayLabel(),
+                                onPlaySongs = onPlaySongs,
+                                onShowActions = onShowActions,
+                            )
+                        }
+                    }
+                }
+            } else {
+                LibraryDetailScaffold(
+                    title = album.name,
+                    subtitle = subtitle,
+                    artwork = resolveArtworkModel(server, album.coverArtId, null),
+                    bottomOverlayPadding = bottomOverlayPadding,
+                ) {
+                    when {
+                        isLoading && album.songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_album)) }
+                        error != null && album.songs.isEmpty() -> item { ErrorStateCard(error) }
+                        else -> {
+                            item {
+                                SectionTitle(
+                                    title = stringResource(R.string.library_track_list),
+                                    subtitle = album.genre ?: stringResource(R.string.library_album_details),
+                                    actionLabel = stringResource(R.string.library_play_album),
+                                    onAction = playAlbum,
+                                )
+                            }
+                            itemsIndexed(album.songs, key = { _, s -> s.id }) { index, song ->
+                                val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
+                                SongRow(
+                                    song = song,
+                                    server = server,
+                                    cachedSong = cachedSongsBySongId[song.id],
+                                    isStreamCached = song.id in streamCachedSongIds,
+                                    isDownloading = song.id in downloadingSongIds,
+                                    isOfflineDegraded = isOfflineDegraded,
+                                    isOfflinePlayable = isOfflinePlayable,
+                                    onClick = { onPlaySongs(album.songs, index) },
+                                    onMore = { onShowActions(song) },
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -1460,59 +1554,102 @@ fun PlaylistDetailScreen(
         playlist.owner,
         songCount?.let { songCountText(it) },
     )
+    val useExpressiveSinglePane = SakiTheme.visuals.useExpressiveSurfaceContainers
     AdaptiveLibraryDetailLayout(
         modifier = Modifier.fillMaxSize(),
         singlePane = {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = bottomContentPadding(bottomOverlayPadding),
-            ) {
-                item {
-                    AlbumDetailHeroCard(
-                        title = playlist.name,
-                        artwork = artworkModel,
-                        accentColor = accent,
-                        metaItems = playlistMetaItems,
-                        canPlay = playlist.songs.isNotEmpty(),
-                        onPlay = playPlaylist,
-                        onBack = onBack,
-                        playContentDescription = stringResource(R.string.library_play_playlist),
-                    )
-                }
-                when {
-                    isLoading && playlist.songs.isEmpty() -> item {
-                        LoadingStateCard(stringResource(R.string.library_loading_playlist))
+            if (useExpressiveSinglePane) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = bottomContentPadding(bottomOverlayPadding),
+                ) {
+                    item {
+                        AlbumDetailHeroCard(
+                            title = playlist.name,
+                            artwork = artworkModel,
+                            accentColor = accent,
+                            metaItems = playlistMetaItems,
+                            canPlay = playlist.songs.isNotEmpty(),
+                            onPlay = playPlaylist,
+                            onBack = onBack,
+                            playContentDescription = stringResource(R.string.library_play_playlist),
+                        )
                     }
-                    error != null && playlist.songs.isEmpty() -> item { ErrorStateCard(error) }
-                    else -> itemsIndexed(
-                        playlist.songs,
-                        key = { index, song -> "${song.id}_$index" },
-                    ) { index, song ->
-                        val isOfflinePlayable = song.isOfflinePlayable(
-                            cachedSongsBySongId,
-                            streamCachedSongIds,
-                        )
-                        AlbumTrackRow(
-                            song = song,
-                            index = index,
-                            useTrackNumbers = false,
-                            albumArtistLabel = null,
-                            cachedSong = cachedSongsBySongId[song.id],
-                            isStreamCached = song.id in streamCachedSongIds,
-                            isDownloading = song.id in downloadingSongIds,
-                            isOfflineDegraded = isOfflineDegraded,
-                            isOfflinePlayable = isOfflinePlayable,
-                            isCurrent = currentPlaybackSongId == song.id,
-                            isPlaying = isPlaying,
-                            accentColor = trackAccent,
-                            artworkModel = resolveArtworkModel(
-                                server,
-                                song.coverArtId,
-                                cachedSongsBySongId[song.id],
-                            ),
-                            onClick = { onPlaySongs(playlist.songs, index) },
-                            onMore = { onShowActions(song) },
-                        )
+                    when {
+                        isLoading && playlist.songs.isEmpty() -> item {
+                            LoadingStateCard(stringResource(R.string.library_loading_playlist))
+                        }
+                        error != null && playlist.songs.isEmpty() -> item { ErrorStateCard(error) }
+                        else -> itemsIndexed(
+                            playlist.songs,
+                            key = { index, song -> "${song.id}_$index" },
+                        ) { index, song ->
+                            val isOfflinePlayable = song.isOfflinePlayable(
+                                cachedSongsBySongId,
+                                streamCachedSongIds,
+                            )
+                            AlbumTrackRow(
+                                song = song,
+                                index = index,
+                                useTrackNumbers = false,
+                                albumArtistLabel = null,
+                                cachedSong = cachedSongsBySongId[song.id],
+                                isStreamCached = song.id in streamCachedSongIds,
+                                isDownloading = song.id in downloadingSongIds,
+                                isOfflineDegraded = isOfflineDegraded,
+                                isOfflinePlayable = isOfflinePlayable,
+                                isCurrent = currentPlaybackSongId == song.id,
+                                isPlaying = isPlaying,
+                                accentColor = trackAccent,
+                                artworkModel = resolveArtworkModel(
+                                    server,
+                                    song.coverArtId,
+                                    cachedSongsBySongId[song.id],
+                                ),
+                                onClick = { onPlaySongs(playlist.songs, index) },
+                                onMore = { onShowActions(song) },
+                            )
+                        }
+                    }
+                }
+            } else {
+                val subtitle = listOfNotNull(
+                    playlist.owner,
+                    if (songCount != null) songCountText(songCount) else null,
+                ).joinToString(" • ")
+                LibraryDetailScaffold(
+                    title = playlist.name,
+                    subtitle = subtitle,
+                    artwork = resolveArtworkModel(server, playlist.coverArtId, null),
+                    bottomOverlayPadding = bottomOverlayPadding,
+                ) {
+                    when {
+                        isLoading && playlist.songs.isEmpty() -> item { LoadingStateCard(stringResource(R.string.library_loading_playlist)) }
+                        error != null && playlist.songs.isEmpty() -> item { ErrorStateCard(error) }
+                        else -> {
+                            item {
+                                SectionTitle(
+                                    title = stringResource(R.string.library_tracks),
+                                    subtitle = stringResource(R.string.library_playlist_sequence),
+                                    actionLabel = stringResource(R.string.library_play_playlist),
+                                    onAction = playPlaylist,
+                                )
+                            }
+                            itemsIndexed(playlist.songs, key = { index, s -> "${s.id}_$index" }) { index, song ->
+                                val isOfflinePlayable = song.isOfflinePlayable(cachedSongsBySongId, streamCachedSongIds)
+                                SongRow(
+                                    song = song,
+                                    server = server,
+                                    cachedSong = cachedSongsBySongId[song.id],
+                                    isStreamCached = song.id in streamCachedSongIds,
+                                    isDownloading = song.id in downloadingSongIds,
+                                    isOfflineDegraded = isOfflineDegraded,
+                                    isOfflinePlayable = isOfflinePlayable,
+                                    onClick = { onPlaySongs(playlist.songs, index) },
+                                    onMore = { onShowActions(song) },
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -1561,6 +1698,49 @@ fun PlaylistDetailScreen(
             )
         },
     )
+}
+
+@Composable
+private fun LibraryDetailScaffold(
+    title: String,
+    subtitle: String?,
+    artwork: Any?,
+    bottomOverlayPadding: Dp,
+    content: androidx.compose.foundation.lazy.LazyListScope.() -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = bottomContentPadding(bottomOverlayPadding),
+    ) {
+        item {
+            Column(modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp, bottom = 20.dp)) {
+                if (artwork != null) {
+                    ArtworkCard(
+                        model = artwork,
+                        contentDescription = title,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(320.dp),
+                        cornerRadiusDp = 34,
+                    )
+                }
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.displaySmall,
+                    modifier = Modifier.padding(top = if (artwork != null) 14.dp else 0.dp),
+                )
+                if (!subtitle.isNullOrBlank()) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 6.dp),
+                    )
+                }
+            }
+        }
+        content()
+    }
 }
 
 @Composable

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/BrowseScreen.kt
@@ -19,15 +19,20 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
@@ -219,6 +224,9 @@ fun BrowseScreen(
             .background(background)
             .padding(contentPadding)
             .statusBarsPadding()
+            .windowInsetsPadding(
+                WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal),
+            )
             .padding(horizontal = 16.dp),
     ) {
         if (currentServer == null) {

--- a/app/src/test/java/org/hdhmc/saki/presentation/library/BrowseComponentsLayoutTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/presentation/library/BrowseComponentsLayoutTest.kt
@@ -1,0 +1,50 @@
+package org.hdhmc.saki.presentation.library
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BrowseComponentsLayoutTest {
+    @Test
+    fun landscapeDetailUsesTwoPanesWhenBothPanesRemainUsable() {
+        assertTrue(supportsLibraryDetailTwoPane(width = 800.dp, height = 400.dp))
+        assertTrue(supportsLibraryDetailTwoPane(width = 1152.dp, height = 720.dp))
+        assertFalse(supportsLibraryDetailTwoPane(width = 700.dp, height = 400.dp))
+        assertFalse(supportsLibraryDetailTwoPane(width = 800.dp, height = 300.dp))
+        assertFalse(supportsLibraryDetailTwoPane(width = 800.dp, height = 800.dp))
+    }
+
+    @Test
+    fun twoPaneMetricsPrioritizeTheTrackListAndCapTabletLineLength() {
+        val phone = calculateLibraryDetailTwoPaneMetrics(800.dp)
+        assertEquals(272.dp, phone.infoPaneWidth)
+        assertEquals(508.dp, phone.contentPaneWidth)
+        assertEquals(800.dp, phone.stageWidth)
+
+        val tablet = calculateLibraryDetailTwoPaneMetrics(1280.dp)
+        assertEquals(320.dp, tablet.infoPaneWidth)
+        assertEquals(640.dp, tablet.contentPaneWidth)
+        assertEquals(980.dp, tablet.stageWidth)
+    }
+
+    @Test
+    fun artistHeaderCompactsOnlyInShortLandscapePanes() {
+        assertTrue(shouldUseCompactArtistDetailHeader(400.dp))
+        assertFalse(shouldUseCompactArtistDetailHeader(520.dp))
+        assertFalse(shouldUseCompactArtistDetailHeader(720.dp))
+    }
+
+    @Test
+    fun detailHeroIsCappedByCompactLandscapeHeight() {
+        assertEquals(
+            269.dp,
+            calculateLibraryDetailHeroWidth(paneWidth = 296.dp, usableHeight = 295.dp),
+        )
+        assertEquals(
+            320.dp,
+            calculateLibraryDetailHeroWidth(paneWidth = 320.dp, usableHeight = 616.dp),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add adaptive two-pane detail layouts for albums, artists, and playlists on landscape phones and tablets, independent of the selected SAKI or Material Expressive visual theme.
- Keep information and primary actions in a bounded left pane while virtualizing tracks in a capped right pane.
- Preserve the existing theme-specific compact/single-pane pages, including the original SAKI song-list behavior.
- Initialize artwork palette extraction only after the selected single/two-pane branch needs it, avoiding unused Coil decode and Palette work on compact SAKI pages.
- Use height-aware compact heroes on landscape phones and an adaptive vertical album grid for artist details.
- Respect horizontal display-cutout insets so content stays clear of punch-hole cameras.

## User impact

Landscape detail pages no longer stretch every track across the full display or spend most of the viewport on a portrait-style hero. Tablet layouts retain a roomier information pane, while short phone landscapes compact artwork and actions so useful content remains visible above the mini player. Compact portrait users retain the existing detail presentation for their selected theme without paying for unused expressive artwork extraction.

## Validation

- `./gradlew testDebugUnitTest assembleDebug -q`
- `./gradlew assembleRelease --console=plain --max-workers=2`
- Release APK verified on a 2880×1800 tablet and a 2608×1200 landscape phone.
- Verified the phone cutout inset shifts Browse content outside the reported 144 px unsafe region.

Follow-up to #324.