### PR TITLE
feat: adapt mini player visibility

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -17,9 +17,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.material3.LocalContentColor
@@ -32,7 +38,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.collectLatest
 import org.hdhmc.saki.domain.model.PlaybackProgressState
 import org.hdhmc.saki.domain.model.PlaybackSessionState
@@ -156,6 +165,52 @@ private fun RootShell(
     val defaultCapsuleHeightPx = with(density) { 72.dp.roundToPx() }
     var capsuleHeightPx by remember { mutableIntStateOf(defaultCapsuleHeightPx) }
     val capsuleOverlayPadding = with(density) { capsuleHeightPx.toDp() }
+    val contentScrolling = remember { mutableStateOf(false) }
+    val scrollScope = rememberCoroutineScope()
+    val contentScrollConnection = remember(scrollScope) {
+        object : NestedScrollConnection {
+            var idleWatcher: Job? = null
+            var lastVerticalScrollNanos: Long = 0L
+
+            fun recordVerticalScroll(offset: Offset) {
+                if (offset.y == 0f) return
+
+                lastVerticalScrollNanos = System.nanoTime()
+                contentScrolling.value = true
+                if (idleWatcher?.isActive == true) return
+                idleWatcher = scrollScope.launch {
+                    while (true) {
+                        delay(MINI_PLAYER_SCROLL_IDLE_DELAY_MS)
+                        val idleMillis = (System.nanoTime() - lastVerticalScrollNanos) / 1_000_000L
+                        if (idleMillis >= MINI_PLAYER_SCROLL_IDLE_DELAY_MS) {
+                            contentScrolling.value = false
+                            idleWatcher = null
+                            break
+                        }
+                    }
+                }
+            }
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource,
+            ): Offset {
+                recordVerticalScroll(if (consumed.y != 0f) consumed else available)
+                return Offset.Zero
+            }
+
+            override suspend fun onPostFling(
+                consumed: Velocity,
+                available: Velocity,
+            ): Velocity {
+                idleWatcher?.cancel()
+                idleWatcher = null
+                contentScrolling.value = false
+                return Velocity.Zero
+            }
+        }
+    }
 
     val settingsBackMotion = rememberPredictiveBackMotion(
         enabled = showSettings && !showNowPlaying,
@@ -166,7 +221,8 @@ private fun RootShell(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(shellBackgroundBrush),
+            .background(shellBackgroundBrush)
+            .nestedScroll(contentScrollConnection),
     ) {
         CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
             Box(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
@@ -211,6 +267,7 @@ private fun RootShell(
                     NowPlayingCapsuleRoute(
                         viewModel = viewModel,
                         onOpenNowPlaying = onOpenNowPlaying,
+                        isContentScrolling = contentScrolling.value,
                     )
                 }
             }
@@ -317,6 +374,7 @@ private fun SettingsRoute(
 private fun NowPlayingCapsuleRoute(
     viewModel: SakiAppViewModel,
     onOpenNowPlaying: () -> Unit,
+    isContentScrolling: Boolean,
 ) {
     val uiState by viewModel.capsuleUiState.collectAsStateWithLifecycle()
     NowPlayingCapsule(
@@ -332,8 +390,11 @@ private fun NowPlayingCapsuleRoute(
         onSkipToPrevious = viewModel::skipToPrevious,
         onSkipToNext = viewModel::skipToNext,
         prewarmDynamicColors = rememberVisualEffectsPolicy().useNowPlayingDynamicArtworkColors,
+        isContentScrolling = isContentScrolling,
     )
 }
+
+private const val MINI_PLAYER_SCROLL_IDLE_DELAY_MS = 220L
 
 @Composable
 private fun NowPlayingOverlayHostRoute(

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -3578,11 +3578,12 @@ private const val MINI_PLAYER_WIDE_LANDSCAPE_WIDTH_FRACTION = 0.68f
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
 
 internal fun calculateMiniPlayerMaxWidth(width: Dp, height: Dp): Dp? {
+    if (width > height && height < MINI_PLAYER_COMPACT_LANDSCAPE_MAX_HEIGHT) {
+        return minOf(width, MINI_PLAYER_COMPACT_LANDSCAPE_MAX_WIDTH)
+    }
     if (width < MINI_PLAYER_WIDE_LAYOUT_MIN_WIDTH) return null
 
     return when {
-        width > height && height < MINI_PLAYER_COMPACT_LANDSCAPE_MAX_HEIGHT ->
-            minOf(width, MINI_PLAYER_COMPACT_LANDSCAPE_MAX_WIDTH)
         width > height ->
             (width * MINI_PLAYER_WIDE_LANDSCAPE_WIDTH_FRACTION).coerceIn(
                 MINI_PLAYER_COMPACT_LANDSCAPE_MAX_WIDTH,

--- a/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/library/PlayerChrome.kt
@@ -6,7 +6,9 @@ import android.os.Build
 import android.util.LruCache
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
@@ -205,6 +207,7 @@ fun NowPlayingCapsule(
     onSkipToPrevious: () -> Unit,
     onSkipToNext: () -> Unit,
     prewarmDynamicColors: Boolean = false,
+    isContentScrolling: Boolean = false,
 ) {
     val visuals = SakiTheme.visuals
     // Warm the current track's artwork color into the cache while the mini player is
@@ -219,6 +222,26 @@ fun NowPlayingCapsule(
     }
     val capsuleContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh.copy(
         alpha = visuals.nowPlayingCapsuleContainerAlpha,
+    )
+    val capsuleAlpha by animateFloatAsState(
+        targetValue = if (isContentScrolling) {
+            visuals.miniPlayerScrollingAlpha
+        } else {
+            visuals.miniPlayerRestingAlpha
+        },
+        animationSpec = tween(
+            durationMillis = if (isContentScrolling) {
+                MINI_PLAYER_FADE_OUT_DURATION_MS
+            } else {
+                MINI_PLAYER_FADE_IN_DURATION_MS
+            },
+            easing = if (isContentScrolling) {
+                FastOutLinearInEasing
+            } else {
+                LinearOutSlowInEasing
+            },
+        ),
+        label = "miniPlayerAlpha",
     )
     val elevation by animateDpAsState(
         targetValue = if (isPlaying) 12.dp else 6.dp,
@@ -236,21 +259,17 @@ fun NowPlayingCapsule(
             .padding(start = 14.dp, end = 14.dp, top = 4.dp, bottom = 8.dp),
         contentAlignment = Alignment.Center,
     ) {
-        val constrainLandscapeCapsuleWidth = maxWidth > maxHeight &&
-            maxHeight < MINI_PLAYER_LANDSCAPE_WIDTH_LIMIT_HEIGHT
+        val capsuleMaxWidth = calculateMiniPlayerMaxWidth(maxWidth, maxHeight)
 
         Card(
             onClick = onExpand,
             enabled = track != null,
             modifier = Modifier
                 .then(
-                    if (constrainLandscapeCapsuleWidth) {
-                        Modifier.widthIn(max = MINI_PLAYER_LANDSCAPE_MAX_WIDTH)
-                    } else {
-                        Modifier
-                    },
+                    capsuleMaxWidth?.let { Modifier.widthIn(max = it) } ?: Modifier,
                 )
                 .fillMaxWidth()
+                .graphicsLayer { alpha = capsuleAlpha }
                 .pointerInput(track != null) {
                     if (track == null) return@pointerInput
                     val distanceThresholdPx = 72.dp.toPx()
@@ -3547,9 +3566,34 @@ private val NOW_PLAYING_LARGE_SCREEN_CONTROL_MAX_WIDTH = 440.dp
 private val NOW_PLAYING_LARGE_SCREEN_CONTROL_HEIGHT_EXTENSION = 40.dp
 private val NOW_PLAYING_LARGE_SCREEN_CONTROL_GROUP_SPACING = 20.dp
 private val NOW_PLAYING_LARGE_SCREEN_PANE_GAP = 36.dp
-private val MINI_PLAYER_LANDSCAPE_MAX_WIDTH = 520.dp
-private val MINI_PLAYER_LANDSCAPE_WIDTH_LIMIT_HEIGHT = 480.dp
+private const val MINI_PLAYER_FADE_OUT_DURATION_MS = 160
+private const val MINI_PLAYER_FADE_IN_DURATION_MS = 260
+private val MINI_PLAYER_WIDE_LAYOUT_MIN_WIDTH = 600.dp
+private val MINI_PLAYER_COMPACT_LANDSCAPE_MAX_WIDTH = 520.dp
+private val MINI_PLAYER_COMPACT_LANDSCAPE_MAX_HEIGHT = 480.dp
+private val MINI_PLAYER_WIDE_LANDSCAPE_MAX_WIDTH = 680.dp
+private val MINI_PLAYER_PORTRAIT_MAX_WIDTH = 640.dp
+private val MINI_PLAYER_PORTRAIT_HORIZONTAL_INSET = 48.dp
+private const val MINI_PLAYER_WIDE_LANDSCAPE_WIDTH_FRACTION = 0.68f
 private val artworkPresentationCache = LruCache<String, ArtworkPresentation>(ARTWORK_PRESENTATION_CACHE_ENTRIES)
+
+internal fun calculateMiniPlayerMaxWidth(width: Dp, height: Dp): Dp? {
+    if (width < MINI_PLAYER_WIDE_LAYOUT_MIN_WIDTH) return null
+
+    return when {
+        width > height && height < MINI_PLAYER_COMPACT_LANDSCAPE_MAX_HEIGHT ->
+            minOf(width, MINI_PLAYER_COMPACT_LANDSCAPE_MAX_WIDTH)
+        width > height ->
+            (width * MINI_PLAYER_WIDE_LANDSCAPE_WIDTH_FRACTION).coerceIn(
+                MINI_PLAYER_COMPACT_LANDSCAPE_MAX_WIDTH,
+                minOf(width, MINI_PLAYER_WIDE_LANDSCAPE_MAX_WIDTH),
+            )
+        else -> minOf(
+            width - MINI_PLAYER_PORTRAIT_HORIZONTAL_INSET,
+            MINI_PLAYER_PORTRAIT_MAX_WIDTH,
+        )
+    }
+}
 
 internal fun shouldArmArtworkPagerNavigation(
     isScrollInProgress: Boolean,

--- a/app/src/main/java/org/hdhmc/saki/ui/theme/SakiTheme.kt
+++ b/app/src/main/java/org/hdhmc/saki/ui/theme/SakiTheme.kt
@@ -38,6 +38,8 @@ data class SakiVisualTokens(
     val miniPlayerContainerCornerRadius: Dp = 32.dp,
     val miniPlayerHandleWidth: Dp = 44.dp,
     val miniPlayerHandleAlpha: Float = 0.38f,
+    val miniPlayerRestingAlpha: Float = 0.95f,
+    val miniPlayerScrollingAlpha: Float = 0.30f,
     val miniPlayerArtworkCornerRadius: Dp = 16.dp,
     val miniPlayerControlContainerAlpha: Float = 0.56f,
     val miniPlayerControlCornerRadius: Dp = 22.dp,

--- a/app/src/test/java/org/hdhmc/saki/presentation/library/PlayerChromeInteractionTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/presentation/library/PlayerChromeInteractionTest.kt
@@ -56,6 +56,27 @@ class PlayerChromeInteractionTest {
     }
 
     @Test
+    fun miniPlayerKeepsPhonePortraitWidthUnconstrained() {
+        assertNull(calculateMiniPlayerMaxWidth(430.dp, 900.dp))
+    }
+
+    @Test
+    fun miniPlayerUsesCompactWidthInShortLandscapeWindows() {
+        assertEquals(520.dp, calculateMiniPlayerMaxWidth(869.dp, 400.dp))
+    }
+
+    @Test
+    fun miniPlayerScalesDownOnHdLandscapeWindows() {
+        assertEquals(544.dp, calculateMiniPlayerMaxWidth(800.dp, 500.dp))
+        assertEquals(680.dp, calculateMiniPlayerMaxWidth(1_280.dp, 800.dp))
+    }
+
+    @Test
+    fun miniPlayerLeavesSideSpaceOnTabletPortraitWindows() {
+        assertEquals(640.dp, calculateMiniPlayerMaxWidth(720.dp, 1_152.dp))
+    }
+
+    @Test
     fun compactLandscapeKeepsMinimumControlBoundsAtFiveHundredByFourHundred() {
         assertTrue(supportsCompactLandscapeNowPlayingLayout(500.dp, 400.dp))
         val metrics = calculateCompactLandscapeStageMetrics(500.dp, 400.dp)

--- a/app/src/test/java/org/hdhmc/saki/presentation/library/PlayerChromeInteractionTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/presentation/library/PlayerChromeInteractionTest.kt
@@ -62,6 +62,9 @@ class PlayerChromeInteractionTest {
 
     @Test
     fun miniPlayerUsesCompactWidthInShortLandscapeWindows() {
+        assertEquals(500.dp, calculateMiniPlayerMaxWidth(500.dp, 400.dp))
+        assertEquals(520.dp, calculateMiniPlayerMaxWidth(599.dp, 400.dp))
+        assertEquals(520.dp, calculateMiniPlayerMaxWidth(600.dp, 400.dp))
         assertEquals(520.dp, calculateMiniPlayerMaxWidth(869.dp, 400.dp))
     }
 


### PR DESCRIPTION
## Summary

- constrain the mini player to an adaptive centered width on HD, tablet, and landscape windows instead of stretching across the full screen
- keep compact phone portrait behavior unchanged while scaling large landscape windows between 520dp and 680dp
- make the mini player slightly translucent at rest and substantially more transparent while vertically scrolling content
- animate opacity changes with asymmetric easing and an idle grace period to avoid flicker during slow or interrupted gestures
- track nested vertical scrolling at the shell level without recomposing on every scroll frame

## Validation

- `./gradlew testDebugUnitTest assembleDebug -q` (52 tests, 0 failures)
- `./gradlew assembleRelease -q`
- installed and tested the Release APK on phone `10.111.111.90:34567` and tablet `10.233.233.69:34567`
- visually verified resting, active-scroll, and settled mini-player states on the tablet
