### PR TITLE
fix: recover stale offline endpoint state

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/remote/EndpointSelector.kt
@@ -52,8 +52,8 @@ class EndpointSelector @Inject constructor(
     private val activeProbes = ConcurrentHashMap<Long, ActiveProbe>()
     private val probeGenerations = ConcurrentHashMap<Long, Long>()
     private val probingServers = ConcurrentHashMap<Long, Boolean>()
-    private val lastReachableVersions = ConcurrentHashMap<EndpointKey, Long>()
-    private val successVersion = AtomicLong(0L)
+    private val latestEndpointEvents = ConcurrentHashMap<EndpointKey, EndpointReachabilityEvent>()
+    private val endpointEventVersion = AtomicLong(0L)
     private val offlineRecoveryJobs = ConcurrentHashMap<Long, Job>()
     private val endpointStateLocks = ConcurrentHashMap<Long, Any>()
 
@@ -115,7 +115,7 @@ class EndpointSelector @Inject constructor(
         bestEndpoints.remove(serverId)
         forcedEndpoints.remove(serverId)
         lastProbeResults.remove(serverId)
-        lastReachableVersions.keys.removeAll { it.serverId == serverId }
+        latestEndpointEvents.keys.removeAll { it.serverId == serverId }
         offlineRecoveryJobs.remove(serverId)?.cancel()
         endpointStateLocks.remove(serverId)
         _probeVersion.update { it + 1 }
@@ -145,7 +145,7 @@ class EndpointSelector @Inject constructor(
         serverConfigs[serverId] = server
         val endpoints = server.endpoints.sortedBy(ServerEndpoint::order)
         val generation = nextProbeGeneration(serverId)
-        val probeStartSuccessVersion = successVersion.get()
+        val probeStartEventVersion = endpointEventVersion.get()
         probingServers[serverId] = true
         _probeVersion.update { it + 1 }
         if (endpoints.isEmpty()) {
@@ -178,7 +178,7 @@ class EndpointSelector @Inject constructor(
                             endpoints = endpoints,
                             reachableLatencies = probeResults,
                             completedEndpointIds = completedEndpointIds,
-                            probeStartSuccessVersion = probeStartSuccessVersion,
+                            probeStartEventVersion = probeStartEventVersion,
                             final = false,
                         )
                     }
@@ -190,7 +190,7 @@ class EndpointSelector @Inject constructor(
                     endpoints = endpoints,
                     reachableLatencies = probeResults,
                     completedEndpointIds = completedEndpointIds,
-                    probeStartSuccessVersion = probeStartSuccessVersion,
+                    probeStartEventVersion = probeStartEventVersion,
                     final = true,
                 )
                 selectBestKnownReachableEndpoint(serverId)
@@ -234,13 +234,16 @@ class EndpointSelector @Inject constructor(
     }
 
     fun invalidate(serverId: Long, failedEndpointId: Long) {
-        forcedEndpoints.remove(serverId, failedEndpointId)
-        val removedActiveEndpoint = bestEndpoints.remove(serverId, failedEndpointId)
-        val endpoint = serverConfigs[serverId]?.endpoints?.firstOrNull { it.id == failedEndpointId }
-            ?: return
-        upsertProbeResult(serverId, EndpointProbeResult(endpoint, latencyMs = null, reachable = false))
-        if (removedActiveEndpoint && forcedEndpoints[serverId] == null) {
-            selectBestKnownReachableEndpoint(serverId)
+        synchronized(endpointStateLock(serverId)) {
+            forcedEndpoints.remove(serverId, failedEndpointId)
+            val removedActiveEndpoint = bestEndpoints.remove(serverId, failedEndpointId)
+            val endpoint = serverConfigs[serverId]?.endpoints?.firstOrNull { it.id == failedEndpointId }
+                ?: return
+            recordEndpointEvent(serverId, failedEndpointId, reachable = false)
+            upsertProbeResult(serverId, EndpointProbeResult(endpoint, latencyMs = null, reachable = false))
+            if (removedActiveEndpoint && forcedEndpoints[serverId] == null) {
+                selectBestKnownReachableEndpoint(serverId)
+            }
         }
         _probeVersion.update { it + 1 }
         if (isOfflineDegraded(serverId)) {
@@ -274,10 +277,12 @@ class EndpointSelector @Inject constructor(
     }
 
     fun recordSuccess(serverId: Long, endpoint: ServerEndpoint, latencyMs: Long? = null) {
-        serverConfigs[serverId] ?: return
-        recordReachableEndpoint(serverId, endpoint, latencyMs)
-        activeProbes[serverId]?.firstReachable?.complete(endpoint)
-        offlineRecoveryJobs.remove(serverId)?.cancel()
+        synchronized(endpointStateLock(serverId)) {
+            serverConfigs[serverId] ?: return
+            recordReachableEndpoint(serverId, endpoint, latencyMs)
+            activeProbes[serverId]?.firstReachable?.complete(endpoint)
+            offlineRecoveryJobs.remove(serverId)?.cancel()
+        }
         _probeVersion.update { it + 1 }
     }
 
@@ -346,7 +351,7 @@ class EndpointSelector @Inject constructor(
         latencyMs: Long?,
     ) {
         synchronized(endpointStateLock(serverId)) {
-            lastReachableVersions[EndpointKey(serverId, endpoint.id)] = successVersion.incrementAndGet()
+            recordEndpointEvent(serverId, endpoint.id, reachable = true)
             val previous = lastProbeResults[serverId]
                 .orEmpty()
                 .firstOrNull { it.endpoint.id == endpoint.id }
@@ -394,20 +399,19 @@ class EndpointSelector @Inject constructor(
         endpoints: List<ServerEndpoint>,
         reachableLatencies: Map<Long, Long>,
         completedEndpointIds: Set<Long>,
-        probeStartSuccessVersion: Long,
+        probeStartEventVersion: Long,
         final: Boolean,
     ) {
         synchronized(endpointStateLock(serverId)) {
             val previousById = lastProbeResults[serverId].orEmpty().associateBy { it.endpoint.id }
             lastProbeResults[serverId] = endpoints.mapNotNull { endpoint ->
                 val latency = reachableLatencies[endpoint.id]
-                val succeededDuringProbe = lastReachableVersions[
-                    EndpointKey(serverId, endpoint.id)
-                ]?.let { reachableVersion -> reachableVersion > probeStartSuccessVersion } == true
+                val latestEvent = latestEndpointEvents[EndpointKey(serverId, endpoint.id)]
                 when (
                     resolveEndpointReachability(
                         hasProbeLatency = latency != null,
-                        succeededDuringProbe = succeededDuringProbe,
+                        latestEvent = latestEvent,
+                        probeStartEventVersion = probeStartEventVersion,
                         probeCompleted = final || endpoint.id in completedEndpointIds,
                         previousReachable = previousById[endpoint.id]?.reachable,
                     )
@@ -440,6 +444,13 @@ class EndpointSelector @Inject constructor(
                 orderedEndpoints.mapNotNull { endpoint -> previousById[endpoint.id] }
             }
         }
+    }
+
+    private fun recordEndpointEvent(serverId: Long, endpointId: Long, reachable: Boolean) {
+        latestEndpointEvents[EndpointKey(serverId, endpointId)] = EndpointReachabilityEvent(
+            version = endpointEventVersion.incrementAndGet(),
+            reachable = reachable,
+        )
     }
 
     private fun endpointStateLock(serverId: Long): Any =
@@ -506,13 +517,20 @@ class EndpointSelector @Inject constructor(
     }
 }
 
+internal data class EndpointReachabilityEvent(
+    val version: Long,
+    val reachable: Boolean,
+)
+
 internal fun resolveEndpointReachability(
     hasProbeLatency: Boolean,
-    succeededDuringProbe: Boolean,
+    latestEvent: EndpointReachabilityEvent?,
+    probeStartEventVersion: Long,
     probeCompleted: Boolean,
     previousReachable: Boolean?,
 ): Boolean? = when {
-    hasProbeLatency || succeededDuringProbe -> true
+    latestEvent != null && latestEvent.version > probeStartEventVersion -> latestEvent.reachable
+    hasProbeLatency -> true
     probeCompleted -> false
     else -> previousReachable
 }

--- a/app/src/main/java/org/hdhmc/saki/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/remote/EndpointSelector.kt
@@ -193,7 +193,6 @@ class EndpointSelector @Inject constructor(
                     probeStartEventVersion = probeStartEventVersion,
                     final = true,
                 )
-                selectBestKnownReachableEndpoint(serverId)
                 clearProbeInProgress(serverId, generation)
                 if (isOfflineDegraded(serverId)) {
                     scheduleOfflineRecovery(serverId)
@@ -242,7 +241,7 @@ class EndpointSelector @Inject constructor(
             recordEndpointEvent(serverId, failedEndpointId, reachable = false)
             upsertProbeResult(serverId, EndpointProbeResult(endpoint, latencyMs = null, reachable = false))
             if (removedActiveEndpoint && forcedEndpoints[serverId] == null) {
-                selectBestKnownReachableEndpoint(serverId)
+                selectBestKnownReachableEndpointLocked(serverId)
             }
         }
         _probeVersion.update { it + 1 }
@@ -287,16 +286,20 @@ class EndpointSelector @Inject constructor(
     }
 
     fun forceEndpoint(serverId: Long, endpointId: Long) {
-        forcedEndpoints[serverId] = endpointId
-        bestEndpoints[serverId] = endpointId
-        offlineRecoveryJobs.remove(serverId)?.cancel()
+        synchronized(endpointStateLock(serverId)) {
+            forcedEndpoints[serverId] = endpointId
+            bestEndpoints[serverId] = endpointId
+            offlineRecoveryJobs.remove(serverId)?.cancel()
+        }
         _probeVersion.update { it + 1 }
     }
 
     fun clearForce(serverId: Long) {
-        forcedEndpoints.remove(serverId)
-        bestEndpoints.remove(serverId)
-        selectBestKnownReachableEndpoint(serverId)
+        synchronized(endpointStateLock(serverId)) {
+            forcedEndpoints.remove(serverId)
+            bestEndpoints.remove(serverId)
+            selectBestKnownReachableEndpointLocked(serverId)
+        }
         _probeVersion.update { it + 1 }
         if (isOfflineDegraded(serverId)) {
             scheduleOfflineRecovery(serverId)
@@ -381,14 +384,12 @@ class EndpointSelector @Inject constructor(
         }
     }
 
-    private fun selectBestKnownReachableEndpoint(serverId: Long) {
+    private fun selectBestKnownReachableEndpointLocked(serverId: Long) {
+        check(Thread.holdsLock(endpointStateLock(serverId)))
         if (forcedEndpoints[serverId] != null) return
-        val bestReachable = lastProbeResults[serverId]
-            .orEmpty()
-            .filter { result -> result.reachable }
-            .minByOrNull { result -> result.latencyMs ?: Long.MAX_VALUE }
-        if (bestReachable != null) {
-            bestEndpoints[serverId] = bestReachable.endpoint.id
+        val bestEndpointId = bestReachableEndpointId(lastProbeResults[serverId].orEmpty())
+        if (bestEndpointId != null) {
+            bestEndpoints[serverId] = bestEndpointId
         } else {
             bestEndpoints.remove(serverId)
         }
@@ -424,6 +425,9 @@ class EndpointSelector @Inject constructor(
                     false -> EndpointProbeResult(endpoint, latencyMs = null, reachable = false)
                     null -> previousById[endpoint.id]
                 }
+            }
+            if (final) {
+                selectBestKnownReachableEndpointLocked(serverId)
             }
         }
         _probeVersion.update { it + 1 }
@@ -516,6 +520,15 @@ class EndpointSelector @Inject constructor(
         }
     }
 }
+
+internal fun bestReachableEndpointId(
+    results: List<EndpointSelector.EndpointProbeResult>,
+): Long? = results
+    .asSequence()
+    .filter { result -> result.reachable }
+    .minByOrNull { result -> result.latencyMs ?: Long.MAX_VALUE }
+    ?.endpoint
+    ?.id
 
 internal data class EndpointReachabilityEvent(
     val version: Long,

--- a/app/src/main/java/org/hdhmc/saki/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/remote/EndpointSelector.kt
@@ -138,80 +138,83 @@ class EndpointSelector @Inject constructor(
      * Cancels any previous in-flight probe for the same server.
      */
     suspend fun probe(serverId: Long, server: ServerConfig): ServerEndpoint? {
-        activeProbes.remove(serverId)?.let { activeProbe ->
-            activeProbe.job.cancel()
-            activeProbe.firstReachable.complete(null)
-        }
-        serverConfigs[serverId] = server
-        val endpoints = server.endpoints.sortedBy(ServerEndpoint::order)
-        val generation = nextProbeGeneration(serverId)
-        val probeStartEventVersion = endpointEventVersion.get()
-        probingServers[serverId] = true
-        _probeVersion.update { it + 1 }
-        if (endpoints.isEmpty()) {
-            lastProbeResults.remove(serverId)
-            bestEndpoints.remove(serverId)
-            probingServers.remove(serverId)
+        val firstReachable = synchronized(endpointStateLock(serverId)) {
+            activeProbes.remove(serverId)?.let { activeProbe ->
+                activeProbe.job.cancel()
+                activeProbe.firstReachable.complete(null)
+            }
+            serverConfigs[serverId] = server
+            val endpoints = server.endpoints.sortedBy(ServerEndpoint::order)
+            val generation = nextProbeGeneration(serverId)
+            val probeStartEventVersion = endpointEventVersion.get()
+            probingServers[serverId] = true
             _probeVersion.update { it + 1 }
-            return null
-        }
+            if (endpoints.isEmpty()) {
+                lastProbeResults.remove(serverId)
+                bestEndpoints.remove(serverId)
+                probingServers.remove(serverId)
+                _probeVersion.update { it + 1 }
+                return null
+            }
 
-        val firstReachable = CompletableDeferred<ServerEndpoint?>()
-        val probeResults = ConcurrentHashMap<Long, Long>()
-        val completedEndpointIds = ConcurrentHashMap.newKeySet<Long>()
-        var probeFinished = false
+            val firstReachable = CompletableDeferred<ServerEndpoint?>()
+            val probeResults = ConcurrentHashMap<Long, Long>()
+            val completedEndpointIds = ConcurrentHashMap.newKeySet<Long>()
+            var probeFinished = false
 
-        val parentJob = scope.launch(start = CoroutineStart.LAZY) {
-            try {
-                val jobs = endpoints.map { endpoint ->
-                    launch {
-                        val latency = pingEndpoint(endpoint, server)
-                        if (!isCurrentProbe(serverId, generation)) return@launch
-                        completedEndpointIds += endpoint.id
-                        if (latency != null) {
-                            probeResults[endpoint.id] = latency
-                            recordReachableEndpoint(serverId, endpoint, latency)
-                            firstReachable.complete(endpoint)
+            val parentJob = scope.launch(start = CoroutineStart.LAZY) {
+                try {
+                    val jobs = endpoints.map { endpoint ->
+                        launch {
+                            val latency = pingEndpoint(endpoint, server)
+                            if (!isCurrentProbe(serverId, generation)) return@launch
+                            completedEndpointIds += endpoint.id
+                            if (latency != null) {
+                                probeResults[endpoint.id] = latency
+                                recordReachableEndpoint(serverId, endpoint, latency)
+                                firstReachable.complete(endpoint)
+                            }
+                            publishProbeResults(
+                                serverId = serverId,
+                                endpoints = endpoints,
+                                reachableLatencies = probeResults,
+                                completedEndpointIds = completedEndpointIds,
+                                probeStartEventVersion = probeStartEventVersion,
+                                final = false,
+                            )
                         }
-                        publishProbeResults(
-                            serverId = serverId,
-                            endpoints = endpoints,
-                            reachableLatencies = probeResults,
-                            completedEndpointIds = completedEndpointIds,
-                            probeStartEventVersion = probeStartEventVersion,
-                            final = false,
-                        )
+                    }
+                    jobs.forEach { it.join() }
+                    if (!isCurrentProbe(serverId, generation)) return@launch
+                    publishProbeResults(
+                        serverId = serverId,
+                        endpoints = endpoints,
+                        reachableLatencies = probeResults,
+                        completedEndpointIds = completedEndpointIds,
+                        probeStartEventVersion = probeStartEventVersion,
+                        final = true,
+                    )
+                    clearProbeInProgress(serverId, generation)
+                    if (isOfflineDegraded(serverId)) {
+                        scheduleOfflineRecovery(serverId)
+                    }
+                    probeFinished = true
+                    firstReachable.complete(null)
+                } finally {
+                    if (!probeFinished && isCurrentProbe(serverId, generation)) {
+                        clearProbeInProgress(serverId, generation)
                     }
                 }
-                jobs.forEach { it.join() }
-                if (!isCurrentProbe(serverId, generation)) return@launch
-                publishProbeResults(
-                    serverId = serverId,
-                    endpoints = endpoints,
-                    reachableLatencies = probeResults,
-                    completedEndpointIds = completedEndpointIds,
-                    probeStartEventVersion = probeStartEventVersion,
-                    final = true,
-                )
-                clearProbeInProgress(serverId, generation)
-                if (isOfflineDegraded(serverId)) {
-                    scheduleOfflineRecovery(serverId)
-                }
-                probeFinished = true
-                firstReachable.complete(null)
-            } finally {
-                if (!probeFinished && isCurrentProbe(serverId, generation)) {
-                    clearProbeInProgress(serverId, generation)
-                }
             }
-        }
 
-        activeProbes[serverId] = ActiveProbe(
-            generation = generation,
-            job = parentJob,
-            firstReachable = firstReachable,
-        )
-        parentJob.start()
+            activeProbes[serverId] = ActiveProbe(
+                generation = generation,
+                job = parentJob,
+                firstReachable = firstReachable,
+            )
+            parentJob.start()
+            firstReachable
+        }
 
         return firstReachable.await()
     }

--- a/app/src/main/java/org/hdhmc/saki/data/remote/EndpointSelector.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/remote/EndpointSelector.kt
@@ -13,12 +13,14 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,6 +52,10 @@ class EndpointSelector @Inject constructor(
     private val activeProbes = ConcurrentHashMap<Long, ActiveProbe>()
     private val probeGenerations = ConcurrentHashMap<Long, Long>()
     private val probingServers = ConcurrentHashMap<Long, Boolean>()
+    private val lastReachableVersions = ConcurrentHashMap<EndpointKey, Long>()
+    private val successVersion = AtomicLong(0L)
+    private val offlineRecoveryJobs = ConcurrentHashMap<Long, Job>()
+    private val endpointStateLocks = ConcurrentHashMap<Long, Any>()
 
     private val _probeVersion = MutableStateFlow(0L)
     val probeVersion: StateFlow<Long> = _probeVersion.asStateFlow()
@@ -74,6 +80,11 @@ class EndpointSelector @Inject constructor(
         val firstReachable: CompletableDeferred<ServerEndpoint?>,
     )
 
+    private data class EndpointKey(
+        val serverId: Long,
+        val endpointId: Long,
+    )
+
     private var networkCallbackRegistered = false
 
     fun start() {
@@ -94,23 +105,30 @@ class EndpointSelector @Inject constructor(
     }
 
     fun unregisterServer(serverId: Long) {
+        activeProbes.remove(serverId)?.let { activeProbe ->
+            activeProbe.job.cancel()
+            activeProbe.firstReachable.complete(null)
+        }
+        probeGenerations.remove(serverId)
+        probingServers.remove(serverId)
         serverConfigs.remove(serverId)
         bestEndpoints.remove(serverId)
         forcedEndpoints.remove(serverId)
         lastProbeResults.remove(serverId)
+        lastReachableVersions.keys.removeAll { it.serverId == serverId }
+        offlineRecoveryJobs.remove(serverId)?.cancel()
+        endpointStateLocks.remove(serverId)
+        _probeVersion.update { it + 1 }
     }
 
     private var reprobeJob: kotlinx.coroutines.Job? = null
 
     private fun onNetworkChanged() {
         forcedEndpoints.clear()
+        cancelOfflineRecoveryJobs()
         reprobeJob?.cancel()
         reprobeJob = scope.launch {
-            val delays = longArrayOf(0, 3_000, 6_000, 12_000)
-            for (d in delays) {
-                if (d > 0) delay(d)
-                serverConfigs.forEach { (serverId, server) -> probe(serverId, server) }
-            }
+            serverConfigs.forEach { (serverId, server) -> probe(serverId, server) }
         }
     }
 
@@ -127,6 +145,7 @@ class EndpointSelector @Inject constructor(
         serverConfigs[serverId] = server
         val endpoints = server.endpoints.sortedBy(ServerEndpoint::order)
         val generation = nextProbeGeneration(serverId)
+        val probeStartSuccessVersion = successVersion.get()
         probingServers[serverId] = true
         _probeVersion.update { it + 1 }
         if (endpoints.isEmpty()) {
@@ -142,7 +161,7 @@ class EndpointSelector @Inject constructor(
         val completedEndpointIds = ConcurrentHashMap.newKeySet<Long>()
         var probeFinished = false
 
-        val parentJob = scope.launch {
+        val parentJob = scope.launch(start = CoroutineStart.LAZY) {
             try {
                 val jobs = endpoints.map { endpoint ->
                     launch {
@@ -154,17 +173,31 @@ class EndpointSelector @Inject constructor(
                             recordReachableEndpoint(serverId, endpoint, latency)
                             firstReachable.complete(endpoint)
                         }
-                        publishProbeResults(serverId, endpoints, probeResults, completedEndpointIds, final = false)
+                        publishProbeResults(
+                            serverId = serverId,
+                            endpoints = endpoints,
+                            reachableLatencies = probeResults,
+                            completedEndpointIds = completedEndpointIds,
+                            probeStartSuccessVersion = probeStartSuccessVersion,
+                            final = false,
+                        )
                     }
                 }
                 jobs.forEach { it.join() }
                 if (!isCurrentProbe(serverId, generation)) return@launch
-                if (probeResults.isEmpty() && forcedEndpoints[serverId] == null) {
-                    bestEndpoints.remove(serverId)
-                }
-                publishProbeResults(serverId, endpoints, probeResults, completedEndpointIds, final = true)
+                publishProbeResults(
+                    serverId = serverId,
+                    endpoints = endpoints,
+                    reachableLatencies = probeResults,
+                    completedEndpointIds = completedEndpointIds,
+                    probeStartSuccessVersion = probeStartSuccessVersion,
+                    final = true,
+                )
                 selectBestKnownReachableEndpoint(serverId)
                 clearProbeInProgress(serverId, generation)
+                if (isOfflineDegraded(serverId)) {
+                    scheduleOfflineRecovery(serverId)
+                }
                 probeFinished = true
                 firstReachable.complete(null)
             } finally {
@@ -179,6 +212,7 @@ class EndpointSelector @Inject constructor(
             job = parentJob,
             firstReachable = firstReachable,
         )
+        parentJob.start()
 
         return firstReachable.await()
     }
@@ -209,6 +243,9 @@ class EndpointSelector @Inject constructor(
             selectBestKnownReachableEndpoint(serverId)
         }
         _probeVersion.update { it + 1 }
+        if (isOfflineDegraded(serverId)) {
+            scheduleOfflineRecovery(serverId)
+        }
     }
 
     fun getActiveEndpointId(serverId: Long): Long? = bestEndpoints[serverId]
@@ -224,7 +261,6 @@ class EndpointSelector @Inject constructor(
     fun isProbeInProgress(serverId: Long): Boolean = probingServers[serverId] == true
 
     fun hasCompletedProbe(serverId: Long): Boolean {
-        if (isProbeInProgress(serverId)) return false
         val endpointIds = serverConfigs[serverId]?.endpoints?.map { it.id }?.toSet().orEmpty()
         if (endpointIds.isEmpty()) return false
         val resultIds = lastProbeResults[serverId].orEmpty().map { it.endpoint.id }.toSet()
@@ -240,12 +276,15 @@ class EndpointSelector @Inject constructor(
     fun recordSuccess(serverId: Long, endpoint: ServerEndpoint, latencyMs: Long? = null) {
         serverConfigs[serverId] ?: return
         recordReachableEndpoint(serverId, endpoint, latencyMs)
+        activeProbes[serverId]?.firstReachable?.complete(endpoint)
+        offlineRecoveryJobs.remove(serverId)?.cancel()
         _probeVersion.update { it + 1 }
     }
 
     fun forceEndpoint(serverId: Long, endpointId: Long) {
         forcedEndpoints[serverId] = endpointId
         bestEndpoints[serverId] = endpointId
+        offlineRecoveryJobs.remove(serverId)?.cancel()
         _probeVersion.update { it + 1 }
     }
 
@@ -254,6 +293,9 @@ class EndpointSelector @Inject constructor(
         bestEndpoints.remove(serverId)
         selectBestKnownReachableEndpoint(serverId)
         _probeVersion.update { it + 1 }
+        if (isOfflineDegraded(serverId)) {
+            scheduleOfflineRecovery(serverId)
+        }
     }
 
     fun isForced(serverId: Long): Boolean = forcedEndpoints.containsKey(serverId)
@@ -303,30 +345,33 @@ class EndpointSelector @Inject constructor(
         endpoint: ServerEndpoint,
         latencyMs: Long?,
     ) {
-        val previous = lastProbeResults[serverId]
-            .orEmpty()
-            .firstOrNull { it.endpoint.id == endpoint.id }
-        upsertProbeResult(
-            serverId,
-            EndpointProbeResult(
-                endpoint = endpoint,
-                latencyMs = latencyMs ?: previous?.latencyMs,
-                reachable = true,
-            ),
-        )
-        if (forcedEndpoints[serverId] == null) {
-            val currentBestId = bestEndpoints[serverId]
-            val currentBestLatency = lastProbeResults[serverId]
+        synchronized(endpointStateLock(serverId)) {
+            lastReachableVersions[EndpointKey(serverId, endpoint.id)] = successVersion.incrementAndGet()
+            val previous = lastProbeResults[serverId]
                 .orEmpty()
-                .firstOrNull { it.endpoint.id == currentBestId }
-                ?.latencyMs
-            if (
-                currentBestId == null ||
-                latencyMs == null ||
-                currentBestLatency == null ||
-                latencyMs < currentBestLatency
-            ) {
-                bestEndpoints[serverId] = endpoint.id
+                .firstOrNull { it.endpoint.id == endpoint.id }
+            upsertProbeResult(
+                serverId,
+                EndpointProbeResult(
+                    endpoint = endpoint,
+                    latencyMs = latencyMs ?: previous?.latencyMs,
+                    reachable = true,
+                ),
+            )
+            if (forcedEndpoints[serverId] == null) {
+                val currentBestId = bestEndpoints[serverId]
+                val currentBestLatency = lastProbeResults[serverId]
+                    .orEmpty()
+                    .firstOrNull { it.endpoint.id == currentBestId }
+                    ?.latencyMs
+                if (
+                    currentBestId == null ||
+                    latencyMs == null ||
+                    currentBestLatency == null ||
+                    latencyMs < currentBestLatency
+                ) {
+                    bestEndpoints[serverId] = endpoint.id
+                }
             }
         }
     }
@@ -349,32 +394,88 @@ class EndpointSelector @Inject constructor(
         endpoints: List<ServerEndpoint>,
         reachableLatencies: Map<Long, Long>,
         completedEndpointIds: Set<Long>,
+        probeStartSuccessVersion: Long,
         final: Boolean,
     ) {
-        val previousById = lastProbeResults[serverId].orEmpty().associateBy { it.endpoint.id }
-        lastProbeResults[serverId] = endpoints.mapNotNull { endpoint ->
-            val latency = reachableLatencies[endpoint.id]
-            when {
-                latency != null -> EndpointProbeResult(endpoint, latency, reachable = true)
-                final || endpoint.id in completedEndpointIds -> EndpointProbeResult(endpoint, null, reachable = false)
-                else -> previousById[endpoint.id]
+        synchronized(endpointStateLock(serverId)) {
+            val previousById = lastProbeResults[serverId].orEmpty().associateBy { it.endpoint.id }
+            lastProbeResults[serverId] = endpoints.mapNotNull { endpoint ->
+                val latency = reachableLatencies[endpoint.id]
+                val succeededDuringProbe = lastReachableVersions[
+                    EndpointKey(serverId, endpoint.id)
+                ]?.let { reachableVersion -> reachableVersion > probeStartSuccessVersion } == true
+                when (
+                    resolveEndpointReachability(
+                        hasProbeLatency = latency != null,
+                        succeededDuringProbe = succeededDuringProbe,
+                        probeCompleted = final || endpoint.id in completedEndpointIds,
+                        previousReachable = previousById[endpoint.id]?.reachable,
+                    )
+                ) {
+                    true -> EndpointProbeResult(
+                        endpoint = endpoint,
+                        latencyMs = latency ?: previousById[endpoint.id]?.latencyMs,
+                        reachable = true,
+                    )
+                    false -> EndpointProbeResult(endpoint, latencyMs = null, reachable = false)
+                    null -> previousById[endpoint.id]
+                }
             }
         }
         _probeVersion.update { it + 1 }
     }
 
     private fun upsertProbeResult(serverId: Long, result: EndpointProbeResult) {
-        val server = serverConfigs[serverId]
-        val previousById = lastProbeResults[serverId]
-            .orEmpty()
-            .associateBy { it.endpoint.id }
-            .toMutableMap()
-        previousById[result.endpoint.id] = result
-        val orderedEndpoints = server?.endpoints?.sortedBy(ServerEndpoint::order).orEmpty()
-        lastProbeResults[serverId] = if (orderedEndpoints.isEmpty()) {
-            previousById.values.toList()
-        } else {
-            orderedEndpoints.mapNotNull { endpoint -> previousById[endpoint.id] }
+        synchronized(endpointStateLock(serverId)) {
+            val server = serverConfigs[serverId]
+            val previousById = lastProbeResults[serverId]
+                .orEmpty()
+                .associateBy { it.endpoint.id }
+                .toMutableMap()
+            previousById[result.endpoint.id] = result
+            val orderedEndpoints = server?.endpoints?.sortedBy(ServerEndpoint::order).orEmpty()
+            lastProbeResults[serverId] = if (orderedEndpoints.isEmpty()) {
+                previousById.values.toList()
+            } else {
+                orderedEndpoints.mapNotNull { endpoint -> previousById[endpoint.id] }
+            }
+        }
+    }
+
+    private fun endpointStateLock(serverId: Long): Any =
+        endpointStateLocks.computeIfAbsent(serverId) { Any() }
+
+    private fun scheduleOfflineRecovery(serverId: Long) {
+        offlineRecoveryJobs.compute(serverId) { _, existing ->
+            if (existing?.isActive == true) {
+                existing
+            } else {
+                scope.launch {
+                    try {
+                        var attempt = 0
+                        while (isOfflineDegraded(serverId)) {
+                            delay(endpointOfflineRecoveryDelayMs(attempt))
+                            val server = serverConfigs[serverId] ?: break
+                            if (!isOfflineDegraded(serverId)) break
+                            probe(serverId, server)
+                            attempt += 1
+                        }
+                    } finally {
+                        val currentJob = kotlin.coroutines.coroutineContext[Job]
+                        if (currentJob != null) {
+                            offlineRecoveryJobs.remove(serverId, currentJob)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun cancelOfflineRecoveryJobs() {
+        offlineRecoveryJobs.forEach { (serverId, job) ->
+            if (offlineRecoveryJobs.remove(serverId, job)) {
+                job.cancel()
+            }
         }
     }
 
@@ -404,3 +505,19 @@ class EndpointSelector @Inject constructor(
         }
     }
 }
+
+internal fun resolveEndpointReachability(
+    hasProbeLatency: Boolean,
+    succeededDuringProbe: Boolean,
+    probeCompleted: Boolean,
+    previousReachable: Boolean?,
+): Boolean? = when {
+    hasProbeLatency || succeededDuringProbe -> true
+    probeCompleted -> false
+    else -> previousReachable
+}
+
+private val EndpointOfflineRecoveryDelaysMs = longArrayOf(5_000L, 15_000L, 30_000L, 60_000L)
+
+internal fun endpointOfflineRecoveryDelayMs(attempt: Int): Long =
+    EndpointOfflineRecoveryDelaysMs[attempt.coerceIn(0, EndpointOfflineRecoveryDelaysMs.lastIndex)]

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -14,9 +14,11 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.ResolvingDataSource
+import androidx.media3.datasource.TransferListener
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.CacheWriter
 import androidx.media3.datasource.cache.SimpleCache
@@ -40,6 +42,7 @@ import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshot
 import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshotSource
 import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshotSourceType
 import org.hdhmc.saki.domain.model.PlaybackPreferences
+import org.hdhmc.saki.domain.model.ServerEndpoint
 import org.hdhmc.saki.domain.model.Song
 import org.hdhmc.saki.domain.model.SoundBalancingMode
 import org.hdhmc.saki.domain.model.StreamQuality
@@ -154,7 +157,38 @@ class SakiPlaybackService : MediaSessionService() {
         val upstreamDataSourceFactory = DefaultDataSource.Factory(
             this,
             OkHttpDataSource.Factory(okHttpClient)
-                .setUserAgent(HTTP_USER_AGENT),
+                .setUserAgent(HTTP_USER_AGENT)
+                .setTransferListener(object : TransferListener {
+                    override fun onTransferInitializing(
+                        source: DataSource,
+                        dataSpec: DataSpec,
+                        isNetwork: Boolean,
+                    ) = Unit
+
+                    override fun onTransferStart(
+                        source: DataSource,
+                        dataSpec: DataSpec,
+                        isNetwork: Boolean,
+                    ) {
+                        if (!isNetwork) return
+                        // Media3 invokes this only after the upstream data source opens successfully.
+                        val selection = dataSpec.customData as? StreamEndpointSelection ?: return
+                        endpointSelector.recordSuccess(selection.serverId, selection.endpoint)
+                    }
+
+                    override fun onBytesTransferred(
+                        source: DataSource,
+                        dataSpec: DataSpec,
+                        isNetwork: Boolean,
+                        bytesTransferred: Int,
+                    ) = Unit
+
+                    override fun onTransferEnd(
+                        source: DataSource,
+                        dataSpec: DataSpec,
+                        isNetwork: Boolean,
+                    ) = Unit
+                }),
         )
         val cacheFactory = CacheDataSource.Factory()
             .setCache(streamCache)
@@ -755,6 +789,11 @@ class SakiPlaybackService : MediaSessionService() {
         return streamCache.getCachedSpans(cacheKey).sumOf { span -> span.length }
     }
 
+    private data class StreamEndpointSelection(
+        val serverId: Long,
+        val endpoint: ServerEndpoint,
+    )
+
     private data class StreamPrefetchPlan(
         val key: String,
         val targets: List<StreamPrefetchTarget>,
@@ -832,11 +871,11 @@ class SakiPlaybackService : MediaSessionService() {
                 throw IOException("No stream candidates for song $songId on server $serverId")
             }
             val candidate = streamRequest.candidates.first()
-            endpointSelector.recordSuccess(serverId, candidate.endpoint)
             val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, requestedQuality)
             return dataSpec.buildUpon()
                 .setUri(candidate.url)
                 .setKey(cacheKey)
+                .setCustomData(StreamEndpointSelection(serverId, candidate.endpoint))
                 .build()
         }
 
@@ -848,13 +887,13 @@ class SakiPlaybackService : MediaSessionService() {
         }
 
         val candidate = streamRequest.candidates.first()
-        endpointSelector.recordSuccess(serverId, candidate.endpoint)
         val realUrl = candidate.url
         val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, quality)
 
         return dataSpec.buildUpon()
             .setUri(realUrl)
             .setKey(cachedResourceKey ?: cacheKey)
+            .setCustomData(StreamEndpointSelection(serverId, candidate.endpoint))
             .build()
     }
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -2705,7 +2705,6 @@ data class EndpointStatus(
     val isOfflineDegraded: Boolean
         get() = activeEndpointId == null &&
             isProbeComplete &&
-            !isProbing &&
             probeResults.isNotEmpty() &&
             probeResults.none { it.reachable }
 }

--- a/app/src/test/java/org/hdhmc/saki/data/remote/EndpointSelectorTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/data/remote/EndpointSelectorTest.kt
@@ -1,6 +1,8 @@
 package org.hdhmc.saki.data.remote
 
+import org.hdhmc.saki.domain.model.ServerEndpoint
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class EndpointSelectorTest {
@@ -30,6 +32,24 @@ class EndpointSelectorTest {
                 previousReachable = true,
             ),
         )
+    }
+
+    @Test
+    fun `invalidation after final publication clears the selected endpoint`() {
+        val endpoint = ServerEndpoint(
+            id = 7L,
+            label = "primary",
+            baseUrl = "https://example.test",
+        )
+        val publishedReachable = listOf(
+            EndpointSelector.EndpointProbeResult(endpoint, latencyMs = 10L, reachable = true),
+        )
+        val invalidated = listOf(
+            EndpointSelector.EndpointProbeResult(endpoint, latencyMs = null, reachable = false),
+        )
+
+        assertEquals(7L, bestReachableEndpointId(publishedReachable))
+        assertNull(bestReachableEndpointId(invalidated))
     }
 
     @Test

--- a/app/src/test/java/org/hdhmc/saki/data/remote/EndpointSelectorTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/data/remote/EndpointSelectorTest.kt
@@ -1,0 +1,37 @@
+package org.hdhmc.saki.data.remote
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EndpointSelectorTest {
+    @Test
+    fun `successful traffic wins over a concurrent failed probe`() {
+        assertEquals(
+            true,
+            resolveEndpointReachability(
+                hasProbeLatency = false,
+                succeededDuringProbe = true,
+                probeCompleted = true,
+                previousReachable = true,
+            ),
+        )
+        assertEquals(
+            false,
+            resolveEndpointReachability(
+                hasProbeLatency = false,
+                succeededDuringProbe = false,
+                probeCompleted = true,
+                previousReachable = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `offline recovery delay backs off and remains capped`() {
+        assertEquals(5_000L, endpointOfflineRecoveryDelayMs(0))
+        assertEquals(15_000L, endpointOfflineRecoveryDelayMs(1))
+        assertEquals(30_000L, endpointOfflineRecoveryDelayMs(2))
+        assertEquals(60_000L, endpointOfflineRecoveryDelayMs(3))
+        assertEquals(60_000L, endpointOfflineRecoveryDelayMs(100))
+    }
+}

--- a/app/src/test/java/org/hdhmc/saki/data/remote/EndpointSelectorTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/data/remote/EndpointSelectorTest.kt
@@ -1,11 +1,73 @@
 package org.hdhmc.saki.data.remote
 
+import android.content.ContextWrapper
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.ServerEndpoint
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class EndpointSelectorTest {
+    @Test
+    fun `concurrent probes replace active probe without stranding callers`() = runBlocking {
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val endpoint = ServerEndpoint(
+            id = 7L,
+            label = "primary",
+            baseUrl = mockServer.url("/").toString().trimEnd('/'),
+        )
+        val server = ServerConfig(
+            id = 3L,
+            name = "test",
+            username = "user",
+            password = "password",
+            endpoints = listOf(endpoint),
+        )
+        val selector = EndpointSelector(
+            context = ContextWrapper(null),
+            okHttpClient = OkHttpClient(),
+            ioDispatcher = Dispatchers.IO,
+        )
+        val probeCount = 32
+        repeat(probeCount) {
+            mockServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setHeadersDelay(200L, TimeUnit.MILLISECONDS),
+            )
+        }
+
+        try {
+            val startBarrier = CyclicBarrier(probeCount)
+            val probes = List(probeCount) {
+                async(Dispatchers.IO) {
+                    startBarrier.await(5L, TimeUnit.SECONDS)
+                    selector.probe(server.id, server)
+                }
+            }
+
+            val results = withTimeout(10_000L) { probes.awaitAll() }
+
+            assertEquals(probeCount, results.size)
+            assertTrue(results.any { result -> result?.id == endpoint.id })
+        } finally {
+            selector.unregisterServer(server.id)
+            mockServer.shutdown()
+        }
+    }
+
     @Test
     fun `newer invalidation wins over success and older probe completion`() {
         val probeStartVersion = 0L

--- a/app/src/test/java/org/hdhmc/saki/data/remote/EndpointSelectorTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/data/remote/EndpointSelectorTest.kt
@@ -5,21 +5,41 @@ import org.junit.Test
 
 class EndpointSelectorTest {
     @Test
-    fun `successful traffic wins over a concurrent failed probe`() {
+    fun `newer invalidation wins over success and older probe completion`() {
+        val probeStartVersion = 0L
+        val success = EndpointReachabilityEvent(version = 1L, reachable = true)
+        val invalidation = EndpointReachabilityEvent(version = 2L, reachable = false)
+
         assertEquals(
             true,
             resolveEndpointReachability(
                 hasProbeLatency = false,
-                succeededDuringProbe = true,
-                probeCompleted = true,
-                previousReachable = true,
+                latestEvent = success,
+                probeStartEventVersion = probeStartVersion,
+                probeCompleted = false,
+                previousReachable = false,
             ),
         )
         assertEquals(
             false,
             resolveEndpointReachability(
+                hasProbeLatency = true,
+                latestEvent = invalidation,
+                probeStartEventVersion = probeStartVersion,
+                probeCompleted = true,
+                previousReachable = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `probe ignores endpoint events older than its start`() {
+        assertEquals(
+            false,
+            resolveEndpointReachability(
                 hasProbeLatency = false,
-                succeededDuringProbe = false,
+                latestEvent = EndpointReachabilityEvent(version = 4L, reachable = true),
+                probeStartEventVersion = 4L,
                 probeCompleted = true,
                 previousReachable = true,
             ),

--- a/app/src/test/java/org/hdhmc/saki/presentation/EndpointStatusTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/presentation/EndpointStatusTest.kt
@@ -1,0 +1,46 @@
+package org.hdhmc.saki.presentation
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EndpointStatusTest {
+    @Test
+    fun `offline degraded remains active while a background recovery probe runs`() {
+        val status = EndpointStatus(
+            isProbing = true,
+            isProbeComplete = true,
+            probeResults = listOf(
+                EndpointProbeInfo(
+                    id = 1L,
+                    label = "Primary",
+                    baseUrl = "https://music.example.test",
+                    latencyMs = null,
+                    reachable = false,
+                ),
+            ),
+        )
+
+        assertTrue(status.isOfflineDegraded)
+    }
+
+    @Test
+    fun `reachable endpoint clears offline degraded during recovery`() {
+        val status = EndpointStatus(
+            activeEndpointId = 1L,
+            isProbing = true,
+            isProbeComplete = true,
+            probeResults = listOf(
+                EndpointProbeInfo(
+                    id = 1L,
+                    label = "Primary",
+                    baseUrl = "https://music.example.test",
+                    latencyMs = 12L,
+                    reachable = true,
+                ),
+            ),
+        )
+
+        assertFalse(status.isOfflineDegraded)
+    }
+}


### PR DESCRIPTION
## Summary
- keep successful API/playback traffic from being overwritten by an older failed endpoint probe
- add automatic degraded-mode endpoint recovery with capped 5s/15s/30s/60s backoff
- keep offline restrictions stable while a background recovery probe runs, avoiding UI availability flicker
- clean up active probes and recovery jobs when servers or network state change

## Root cause
Endpoint probes only retried for a finite window after network changes. If routing, DNS, or the server recovered after that window without another Android network callback, the selector retained an all-unreachable result indefinitely. Startup could also run normal API traffic concurrently with endpoint pings, allowing a late failed ping to overwrite a newer successful request. Manual reprobe from Now Playing worked because it started a new probe generation.

## Validation
- `./gradlew testDebugUnitTest --no-daemon --max-workers=2 -Dorg.gradle.parallel=false`
- focused endpoint merge, recovery backoff, and degraded-state tests
- `./gradlew assembleRelease --no-daemon --max-workers=1 -Dorg.gradle.parallel=false`
- `git diff --check`

The Release APK was built successfully. Device installation was not repeated because the `.90` ADB target was offline/unreachable at validation time.