### PR TITLE
fix: restore seeking and duration for transcoded streams

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultStreamCacheRepository.kt
@@ -11,6 +11,7 @@ import org.hdhmc.saki.domain.model.StreamQuality
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
 import org.hdhmc.saki.domain.repository.StreamCacheRepository
 import org.hdhmc.saki.playback.ConfigurableLeastRecentlyUsedCacheEvictor
+import org.hdhmc.saki.playback.STREAM_CACHE_EOF_LENGTH_METADATA_KEY
 import org.hdhmc.saki.playback.buildStreamCacheKey
 import org.hdhmc.saki.playback.parseStreamCacheKey
 import dagger.Lazy
@@ -124,9 +125,8 @@ class DefaultStreamCacheRepository @Inject constructor(
         quality: StreamQuality,
     ): StreamCacheProgress? {
         val cacheKey = buildStreamCacheKey(serverId, songId, quality)
-        val contentLength = ContentMetadata.getContentLength(streamCache.getContentMetadata(cacheKey))
-            .takeIf { length -> length != C.LENGTH_UNSET.toLong() && length > 0L }
-            ?: return null
+        val metadata = streamCache.getContentMetadata(cacheKey)
+        val contentLength = completeStreamLength(metadata) ?: return null
         val cachedPrefixBytes = streamCache.getCachedLength(cacheKey, 0L, contentLength)
             .takeIf { length -> length > 0L }
             ?.coerceAtMost(contentLength)
@@ -201,15 +201,8 @@ class DefaultStreamCacheRepository @Inject constructor(
             val cachedBytes = streamCache.getCachedSpans(key).sumOf { span -> span.length }
             bytesByServer[parsed.serverId] = (bytesByServer[parsed.serverId] ?: 0L) + cachedBytes
 
-            val contentLength = ContentMetadata.getContentLength(streamCache.getContentMetadata(key))
-            val isFullyCached = if (contentLength != C.LENGTH_UNSET.toLong() && contentLength > 0L) {
-                streamCache.isCached(key, 0, contentLength)
-            } else {
-                // No Content-Length (e.g. transcoded stream): consider cached if the
-                // resource has a contiguous cached prefix starting at 0. SimpleCache
-                // may split a completed CacheWriter result into multiple spans.
-                hasContiguousCachedPrefix(key)
-            }
+            val completeLength = completeStreamLength(streamCache.getContentMetadata(key))
+            val isFullyCached = completeLength != null && streamCache.isCached(key, 0L, completeLength)
             if (isFullyCached) {
                 cachedSongIdsByServerAndQuality
                     .getOrPut(parsed.serverId) { mutableMapOf() }
@@ -226,20 +219,11 @@ class DefaultStreamCacheRepository @Inject constructor(
         )
     }
 
-    private fun hasContiguousCachedPrefix(key: String): Boolean {
-        val spans = streamCache.getCachedSpans(key).sortedBy { span -> span.position }
-        if (spans.isEmpty() || spans.first().position != 0L) return false
-
-        var coveredUntil = 0L
-        for (span in spans) {
-            if (span.length <= 0L) continue
-            if (span.position > coveredUntil) return false
-            val spanEnd = span.position + span.length
-            if (spanEnd > coveredUntil) {
-                coveredUntil = spanEnd
-            }
-        }
-        return coveredUntil > 0L
+    private fun completeStreamLength(metadata: ContentMetadata): Long? {
+        val contentLength = ContentMetadata.getContentLength(metadata)
+            .takeIf { length -> length != C.LENGTH_UNSET.toLong() && length > 0L }
+        return contentLength ?: metadata.get(STREAM_CACHE_EOF_LENGTH_METADATA_KEY, C.LENGTH_UNSET.toLong())
+            .takeIf { length -> length != C.LENGTH_UNSET.toLong() && length > 0L }
     }
 }
 

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultSubsonicRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultSubsonicRepository.kt
@@ -270,6 +270,7 @@ class DefaultSubsonicRepository @Inject constructor(
         songId: String,
         maxBitRate: Int?,
         format: String?,
+        timeOffsetSeconds: Int?,
     ): SubsonicStreamRequest = withContext(ioDispatcher) {
         SubsonicStreamRequest(
             songId = songId,
@@ -280,6 +281,7 @@ class DefaultSubsonicRepository @Inject constructor(
                     "id" to songId,
                     "maxBitRate" to maxBitRate?.toString(),
                     "format" to format,
+                    "timeOffset" to timeOffsetSeconds?.takeIf { it > 0 }?.toString(),
                 ),
             ),
         )

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/SubsonicRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/SubsonicRepository.kt
@@ -88,6 +88,7 @@ interface SubsonicRepository {
         songId: String,
         maxBitRate: Int? = null,
         format: String? = null,
+        timeOffsetSeconds: Int? = null,
     ): SubsonicStreamRequest
 
     suspend fun buildDownloadRequest(

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -22,6 +22,7 @@ import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.TransferListener
 import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.ContentMetadataMutations
 import androidx.media3.datasource.cache.CacheWriter
 import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.datasource.okhttp.OkHttpDataSource
@@ -99,6 +100,52 @@ private fun String.forStreamOffset(timeOffsetSeconds: Int?): String =
 private fun Int.forStreamOffset(timeOffsetSeconds: Int?): Int =
     if (timeOffsetSeconds == null) this else this or DataSpec.FLAG_DONT_CACHE_IF_LENGTH_UNKNOWN
 
+private class EofTrackingDataSource(
+    private val upstream: DataSource,
+    private val onEof: (DataSpec, Long) -> Unit,
+) : DataSource {
+    private var openedDataSpec: DataSpec? = null
+    private var bytesRead = 0L
+    private var reportedEof = false
+
+    override fun addTransferListener(transferListener: TransferListener) {
+        upstream.addTransferListener(transferListener)
+    }
+
+    override fun open(dataSpec: DataSpec): Long {
+        openedDataSpec = dataSpec
+        bytesRead = 0L
+        reportedEof = false
+        return upstream.open(dataSpec)
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        val read = upstream.read(buffer, offset, length)
+        if (read == C.RESULT_END_OF_INPUT) {
+            val dataSpec = openedDataSpec
+            if (!reportedEof && dataSpec != null) {
+                reportedEof = true
+                onEof(dataSpec, dataSpec.position + bytesRead)
+            }
+        } else if (read > 0) {
+            bytesRead += read
+        }
+        return read
+    }
+
+    override fun getUri(): Uri? = upstream.uri
+
+    override fun getResponseHeaders(): Map<String, List<String>> = upstream.responseHeaders
+
+    override fun close() {
+        try {
+            upstream.close()
+        } finally {
+            openedDataSpec = null
+        }
+    }
+}
+
 private data class ActiveServerSeek(
     val mediaItemIndex: Int,
     val serverId: Long,
@@ -109,6 +156,12 @@ private data class ActiveServerSeek(
 internal fun shouldPauseOffsetStreamAtEnd(repeatMode: Int, mediaItemCount: Int): Boolean =
     repeatMode == Player.REPEAT_MODE_ONE ||
         (repeatMode == Player.REPEAT_MODE_ALL && mediaItemCount == 1)
+
+internal fun isConfirmedTranscode(sourceBitRate: Int?, requestedBitRate: Int?): Boolean {
+    val source = sourceBitRate?.takeIf { it > 0 } ?: return false
+    val requested = requestedBitRate?.takeIf { it > 0 } ?: return false
+    return source > requested
+}
 
 @AndroidEntryPoint
 @UnstableApi
@@ -180,41 +233,44 @@ class SakiPlaybackService : MediaSessionService() {
             .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
             .build()
 
+        val httpDataSourceFactory = OkHttpDataSource.Factory(okHttpClient)
+            .setUserAgent(HTTP_USER_AGENT)
+            .setTransferListener(object : TransferListener {
+                override fun onTransferInitializing(
+                    source: DataSource,
+                    dataSpec: DataSpec,
+                    isNetwork: Boolean,
+                ) = Unit
+
+                override fun onTransferStart(
+                    source: DataSource,
+                    dataSpec: DataSpec,
+                    isNetwork: Boolean,
+                ) {
+                    if (!isNetwork) return
+                    // Media3 invokes this only after the upstream data source opens successfully.
+                    val selection = dataSpec.customData as? StreamEndpointSelection ?: return
+                    endpointSelector.recordSuccess(selection.serverId, selection.endpoint)
+                }
+
+                override fun onBytesTransferred(
+                    source: DataSource,
+                    dataSpec: DataSpec,
+                    isNetwork: Boolean,
+                    bytesTransferred: Int,
+                ) = Unit
+
+                override fun onTransferEnd(
+                    source: DataSource,
+                    dataSpec: DataSpec,
+                    isNetwork: Boolean,
+                ) = Unit
+            })
         val upstreamDataSourceFactory = DefaultDataSource.Factory(
             this,
-            OkHttpDataSource.Factory(okHttpClient)
-                .setUserAgent(HTTP_USER_AGENT)
-                .setTransferListener(object : TransferListener {
-                    override fun onTransferInitializing(
-                        source: DataSource,
-                        dataSpec: DataSpec,
-                        isNetwork: Boolean,
-                    ) = Unit
-
-                    override fun onTransferStart(
-                        source: DataSource,
-                        dataSpec: DataSpec,
-                        isNetwork: Boolean,
-                    ) {
-                        if (!isNetwork) return
-                        // Media3 invokes this only after the upstream data source opens successfully.
-                        val selection = dataSpec.customData as? StreamEndpointSelection ?: return
-                        endpointSelector.recordSuccess(selection.serverId, selection.endpoint)
-                    }
-
-                    override fun onBytesTransferred(
-                        source: DataSource,
-                        dataSpec: DataSpec,
-                        isNetwork: Boolean,
-                        bytesTransferred: Int,
-                    ) = Unit
-
-                    override fun onTransferEnd(
-                        source: DataSource,
-                        dataSpec: DataSpec,
-                        isNetwork: Boolean,
-                    ) = Unit
-                }),
+            DataSource.Factory {
+                EofTrackingDataSource(httpDataSourceFactory.createDataSource(), ::recordStreamCacheEof)
+            },
         )
         val cacheFactory = CacheDataSource.Factory()
             .setCache(streamCache)
@@ -868,6 +924,21 @@ class SakiPlaybackService : MediaSessionService() {
         fun planKey(): String = "$serverId:$songId:$qualityKey"
     }
 
+    private fun recordStreamCacheEof(dataSpec: DataSpec, eofPosition: Long) {
+        val cacheKey = dataSpec.key ?: return
+        if (eofPosition <= 0L || parseStreamCacheKey(cacheKey) == null) return
+        runCatching {
+            streamCache.applyContentMetadataMutations(
+                cacheKey,
+                ContentMetadataMutations().set(STREAM_CACHE_EOF_LENGTH_METADATA_KEY, eofPosition),
+            )
+        }.onSuccess {
+            streamCacheRepository.requestSnapshotRefresh()
+        }.onFailure { throwable ->
+            Log.w(STREAM_PREFETCH_LOG_TAG, "Failed to record stream cache EOF for $cacheKey", throwable)
+        }
+    }
+
     /**
      * Resolves placeholder `saki://stream` URIs to real Subsonic stream URLs at the moment
      * ExoPlayer actually opens the data source. This ensures the quality and endpoint are
@@ -1049,6 +1120,7 @@ class SakiPlaybackService : MediaSessionService() {
                 Player.COMMAND_SEEK_BACK,
                 Player.COMMAND_SEEK_FORWARD,
                 Player.COMMAND_SEEK_TO_DEFAULT_POSITION,
+                Player.COMMAND_SEEK_TO_PREVIOUS,
                 Player.COMMAND_SEEK_TO_MEDIA_ITEM,
                 -> true
                 else -> false
@@ -1189,11 +1261,8 @@ class SakiPlaybackService : MediaSessionService() {
         activePlayer.playWhenReady = shouldResume
     }
 
-    private fun PlaybackRequest.supportsServerSideSeek(): Boolean {
-        if (isCached) return false
-        val requestedBitRate = maxBitRate?.takeIf { it > 0 } ?: return false
-        return sourceBitRate?.let { it > requestedBitRate } ?: true
-    }
+    private fun PlaybackRequest.supportsServerSideSeek(): Boolean =
+        !isCached && isConfirmedTranscode(sourceBitRate, maxBitRate)
 
     private fun shouldPreferLocalStreamCache(serverId: Long): Boolean {
         return endpointSelector.isOfflineDegraded(serverId)

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -155,6 +155,7 @@ private data class ActiveServerSeek(
     val serverId: Long,
     val songId: String,
     val offsetMs: Long,
+    val streamQuality: StreamQuality,
 )
 
 internal fun shouldPauseOffsetStreamAtEnd(repeatMode: Int, mediaItemCount: Int): Boolean =
@@ -166,6 +167,15 @@ internal fun isConfirmedTranscode(sourceBitRate: Int?, requestedBitRate: Int?): 
     val requested = requestedBitRate?.takeIf { it > 0 } ?: return false
     return source > requested
 }
+
+internal fun supportsTranscodedServerSeek(
+    isCached: Boolean,
+    sourceBitRate: Int?,
+    openedStreamQuality: StreamQuality?,
+): Boolean =
+    !isCached &&
+        openedStreamQuality != null &&
+        isConfirmedTranscode(sourceBitRate, openedStreamQuality.maxBitRate)
 
 internal fun selectEffectiveStreamQuality(
     prefs: PlaybackPreferences,
@@ -242,6 +252,7 @@ class SakiPlaybackService : MediaSessionService() {
     private var activeStreamCacheWriter: CacheWriter? = null
     @Volatile
     private var activeServerSeek: ActiveServerSeek? = null
+    private val openedStreamQualities = ConcurrentHashMap<String, StreamQuality>()
     private var pauseAtEndBeforeServerSeek: Boolean? = null
 
     override fun onCreate() {
@@ -270,6 +281,7 @@ class SakiPlaybackService : MediaSessionService() {
                     // Media3 invokes this only after the upstream data source opens successfully.
                     val selection = dataSpec.customData as? StreamEndpointSelection ?: return
                     endpointSelector.recordSuccess(selection.serverId, selection.endpoint)
+                    openedStreamQualities[selection.placeholderUri] = selection.streamQuality
                 }
 
                 override fun onBytesTransferred(
@@ -789,6 +801,9 @@ class SakiPlaybackService : MediaSessionService() {
     private fun ExoPlayer.logicalCurrentPositionMs(): Long =
         currentPosition.coerceAtLeast(0L) + currentStreamOffsetMs()
 
+    private fun MediaItem.openedStreamQuality(): StreamQuality? =
+        localConfiguration?.uri?.toString()?.let(openedStreamQualities::get)
+
     private fun ExoPlayer.durationForPrefetchMs(
         index: Int,
         mediaItem: MediaItem,
@@ -917,6 +932,8 @@ class SakiPlaybackService : MediaSessionService() {
     private data class StreamEndpointSelection(
         val serverId: Long,
         val endpoint: ServerEndpoint,
+        val placeholderUri: String,
+        val streamQuality: StreamQuality,
     )
 
     private data class StreamPrefetchPlan(
@@ -975,8 +992,9 @@ class SakiPlaybackService : MediaSessionService() {
             ?: throw IOException("Missing serverId in stream placeholder URI")
         val songId = uri.getQueryParameter("songId")
             ?: throw IOException("Missing songId in stream placeholder URI")
-        val timeOffsetSeconds = activeServerSeek
+        val activeSeek = activeServerSeek
             ?.takeIf { seek -> seek.serverId == serverId && seek.songId == songId }
+        val timeOffsetSeconds = activeSeek
             ?.offsetMs
             ?.div(1_000L)
             ?.toInt()
@@ -984,7 +1002,7 @@ class SakiPlaybackService : MediaSessionService() {
 
         // Use cached prefs to avoid blocking; fall back to blocking read if not yet available
         val prefs = cachedPlaybackPrefs ?: runBlocking { playbackPreferencesRepository.getPreferences() }
-        val requestedQuality = requestedStreamQuality(
+        val requestedQuality = activeSeek?.streamQuality ?: requestedStreamQuality(
             prefs = prefs,
             fallbackMaxBitRate = uri.getQueryParameter("maxBitRate")?.toIntOrNull(),
         )
@@ -1000,6 +1018,7 @@ class SakiPlaybackService : MediaSessionService() {
             streamCacheRepository.buildCacheKey(serverId, songId, quality)
         }
         if (allowCachedResource && preferLocalCache && cachedResourceKey != null) {
+            openedStreamQualities.remove(uri.toString())
             return dataSpec.buildUpon()
                 .setUri(cachedStreamUri(cachedResourceKey))
                 .setKey(cachedResourceKey)
@@ -1027,7 +1046,14 @@ class SakiPlaybackService : MediaSessionService() {
                 .setUri(candidate.url)
                 .setKey(cacheKey.forStreamOffset(timeOffsetSeconds))
                 .setFlags(dataSpec.flags.forStreamOffset(timeOffsetSeconds))
-                .setCustomData(StreamEndpointSelection(serverId, candidate.endpoint))
+                .setCustomData(
+                    StreamEndpointSelection(
+                        serverId = serverId,
+                        endpoint = candidate.endpoint,
+                        placeholderUri = uri.toString(),
+                        streamQuality = requestedQuality,
+                    ),
+                )
                 .build()
         }
 
@@ -1052,7 +1078,14 @@ class SakiPlaybackService : MediaSessionService() {
             .setUri(realUrl)
             .setKey((cachedResourceKey ?: cacheKey).forStreamOffset(timeOffsetSeconds))
             .setFlags(dataSpec.flags.forStreamOffset(timeOffsetSeconds))
-            .setCustomData(StreamEndpointSelection(serverId, candidate.endpoint))
+            .setCustomData(
+                StreamEndpointSelection(
+                    serverId = serverId,
+                    endpoint = candidate.endpoint,
+                    placeholderUri = uri.toString(),
+                    streamQuality = quality,
+                ),
+            )
             .build()
     }
 
@@ -1063,15 +1096,20 @@ class SakiPlaybackService : MediaSessionService() {
             val state = super.getState()
             val currentItem = exoPlayer.currentMediaItem
             val currentRequest = currentItem?.toPlaybackRequestOrNull()
-            val exposesServerSideSeek = currentRequest?.supportsServerSideSeek() == true &&
+            val openedQuality = currentItem?.openedStreamQuality()
+            val exposesServerSideSeek = currentRequest?.supportsServerSideSeek(openedQuality) == true &&
                 currentItem.metadataDurationMs() != null
             val stateBuilder = state.buildUpon()
                 .setPlaylist(
-                    state.playlist.map { itemData ->
+                    state.playlist.mapIndexed { index, itemData ->
                         val item = itemData.mediaItem
                         val request = item.toPlaybackRequestOrNull()
                         val durationMs = item.metadataDurationMs()
-                        if (request?.supportsServerSideSeek() == true && durationMs != null) {
+                        if (
+                            index == exoPlayer.currentMediaItemIndex &&
+                            request?.supportsServerSideSeek(openedQuality) == true &&
+                            durationMs != null
+                        ) {
                             itemData.buildUpon()
                                 .setLiveConfiguration(null)
                                 .setPresentationStartTimeMs(C.TIME_UNSET)
@@ -1151,9 +1189,8 @@ class SakiPlaybackService : MediaSessionService() {
             if (mediaItemIndex == C.INDEX_UNSET) return false
             val item = exoPlayer.currentMediaItem ?: return false
             val request = item.toPlaybackRequestOrNull() ?: return false
-            val prefs = cachedPlaybackPrefs ?: return false
-            val preferredQuality = request.requestedStreamQuality(prefs)
-            if (!request.supportsServerSideSeek(preferredQuality)) return false
+            val openedQuality = item.openedStreamQuality() ?: return false
+            if (!request.supportsServerSideSeek(openedQuality)) return false
 
             val durationMs = item.metadataDurationMs() ?: return false
             val targetPositionMs = requestedPositionMs
@@ -1181,6 +1218,7 @@ class SakiPlaybackService : MediaSessionService() {
                         serverId = request.serverId,
                         songId = request.songId,
                         offsetMs = serverOffsetMs,
+                        streamQuality = openedQuality,
                     )
                 } else {
                     null
@@ -1275,13 +1313,8 @@ class SakiPlaybackService : MediaSessionService() {
         activePlayer.playWhenReady = shouldResume
     }
 
-    private fun PlaybackRequest.supportsServerSideSeek(): Boolean {
-        val prefs = cachedPlaybackPrefs ?: return false
-        return supportsServerSideSeek(requestedStreamQuality(prefs))
-    }
-
-    private fun PlaybackRequest.supportsServerSideSeek(quality: StreamQuality): Boolean =
-        !isCached && isConfirmedTranscode(sourceBitRate, quality.maxBitRate)
+    private fun PlaybackRequest.supportsServerSideSeek(quality: StreamQuality?): Boolean =
+        supportsTranscodedServerSeek(isCached, sourceBitRate, quality)
 
     private fun shouldPreferLocalStreamCache(serverId: Long): Boolean {
         return endpointSelector.isOfflineDegraded(serverId)
@@ -1311,6 +1344,7 @@ class SakiPlaybackService : MediaSessionService() {
     override fun onDestroy() {
         savePlayQueue(immediate = true)
         cancelStreamPrefetch()
+        openedStreamQualities.clear()
         releaseSoundBalancingEffect()
 
         mediaSession?.release()

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -9,9 +9,11 @@ import android.os.SystemClock
 import android.util.Log
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.ForwardingSimpleBasePlayer
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.SimpleBasePlayer
 import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
@@ -49,6 +51,7 @@ import org.hdhmc.saki.domain.model.StreamQuality
 import org.hdhmc.saki.domain.repository.LocalPlayQueueRepository
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
 import org.hdhmc.saki.domain.repository.SubsonicRepository
+import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import dagger.hilt.android.AndroidEntryPoint
@@ -86,6 +89,26 @@ private const val STREAM_PREFETCH_RETRY_DELAY_MS = 30_000L
 private fun Long.coerceKnownDuration(): Long? {
     return takeIf { it != C.TIME_UNSET && it > 0L }
 }
+
+private fun Long.toWholeSecondOffsetMs(): Long =
+    coerceAtLeast(0L).div(1_000L).times(1_000L)
+
+private fun String.forStreamOffset(timeOffsetSeconds: Int?): String =
+    timeOffsetSeconds?.let { offset -> "$this|seek=$offset" } ?: this
+
+private fun Int.forStreamOffset(timeOffsetSeconds: Int?): Int =
+    if (timeOffsetSeconds == null) this else this or DataSpec.FLAG_DONT_CACHE_IF_LENGTH_UNKNOWN
+
+private data class ActiveServerSeek(
+    val mediaItemIndex: Int,
+    val serverId: Long,
+    val songId: String,
+    val offsetMs: Long,
+)
+
+internal fun shouldPauseOffsetStreamAtEnd(repeatMode: Int, mediaItemCount: Int): Boolean =
+    repeatMode == Player.REPEAT_MODE_ONE ||
+        (repeatMode == Player.REPEAT_MODE_ALL && mediaItemCount == 1)
 
 @AndroidEntryPoint
 @UnstableApi
@@ -145,6 +168,9 @@ class SakiPlaybackService : MediaSessionService() {
     private val deferredStreamPrefetchTargets = ConcurrentHashMap<StreamPrefetchTargetKey, Long>()
     @Volatile
     private var activeStreamCacheWriter: CacheWriter? = null
+    @Volatile
+    private var activeServerSeek: ActiveServerSeek? = null
+    private var pauseAtEndBeforeServerSeek: Boolean? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -243,6 +269,7 @@ class SakiPlaybackService : MediaSessionService() {
                 addListener(PlayQueueSaveListener())
                 addListener(NotificationMediaButtonListener())
                 addListener(StreamPrefetchListener())
+                addListener(ServerSeekStateListener())
                 addListener(object : Player.Listener {
                     override fun onTimelineChanged(timeline: androidx.media3.common.Timeline, reason: Int) {
                         val pending = pendingShuffleOrder ?: return
@@ -265,7 +292,7 @@ class SakiPlaybackService : MediaSessionService() {
         )
 
         player = exoPlayer
-        mediaSession = MediaSession.Builder(this, exoPlayer)
+        mediaSession = MediaSession.Builder(this, SakiSessionPlayer(exoPlayer))
             .setSessionActivity(sessionActivity)
             .setCallback(SakiMediaSessionCallback())
             .setBitmapLoader(CoilBitmapLoader(this))
@@ -290,7 +317,11 @@ class SakiPlaybackService : MediaSessionService() {
                 // Keep preload in sync with the same live state the prefetch planner uses, so a
                 // mid-session switch into CUSTOM-long mode can't run prefetch while preload is
                 // still on (which would reintroduce the cache-key contention).
-                player?.preloadConfiguration = preloadConfigurationFor(prefs)
+                player?.preloadConfiguration = if (activeServerSeek == null) {
+                    preloadConfigurationFor(prefs)
+                } else {
+                    ExoPlayer.PreloadConfiguration.DEFAULT
+                }
                 syncCurrentStreamPrefetch()
             }
         }
@@ -323,7 +354,7 @@ class SakiPlaybackService : MediaSessionService() {
                                 continue
                             }
                             mediaSession ?: break
-                            val positionMs = activePlayer.currentPosition
+                            val positionMs = activePlayer.logicalCurrentPositionMs()
                             val lines = lyrics.lines
                             val index = lines.binarySearchLastBefore(positionMs)
                             val text = if (index >= 0) lines[index].text.takeIf { it.isNotBlank() } else null
@@ -610,7 +641,7 @@ class SakiPlaybackService : MediaSessionService() {
                 request = request,
                 window = window,
             )
-            val positionMs = if (index == currentIndex) currentPosition.coerceAtLeast(0L) else 0L
+            val positionMs = if (index == currentIndex) logicalCurrentPositionMs() else 0L
             val remainingTrackMs = durationMs
                 ?.minus(positionMs)
                 ?.coerceAtLeast(0L)
@@ -668,12 +699,30 @@ class SakiPlaybackService : MediaSessionService() {
         )
     }
 
+    private fun ExoPlayer.currentStreamOffsetMs(): Long {
+        val activeSeek = activeServerSeek ?: return 0L
+        if (currentMediaItemIndex != activeSeek.mediaItemIndex) return 0L
+        val request = currentMediaItem?.toPlaybackRequestOrNull() ?: return 0L
+        return if (request.serverId == activeSeek.serverId && request.songId == activeSeek.songId) {
+            activeSeek.offsetMs
+        } else {
+            0L
+        }
+    }
+
+    private fun ExoPlayer.logicalCurrentPositionMs(): Long =
+        currentPosition.coerceAtLeast(0L) + currentStreamOffsetMs()
+
     private fun ExoPlayer.durationForPrefetchMs(
         index: Int,
         mediaItem: MediaItem,
         request: PlaybackRequest,
         window: Timeline.Window,
     ): Long? {
+        if (index == currentMediaItemIndex && currentStreamOffsetMs() > 0L) {
+            return request.durationMs?.coerceKnownDuration()
+                ?: mediaItem.metadataDurationMs()
+        }
         val playerDuration = if (index == currentMediaItemIndex) {
             duration.coerceKnownDuration()
         } else {
@@ -835,6 +884,12 @@ class SakiPlaybackService : MediaSessionService() {
             ?: throw IOException("Missing serverId in stream placeholder URI")
         val songId = uri.getQueryParameter("songId")
             ?: throw IOException("Missing songId in stream placeholder URI")
+        val timeOffsetSeconds = activeServerSeek
+            ?.takeIf { seek -> seek.serverId == serverId && seek.songId == songId }
+            ?.offsetMs
+            ?.div(1_000L)
+            ?.toInt()
+            ?.takeIf { it > 0 }
 
         // Use cached prefs to avoid blocking; fall back to blocking read if not yet available
         val prefs = cachedPlaybackPrefs ?: runBlocking { playbackPreferencesRepository.getPreferences() }
@@ -849,7 +904,11 @@ class SakiPlaybackService : MediaSessionService() {
         }
         val preferLocalCache = shouldPreferLocalStreamCache(serverId)
         val cacheLookupQuality = if (preferLocalCache) StreamQuality.entries.last() else requestedQuality
-        val cachedQualityKey = streamCacheRepository.findCachedQualityKey(serverId, songId, cacheLookupQuality)
+        val cachedQualityKey = if (timeOffsetSeconds == null) {
+            streamCacheRepository.findCachedQualityKey(serverId, songId, cacheLookupQuality)
+        } else {
+            null
+        }
         val cachedQuality = cachedQualityKey?.let { key -> StreamQuality.fromStorageKey(key) }
         val cachedResourceKey = cachedQuality?.let { quality ->
             streamCacheRepository.buildCacheKey(serverId, songId, quality)
@@ -865,7 +924,13 @@ class SakiPlaybackService : MediaSessionService() {
         val format = uri.getQueryParameter("format")
         if (!prefs.adaptiveQualityEnabled && cachedResourceKey == null && format != null && format != requestedQuality.format) {
             val streamRequest = runBlocking {
-                subsonicRepository.buildStreamRequest(serverId, songId, requestedQuality.maxBitRate, format)
+                subsonicRepository.buildStreamRequest(
+                    serverId = serverId,
+                    songId = songId,
+                    maxBitRate = requestedQuality.maxBitRate,
+                    format = format,
+                    timeOffsetSeconds = timeOffsetSeconds,
+                )
             }
             if (streamRequest.candidates.isEmpty()) {
                 throw IOException("No stream candidates for song $songId on server $serverId")
@@ -874,13 +939,20 @@ class SakiPlaybackService : MediaSessionService() {
             val cacheKey = streamCacheRepository.buildCacheKey(serverId, songId, requestedQuality)
             return dataSpec.buildUpon()
                 .setUri(candidate.url)
-                .setKey(cacheKey)
+                .setKey(cacheKey.forStreamOffset(timeOffsetSeconds))
+                .setFlags(dataSpec.flags.forStreamOffset(timeOffsetSeconds))
                 .setCustomData(StreamEndpointSelection(serverId, candidate.endpoint))
                 .build()
         }
 
         val streamRequest = runBlocking {
-            subsonicRepository.buildStreamRequest(serverId, songId, quality.maxBitRate, quality.format)
+            subsonicRepository.buildStreamRequest(
+                serverId = serverId,
+                songId = songId,
+                maxBitRate = quality.maxBitRate,
+                format = quality.format,
+                timeOffsetSeconds = timeOffsetSeconds,
+            )
         }
         if (streamRequest.candidates.isEmpty()) {
             throw IOException("No stream candidates for song $songId on server $serverId")
@@ -892,9 +964,235 @@ class SakiPlaybackService : MediaSessionService() {
 
         return dataSpec.buildUpon()
             .setUri(realUrl)
-            .setKey(cachedResourceKey ?: cacheKey)
+            .setKey((cachedResourceKey ?: cacheKey).forStreamOffset(timeOffsetSeconds))
+            .setFlags(dataSpec.flags.forStreamOffset(timeOffsetSeconds))
             .setCustomData(StreamEndpointSelection(serverId, candidate.endpoint))
             .build()
+    }
+
+    private inner class SakiSessionPlayer(
+        private val exoPlayer: ExoPlayer,
+    ) : ForwardingSimpleBasePlayer(exoPlayer) {
+        override fun getState(): SimpleBasePlayer.State {
+            val state = super.getState()
+            val currentItem = exoPlayer.currentMediaItem
+            val currentRequest = currentItem?.toPlaybackRequestOrNull()
+            val exposesServerSideSeek = currentRequest?.supportsServerSideSeek() == true &&
+                currentItem.metadataDurationMs() != null
+            val stateBuilder = state.buildUpon()
+                .setPlaylist(
+                    state.playlist.map { itemData ->
+                        val item = itemData.mediaItem
+                        val request = item.toPlaybackRequestOrNull()
+                        val durationMs = item.metadataDurationMs()
+                        if (request?.supportsServerSideSeek() == true && durationMs != null) {
+                            itemData.buildUpon()
+                                .setLiveConfiguration(null)
+                                .setPresentationStartTimeMs(C.TIME_UNSET)
+                                .setWindowStartTimeMs(C.TIME_UNSET)
+                                .setElapsedRealtimeEpochOffsetMs(C.TIME_UNSET)
+                                .setIsDynamic(false)
+                                .setIsSeekable(true)
+                                .setDurationUs(durationMs * 1_000L)
+                                .setPeriods(emptyList())
+                                .build()
+                        } else {
+                            itemData
+                        }
+                    },
+                )
+
+            if (!exposesServerSideSeek) {
+                return stateBuilder.build()
+            }
+
+            val logicalDurationMs = currentItem.metadataDurationMs()!!
+            val logicalPosition = SimpleBasePlayer.PositionSupplier {
+                exoPlayer.logicalCurrentPositionMs().coerceAtMost(logicalDurationMs)
+            }
+            val logicalBufferedPosition = SimpleBasePlayer.PositionSupplier {
+                (exoPlayer.contentBufferedPosition.coerceAtLeast(0L) + exoPlayer.currentStreamOffsetMs())
+                    .coerceAtMost(logicalDurationMs)
+            }
+            stateBuilder
+                .setAvailableCommands(
+                    state.availableCommands.buildUpon()
+                        .add(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
+                        .add(Player.COMMAND_GET_TIMELINE)
+                        .add(Player.COMMAND_GET_METADATA)
+                        .add(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+                        .add(Player.COMMAND_SEEK_BACK)
+                        .add(Player.COMMAND_SEEK_FORWARD)
+                        .build(),
+                )
+                .setContentPositionMs(logicalPosition)
+                .setContentBufferedPositionMs(logicalBufferedPosition)
+            if (state.hasPositionDiscontinuity) {
+                stateBuilder.setPositionDiscontinuity(
+                    state.positionDiscontinuityReason,
+                    (state.discontinuityPositionMs + exoPlayer.currentStreamOffsetMs())
+                        .coerceAtMost(logicalDurationMs),
+                )
+            }
+            return stateBuilder.build()
+        }
+
+        override fun handleSeek(
+            mediaItemIndex: Int,
+            positionMs: Long,
+            seekCommand: Int,
+        ): ListenableFuture<*> {
+            val targetsCurrentItem = mediaItemIndex == C.INDEX_UNSET ||
+                mediaItemIndex == exoPlayer.currentMediaItemIndex
+            val canUseServerOffset = targetsCurrentItem && when (seekCommand) {
+                Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+                Player.COMMAND_SEEK_BACK,
+                Player.COMMAND_SEEK_FORWARD,
+                Player.COMMAND_SEEK_TO_DEFAULT_POSITION,
+                Player.COMMAND_SEEK_TO_MEDIA_ITEM,
+                -> true
+                else -> false
+            }
+            if (canUseServerOffset && seekTranscodedStream(positionMs)) {
+                return Futures.immediateVoidFuture()
+            }
+            return super.handleSeek(mediaItemIndex, positionMs, seekCommand)
+        }
+
+        private fun seekTranscodedStream(requestedPositionMs: Long): Boolean {
+            val mediaItemIndex = exoPlayer.currentMediaItemIndex
+            if (mediaItemIndex == C.INDEX_UNSET) return false
+            val item = exoPlayer.currentMediaItem ?: return false
+            val request = item.toPlaybackRequestOrNull() ?: return false
+            if (!request.supportsServerSideSeek()) return false
+
+            val durationMs = item.metadataDurationMs() ?: return false
+            val targetPositionMs = requestedPositionMs
+                .coerceIn(0L, (durationMs - 1_000L).coerceAtLeast(0L))
+                .toWholeSecondOffsetMs()
+            val preferredQuality = StreamQuality.entries
+                .find { quality -> quality.maxBitRate == request.maxBitRate }
+                ?: StreamQuality.ORIGINAL
+            val hasCompleteBaseStream = streamCacheRepository.findCachedQualityKey(
+                serverId = request.serverId,
+                songId = request.songId,
+                preferredQuality = preferredQuality,
+            ) != null
+            val currentOffsetMs = exoPlayer.currentStreamOffsetMs()
+
+            if (hasCompleteBaseStream && currentOffsetMs == 0L) {
+                return false
+            }
+
+            val serverOffsetMs = if (hasCompleteBaseStream) 0L else targetPositionMs
+            val rawSeekPositionMs = if (hasCompleteBaseStream) targetPositionMs else 0L
+            val wasPlaying = exoPlayer.playWhenReady
+            exoPlayer.stop()
+            updateActiveServerSeek(
+                if (serverOffsetMs > 0L) {
+                    ActiveServerSeek(
+                        mediaItemIndex = mediaItemIndex,
+                        serverId = request.serverId,
+                        songId = request.songId,
+                        offsetMs = serverOffsetMs,
+                    )
+                } else {
+                    null
+                },
+            )
+            exoPlayer.seekTo(mediaItemIndex, rawSeekPositionMs)
+            exoPlayer.prepare()
+            exoPlayer.playWhenReady = wasPlaying
+            return true
+        }
+    }
+
+    private fun updateActiveServerSeek(activeSeek: ActiveServerSeek?) {
+        val previousSeek = activeServerSeek
+        val activePlayer = player
+        if (previousSeek == null && activeSeek != null && activePlayer != null) {
+            pauseAtEndBeforeServerSeek = activePlayer.pauseAtEndOfMediaItems
+        }
+        activeServerSeek = activeSeek
+        activePlayer?.let {
+            if (activeSeek == null) {
+                pauseAtEndBeforeServerSeek?.let(it::setPauseAtEndOfMediaItems)
+                pauseAtEndBeforeServerSeek = null
+            } else {
+                syncOffsetStreamPauseAtEnd(it)
+            }
+            it.preloadConfiguration = if (activeSeek == null) {
+                cachedPlaybackPrefs?.let(::preloadConfigurationFor)
+                    ?: ExoPlayer.PreloadConfiguration.DEFAULT
+            } else {
+                ExoPlayer.PreloadConfiguration.DEFAULT
+            }
+        }
+    }
+
+    private fun syncOffsetStreamPauseAtEnd(activePlayer: ExoPlayer) {
+        val shouldPauseAtEnd = activeServerSeek != null &&
+            shouldPauseOffsetStreamAtEnd(activePlayer.repeatMode, activePlayer.mediaItemCount)
+        val desiredValue = shouldPauseAtEnd || pauseAtEndBeforeServerSeek == true
+        if (activePlayer.pauseAtEndOfMediaItems != desiredValue) {
+            activePlayer.setPauseAtEndOfMediaItems(desiredValue)
+        }
+    }
+
+    private inner class ServerSeekStateListener : Player.Listener {
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            val activeSeek = activeServerSeek ?: return
+            val activePlayer = player ?: return
+            val request = mediaItem?.toPlaybackRequestOrNull()
+            val remainsOnOffsetStream =
+                activePlayer.currentMediaItemIndex == activeSeek.mediaItemIndex &&
+                    request?.serverId == activeSeek.serverId &&
+                    request.songId == activeSeek.songId
+            if (!remainsOnOffsetStream) {
+                updateActiveServerSeek(null)
+            }
+        }
+
+        override fun onRepeatModeChanged(repeatMode: Int) {
+            val activePlayer = player ?: return
+            if (activeServerSeek != null) {
+                syncOffsetStreamPauseAtEnd(activePlayer)
+            }
+        }
+
+        override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+            if (playWhenReady || reason != Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM) return
+            val activeSeek = activeServerSeek ?: return
+            val activePlayer = player ?: return
+            if (!shouldPauseOffsetStreamAtEnd(activePlayer.repeatMode, activePlayer.mediaItemCount)) return
+            restartOffsetStreamRepeatFromBeginning(activePlayer, activeSeek.mediaItemIndex, shouldResume = true)
+        }
+
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            if (playbackState != Player.STATE_ENDED) return
+            val activeSeek = activeServerSeek ?: return
+            val activePlayer = player ?: return
+            if (!shouldPauseOffsetStreamAtEnd(activePlayer.repeatMode, activePlayer.mediaItemCount)) return
+            restartOffsetStreamRepeatFromBeginning(activePlayer, activeSeek.mediaItemIndex, shouldResume = true)
+        }
+    }
+
+    private fun restartOffsetStreamRepeatFromBeginning(
+        activePlayer: ExoPlayer,
+        mediaItemIndex: Int,
+        shouldResume: Boolean,
+    ) {
+        activePlayer.stop()
+        updateActiveServerSeek(null)
+        activePlayer.seekTo(mediaItemIndex, 0L)
+        activePlayer.prepare()
+        activePlayer.playWhenReady = shouldResume
+    }
+
+    private fun PlaybackRequest.supportsServerSideSeek(): Boolean {
+        if (isCached) return false
+        val requestedBitRate = maxBitRate?.takeIf { it > 0 } ?: return false
+        return sourceBitRate?.let { it > requestedBitRate } ?: true
     }
 
     private fun shouldPreferLocalStreamCache(serverId: Long): Boolean {
@@ -950,7 +1248,7 @@ class SakiPlaybackService : MediaSessionService() {
             .filter { itemRequest -> itemRequest.serverId == request.serverId }
         val songIds = queueRequests.map(PlaybackRequest::songId)
         if (songIds.isEmpty()) return
-        val positionMs = activePlayer.currentPosition
+        val positionMs = activePlayer.logicalCurrentPositionMs()
         val serverId = request.serverId
         val currentSongId = request.songId
         val snapshot = LocalPlayQueueSnapshot(

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -39,6 +39,7 @@ import androidx.media3.session.SessionResult
 import org.hdhmc.saki.MainActivity
 import org.hdhmc.saki.R
 import org.hdhmc.saki.data.remote.HTTP_USER_AGENT
+import org.hdhmc.saki.data.remote.NetworkType
 import org.hdhmc.saki.domain.model.BufferStrategy
 import org.hdhmc.saki.domain.model.LyricLine
 import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshot
@@ -100,6 +101,9 @@ private fun String.forStreamOffset(timeOffsetSeconds: Int?): String =
 private fun Int.forStreamOffset(timeOffsetSeconds: Int?): Int =
     if (timeOffsetSeconds == null) this else this or DataSpec.FLAG_DONT_CACHE_IF_LENGTH_UNKNOWN
 
+internal fun isResourceEof(requestLength: Long, bytesRead: Long): Boolean =
+    requestLength == C.LENGTH_UNSET.toLong() || bytesRead < requestLength
+
 private class EofTrackingDataSource(
     private val upstream: DataSource,
     private val onEof: (DataSpec, Long) -> Unit,
@@ -123,7 +127,7 @@ private class EofTrackingDataSource(
         val read = upstream.read(buffer, offset, length)
         if (read == C.RESULT_END_OF_INPUT) {
             val dataSpec = openedDataSpec
-            if (!reportedEof && dataSpec != null) {
+            if (!reportedEof && dataSpec != null && isResourceEof(dataSpec.length, bytesRead)) {
                 reportedEof = true
                 onEof(dataSpec, dataSpec.position + bytesRead)
             }
@@ -161,6 +165,21 @@ internal fun isConfirmedTranscode(sourceBitRate: Int?, requestedBitRate: Int?): 
     val source = sourceBitRate?.takeIf { it > 0 } ?: return false
     val requested = requestedBitRate?.takeIf { it > 0 } ?: return false
     return source > requested
+}
+
+internal fun selectEffectiveStreamQuality(
+    prefs: PlaybackPreferences,
+    networkType: NetworkType,
+    fallbackMaxBitRate: Int?,
+): StreamQuality {
+    if (!prefs.adaptiveQualityEnabled) {
+        return StreamQuality.entries.find { it.maxBitRate == fallbackMaxBitRate }
+            ?: StreamQuality.ORIGINAL
+    }
+    return when (networkType) {
+        NetworkType.WIFI -> prefs.wifiStreamQuality
+        NetworkType.MOBILE -> prefs.mobileStreamQuality
+    }
 }
 
 @AndroidEntryPoint
@@ -611,16 +630,17 @@ class SakiPlaybackService : MediaSessionService() {
         }
     }
 
-    private fun PlaybackRequest.requestedStreamQuality(prefs: PlaybackPreferences): StreamQuality {
-        return if (prefs.adaptiveQualityEnabled) {
-            when (networkTypeProvider.networkType.value) {
-                org.hdhmc.saki.data.remote.NetworkType.WIFI -> prefs.wifiStreamQuality
-                org.hdhmc.saki.data.remote.NetworkType.MOBILE -> prefs.mobileStreamQuality
-            }
-        } else {
-            StreamQuality.entries.find { it.maxBitRate == maxBitRate } ?: StreamQuality.ORIGINAL
-        }
-    }
+    private fun requestedStreamQuality(
+        prefs: PlaybackPreferences,
+        fallbackMaxBitRate: Int?,
+    ): StreamQuality = selectEffectiveStreamQuality(
+        prefs = prefs,
+        networkType = networkTypeProvider.networkType.value,
+        fallbackMaxBitRate = fallbackMaxBitRate,
+    )
+
+    private fun PlaybackRequest.requestedStreamQuality(prefs: PlaybackPreferences): StreamQuality =
+        requestedStreamQuality(prefs, maxBitRate)
 
     private fun PlaybackRequest.withStreamQuality(quality: StreamQuality): PlaybackRequest {
         return copy(
@@ -964,15 +984,10 @@ class SakiPlaybackService : MediaSessionService() {
 
         // Use cached prefs to avoid blocking; fall back to blocking read if not yet available
         val prefs = cachedPlaybackPrefs ?: runBlocking { playbackPreferencesRepository.getPreferences() }
-        val requestedQuality = if (prefs.adaptiveQualityEnabled) {
-            when (networkTypeProvider.networkType.value) {
-                org.hdhmc.saki.data.remote.NetworkType.WIFI -> prefs.wifiStreamQuality
-                org.hdhmc.saki.data.remote.NetworkType.MOBILE -> prefs.mobileStreamQuality
-            }
-        } else {
-            val maxBitRate = uri.getQueryParameter("maxBitRate")?.toIntOrNull()
-            StreamQuality.entries.find { it.maxBitRate == maxBitRate } ?: StreamQuality.ORIGINAL
-        }
+        val requestedQuality = requestedStreamQuality(
+            prefs = prefs,
+            fallbackMaxBitRate = uri.getQueryParameter("maxBitRate")?.toIntOrNull(),
+        )
         val preferLocalCache = shouldPreferLocalStreamCache(serverId)
         val cacheLookupQuality = if (preferLocalCache) StreamQuality.entries.last() else requestedQuality
         val cachedQualityKey = if (timeOffsetSeconds == null) {
@@ -1136,15 +1151,14 @@ class SakiPlaybackService : MediaSessionService() {
             if (mediaItemIndex == C.INDEX_UNSET) return false
             val item = exoPlayer.currentMediaItem ?: return false
             val request = item.toPlaybackRequestOrNull() ?: return false
-            if (!request.supportsServerSideSeek()) return false
+            val prefs = cachedPlaybackPrefs ?: return false
+            val preferredQuality = request.requestedStreamQuality(prefs)
+            if (!request.supportsServerSideSeek(preferredQuality)) return false
 
             val durationMs = item.metadataDurationMs() ?: return false
             val targetPositionMs = requestedPositionMs
                 .coerceIn(0L, (durationMs - 1_000L).coerceAtLeast(0L))
                 .toWholeSecondOffsetMs()
-            val preferredQuality = StreamQuality.entries
-                .find { quality -> quality.maxBitRate == request.maxBitRate }
-                ?: StreamQuality.ORIGINAL
             val hasCompleteBaseStream = streamCacheRepository.findCachedQualityKey(
                 serverId = request.serverId,
                 songId = request.songId,
@@ -1261,8 +1275,13 @@ class SakiPlaybackService : MediaSessionService() {
         activePlayer.playWhenReady = shouldResume
     }
 
-    private fun PlaybackRequest.supportsServerSideSeek(): Boolean =
-        !isCached && isConfirmedTranscode(sourceBitRate, maxBitRate)
+    private fun PlaybackRequest.supportsServerSideSeek(): Boolean {
+        val prefs = cachedPlaybackPrefs ?: return false
+        return supportsServerSideSeek(requestedStreamQuality(prefs))
+    }
+
+    private fun PlaybackRequest.supportsServerSideSeek(quality: StreamQuality): Boolean =
+        !isCached && isConfirmedTranscode(sourceBitRate, quality.maxBitRate)
 
     private fun shouldPreferLocalStreamCache(serverId: Long): Boolean {
         return endpointSelector.isOfflineDegraded(serverId)

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -64,6 +64,7 @@ import java.net.NoRouteToHostException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.concurrent.ConcurrentHashMap
+import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -664,7 +665,7 @@ class SakiPlaybackService : MediaSessionService() {
         )
     }
 
-    private fun PlaybackRequest.toStreamPlaceholderUri(): Uri {
+    private fun PlaybackRequest.toStreamPlaceholderUri(streamInstanceId: String? = null): Uri {
         return Uri.Builder()
             .scheme("saki")
             .authority("stream")
@@ -673,6 +674,7 @@ class SakiPlaybackService : MediaSessionService() {
             .apply {
                 maxBitRate?.let { appendQueryParameter("maxBitRate", it.toString()) }
                 format?.let { appendQueryParameter("format", it) }
+                streamInstanceId?.let { appendQueryParameter("instanceId", it) }
             }
             .build()
     }
@@ -1199,7 +1201,7 @@ class SakiPlaybackService : MediaSessionService() {
             val hasCompleteBaseStream = streamCacheRepository.findCachedQualityKey(
                 serverId = request.serverId,
                 songId = request.songId,
-                preferredQuality = preferredQuality,
+                preferredQuality = openedQuality,
             ) != null
             val currentOffsetMs = exoPlayer.currentStreamOffsetMs()
 
@@ -1548,7 +1550,9 @@ class SakiPlaybackService : MediaSessionService() {
             }
 
             // Build placeholder URI — real stream URL resolved at play time by ResolvingDataSource
-            val placeholderUri = request.toStreamPlaceholderUri()
+            val placeholderUri = request.toStreamPlaceholderUri(
+                streamInstanceId = UUID.randomUUID().toString(),
+            )
 
             // Resolve artwork URL using canonical endpoint (first by order) so
             // CoverArtEndpointInterceptor can rewrite it to the current best endpoint at load time

--- a/app/src/main/java/org/hdhmc/saki/playback/StreamCacheKeys.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/StreamCacheKeys.kt
@@ -6,6 +6,7 @@ private const val STREAM_CACHE_KEY_PREFIX = "saki.stream.v1"
 private const val ENCODED_STREAM_CACHE_KEY_PREFIX = "saki.stream.v2"
 private const val FIELD_DELIMITER = '|'
 private const val ENCODED_ESCAPE = '%'
+internal const val STREAM_CACHE_EOF_LENGTH_METADATA_KEY = "custom_saki_stream_eof_length"
 
 data class StreamCacheResourceKey(
     val serverId: Long,

--- a/app/src/main/java/org/hdhmc/saki/playback/SubsonicPlaybackItems.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SubsonicPlaybackItems.kt
@@ -386,6 +386,7 @@ internal fun PlaybackRequest.toMediaMetadata(): MediaMetadata {
         .setTitle(title)
         .setArtist(artist)
         .setAlbumTitle(album)
+        .setDurationMs(durationMs)
         .setTrackNumber(track)
         .setDiscNumber(discNumber)
         .setArtworkUri(artworkUri?.let(Uri::parse))

--- a/app/src/test/java/org/hdhmc/saki/data/repository/DefaultSubsonicRepositoryTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/data/repository/DefaultSubsonicRepositoryTest.kt
@@ -137,6 +137,7 @@ class DefaultSubsonicRepositoryTest {
             songId = "song-42",
             maxBitRate = 320,
             format = "raw",
+            timeOffsetSeconds = 42,
         )
 
         assertEquals("song-42", request.songId)
@@ -146,6 +147,7 @@ class DefaultSubsonicRepositoryTest {
         assertTrue(request.candidates.first().url.contains("id=song-42"))
         assertTrue(request.candidates.first().url.contains("maxBitRate=320"))
         assertTrue(request.candidates.first().url.contains("format=raw"))
+        assertTrue(request.candidates.first().url.contains("timeOffset=42"))
         assertTrue(request.candidates.first().url.contains("u=nemo"))
     }
 

--- a/app/src/test/java/org/hdhmc/saki/playback/ServerSeekRepeatTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/playback/ServerSeekRepeatTest.kt
@@ -1,6 +1,11 @@
 package org.hdhmc.saki.playback
 
+import androidx.media3.common.C
 import androidx.media3.common.Player
+import org.hdhmc.saki.data.remote.NetworkType
+import org.hdhmc.saki.domain.model.PlaybackPreferences
+import org.hdhmc.saki.domain.model.StreamQuality
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -24,5 +29,29 @@ class ServerSeekRepeatTest {
         assertFalse(isConfirmedTranscode(sourceBitRate = 128, requestedBitRate = 320))
         assertFalse(isConfirmedTranscode(sourceBitRate = null, requestedBitRate = 128))
         assertFalse(isConfirmedTranscode(sourceBitRate = 320, requestedBitRate = null))
+    }
+
+    @Test
+    fun `only whole-resource EOF marks a stream complete`() {
+        assertTrue(isResourceEof(requestLength = C.LENGTH_UNSET.toLong(), bytesRead = 8_192L))
+        assertTrue(isResourceEof(requestLength = 8_192L, bytesRead = 4_096L))
+        assertFalse(isResourceEof(requestLength = 8_192L, bytesRead = 8_192L))
+    }
+
+    @Test
+    fun `adaptive quality overrides the queue time stream quality`() {
+        val prefs = PlaybackPreferences(
+            adaptiveQualityEnabled = true,
+            wifiStreamQuality = StreamQuality.KBPS_320,
+            mobileStreamQuality = StreamQuality.KBPS_128,
+        )
+
+        val effectiveQuality = selectEffectiveStreamQuality(
+            prefs = prefs,
+            networkType = NetworkType.MOBILE,
+            fallbackMaxBitRate = StreamQuality.KBPS_320.maxBitRate,
+        )
+
+        assertEquals(StreamQuality.KBPS_128, effectiveQuality)
     }
 }

--- a/app/src/test/java/org/hdhmc/saki/playback/ServerSeekRepeatTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/playback/ServerSeekRepeatTest.kt
@@ -17,4 +17,12 @@ class ServerSeekRepeatTest {
         assertFalse(shouldPauseOffsetStreamAtEnd(Player.REPEAT_MODE_ALL, mediaItemCount = 3))
         assertFalse(shouldPauseOffsetStreamAtEnd(Player.REPEAT_MODE_OFF, mediaItemCount = 1))
     }
+
+    @Test
+    fun `server-side seek requires confirmed transcoding`() {
+        assertTrue(isConfirmedTranscode(sourceBitRate = 320, requestedBitRate = 128))
+        assertFalse(isConfirmedTranscode(sourceBitRate = 128, requestedBitRate = 320))
+        assertFalse(isConfirmedTranscode(sourceBitRate = null, requestedBitRate = 128))
+        assertFalse(isConfirmedTranscode(sourceBitRate = 320, requestedBitRate = null))
+    }
 }

--- a/app/src/test/java/org/hdhmc/saki/playback/ServerSeekRepeatTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/playback/ServerSeekRepeatTest.kt
@@ -1,0 +1,20 @@
+package org.hdhmc.saki.playback
+
+import androidx.media3.common.Player
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ServerSeekRepeatTest {
+    @Test
+    fun `repeating the current offset stream pauses at its end`() {
+        assertTrue(shouldPauseOffsetStreamAtEnd(Player.REPEAT_MODE_ONE, mediaItemCount = 3))
+        assertTrue(shouldPauseOffsetStreamAtEnd(Player.REPEAT_MODE_ALL, mediaItemCount = 1))
+    }
+
+    @Test
+    fun `repeat all with a following item does not pause the offset stream`() {
+        assertFalse(shouldPauseOffsetStreamAtEnd(Player.REPEAT_MODE_ALL, mediaItemCount = 3))
+        assertFalse(shouldPauseOffsetStreamAtEnd(Player.REPEAT_MODE_OFF, mediaItemCount = 1))
+    }
+}

--- a/app/src/test/java/org/hdhmc/saki/playback/ServerSeekRepeatTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/playback/ServerSeekRepeatTest.kt
@@ -32,6 +32,24 @@ class ServerSeekRepeatTest {
     }
 
     @Test
+    fun `server-side seek follows the opened stream quality`() {
+        assertTrue(
+            supportsTranscodedServerSeek(
+                isCached = false,
+                sourceBitRate = 320,
+                openedStreamQuality = StreamQuality.KBPS_128,
+            ),
+        )
+        assertFalse(
+            supportsTranscodedServerSeek(
+                isCached = false,
+                sourceBitRate = 320,
+                openedStreamQuality = StreamQuality.ORIGINAL,
+            ),
+        )
+    }
+
+    @Test
     fun `only whole-resource EOF marks a stream complete`() {
         assertTrue(isResourceEof(requestLength = C.LENGTH_UNSET.toLong(), bytesRead = 8_192L))
         assertTrue(isResourceEof(requestLength = 8_192L, bytesRead = 4_096L))


### PR DESCRIPTION
## Summary
- expose the library duration and a seekable logical timeline for newly transcoded streams
- restart Navidrome transcoding with `timeOffset` for seeks while keeping the Media3 playlist and shuffle order stable
- isolate offset responses from the base stream cache and preserve logical progress for lyrics, queue persistence, and notifications
- keep repeat-current playback on the same item by pausing the temporary offset stream at its end before reopening the full source

## Root cause
Fresh Navidrome transcoding responses do not expose a stable content length or byte-range seeking. Media3 therefore treated them as short, non-seekable streams, and byte-based cache metadata could not represent server-side seeks safely.

## Validation
- `./gradlew :app:compileDebugKotlin -q`
- `./gradlew testDebugUnitTest -q`
- `./gradlew assembleRelease -q --no-daemon`
- release APK installed on `10.111.111.90:34567`
- manually verified transcoded notification progress/seek and shuffle end-of-track transition

The unrelated local `deploy.sh` change is intentionally excluded.