### PR TITLE
Add configurable Bluetooth lyrics lead time

### DIFF
--- a/app/src/main/java/org/hdhmc/saki/data/repository/ConfigBackupManager.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/ConfigBackupManager.kt
@@ -8,6 +8,7 @@ import org.hdhmc.saki.domain.model.DEFAULT_SUBSONIC_API_VERSION
 import org.hdhmc.saki.domain.model.DEFAULT_SUBSONIC_CLIENT
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.ServerEndpoint
+import org.hdhmc.saki.domain.model.normalizeBluetoothLyricsOffsetMs
 import org.hdhmc.saki.domain.model.normalizeSongsPageSize
 import org.hdhmc.saki.domain.repository.ServerConfigRepository
 import com.squareup.moshi.JsonClass
@@ -128,6 +129,11 @@ class ConfigBackupManager @Inject constructor(
                         }
                         DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS.name -> {
                             ds[DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS] = value.toBooleanStrictOrNull() ?: return@forEach
+                            settingsApplied = true
+                        }
+                        DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS_OFFSET_MS.name -> {
+                            ds[DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS_OFFSET_MS] =
+                                value.toIntOrNull()?.let(::normalizeBluetoothLyricsOffsetMs) ?: return@forEach
                             settingsApplied = true
                         }
                         DataStorePlaybackPreferencesRepository.KEY_ADAPTIVE_QUALITY.name -> {

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DataStorePlaybackPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DataStorePlaybackPreferencesRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import org.hdhmc.saki.domain.model.BufferStrategy
+import org.hdhmc.saki.domain.model.DEFAULT_BLUETOOTH_LYRICS_OFFSET_MS
 import org.hdhmc.saki.domain.model.DEFAULT_CUSTOM_BUFFER_SECONDS
 import org.hdhmc.saki.domain.model.DEFAULT_IMAGE_CACHE_SIZE_MB
 import org.hdhmc.saki.domain.model.DEFAULT_STREAM_CACHE_SIZE_MB
@@ -22,6 +23,7 @@ import org.hdhmc.saki.domain.model.PlaybackPreferences
 import org.hdhmc.saki.domain.model.STREAM_CACHE_SIZE_STEP_MB
 import org.hdhmc.saki.domain.model.SoundBalancingMode
 import org.hdhmc.saki.domain.model.StreamQuality
+import org.hdhmc.saki.domain.model.normalizeBluetoothLyricsOffsetMs
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
 import java.io.IOException
 import javax.inject.Inject
@@ -79,6 +81,12 @@ class DataStorePlaybackPreferencesRepository @Inject constructor(
         dataStore.edit { it[KEY_BLUETOOTH_LYRICS] = enabled }
     }
 
+    override suspend fun updateBluetoothLyricsOffsetMs(offsetMs: Int) {
+        dataStore.edit {
+            it[KEY_BLUETOOTH_LYRICS_OFFSET_MS] = normalizeBluetoothLyricsOffsetMs(offsetMs)
+        }
+    }
+
     override suspend fun updateBufferStrategy(strategy: BufferStrategy) {
         dataStore.edit { it[KEY_BUFFER_STRATEGY] = strategy.storageKey }
     }
@@ -127,6 +135,7 @@ class DataStorePlaybackPreferencesRepository @Inject constructor(
         val KEY_SOUND_BALANCING_MODE = stringPreferencesKey("sound_balancing_mode")
         val KEY_STREAM_CACHE_SIZE_MB = intPreferencesKey("stream_cache_size_mb")
         val KEY_BLUETOOTH_LYRICS = booleanPreferencesKey("bluetooth_lyrics_enabled")
+        val KEY_BLUETOOTH_LYRICS_OFFSET_MS = intPreferencesKey("bluetooth_lyrics_offset_ms")
         val KEY_BUFFER_STRATEGY = stringPreferencesKey("buffer_strategy")
         val KEY_CUSTOM_BUFFER_SECONDS = intPreferencesKey("custom_buffer_seconds")
         val KEY_IMAGE_CACHE_SIZE_MB = intPreferencesKey("image_cache_size_mb")
@@ -155,6 +164,10 @@ private fun Preferences.toPlaybackPreferences() = PlaybackPreferences(
     streamCacheSizeMb = (this[DataStorePlaybackPreferencesRepository.KEY_STREAM_CACHE_SIZE_MB]
         ?: DEFAULT_STREAM_CACHE_SIZE_MB).normalizeStreamCacheSizeMb(),
     bluetoothLyricsEnabled = this[DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS] ?: false,
+    bluetoothLyricsOffsetMs = normalizeBluetoothLyricsOffsetMs(
+        this[DataStorePlaybackPreferencesRepository.KEY_BLUETOOTH_LYRICS_OFFSET_MS]
+            ?: DEFAULT_BLUETOOTH_LYRICS_OFFSET_MS,
+    ),
     bufferStrategy = BufferStrategy.fromStorageKey(
         this[DataStorePlaybackPreferencesRepository.KEY_BUFFER_STRATEGY],
     ),

--- a/app/src/main/java/org/hdhmc/saki/data/repository/DefaultPlaybackPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/data/repository/DefaultPlaybackPreferencesRepository.kt
@@ -70,6 +70,9 @@ class DefaultPlaybackPreferencesRepository @Inject constructor(
         }
     }
 
+    override suspend fun updateBluetoothLyricsOffsetMs(offsetMs: Int) =
+        error("Room-backed repository does not support Bluetooth lyrics offset. Use DataStore implementation.")
+
     override suspend fun updateBufferStrategy(strategy: BufferStrategy) =
         error("Room-backed repository does not support buffer settings. Use DataStore implementation.")
     override suspend fun updateCustomBufferSeconds(seconds: Int) =

--- a/app/src/main/java/org/hdhmc/saki/domain/model/PlaybackModels.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/model/PlaybackModels.kt
@@ -132,11 +132,30 @@ const val MIN_CUSTOM_BUFFER_SECONDS = 30
 const val MAX_CUSTOM_BUFFER_SECONDS = 1800
 const val CUSTOM_BUFFER_STEP_SECONDS = 30
 
+const val DEFAULT_BLUETOOTH_LYRICS_OFFSET_MS = 0
+const val MIN_BLUETOOTH_LYRICS_OFFSET_MS = 0
+const val MAX_BLUETOOTH_LYRICS_OFFSET_MS = 2_000
+const val BLUETOOTH_LYRICS_OFFSET_STEP_MS = 250
+
 fun normalizeCustomBufferSeconds(seconds: Int): Int {
     val clamped = seconds.coerceIn(MIN_CUSTOM_BUFFER_SECONDS, MAX_CUSTOM_BUFFER_SECONDS)
     val stepsFromMin = ((clamped - MIN_CUSTOM_BUFFER_SECONDS).toFloat() / CUSTOM_BUFFER_STEP_SECONDS).toInt()
     val lower = MIN_CUSTOM_BUFFER_SECONDS + (stepsFromMin * CUSTOM_BUFFER_STEP_SECONDS)
     val upper = (lower + CUSTOM_BUFFER_STEP_SECONDS).coerceAtMost(MAX_CUSTOM_BUFFER_SECONDS)
+    return if (clamped - lower < upper - clamped) lower else upper
+}
+
+fun normalizeBluetoothLyricsOffsetMs(offsetMs: Int): Int {
+    val clamped = offsetMs.coerceIn(
+        MIN_BLUETOOTH_LYRICS_OFFSET_MS,
+        MAX_BLUETOOTH_LYRICS_OFFSET_MS,
+    )
+    val stepsFromMin =
+        (clamped - MIN_BLUETOOTH_LYRICS_OFFSET_MS) / BLUETOOTH_LYRICS_OFFSET_STEP_MS
+    val lower = MIN_BLUETOOTH_LYRICS_OFFSET_MS +
+        (stepsFromMin * BLUETOOTH_LYRICS_OFFSET_STEP_MS)
+    val upper = (lower + BLUETOOTH_LYRICS_OFFSET_STEP_MS)
+        .coerceAtMost(MAX_BLUETOOTH_LYRICS_OFFSET_MS)
     return if (clamped - lower < upper - clamped) lower else upper
 }
 
@@ -149,6 +168,7 @@ data class PlaybackPreferences(
     val soundBalancingMode: SoundBalancingMode = SoundBalancingMode.OFF,
     val streamCacheSizeMb: Int = DEFAULT_STREAM_CACHE_SIZE_MB,
     val bluetoothLyricsEnabled: Boolean = false,
+    val bluetoothLyricsOffsetMs: Int = DEFAULT_BLUETOOTH_LYRICS_OFFSET_MS,
     val bufferStrategy: BufferStrategy = BufferStrategy.NORMAL,
     val customBufferSeconds: Int = DEFAULT_CUSTOM_BUFFER_SECONDS,
     val imageCacheSizeMb: Int = DEFAULT_IMAGE_CACHE_SIZE_MB,

--- a/app/src/main/java/org/hdhmc/saki/domain/repository/PlaybackPreferencesRepository.kt
+++ b/app/src/main/java/org/hdhmc/saki/domain/repository/PlaybackPreferencesRepository.kt
@@ -27,6 +27,8 @@ interface PlaybackPreferencesRepository {
 
     suspend fun updateBluetoothLyrics(enabled: Boolean)
 
+    suspend fun updateBluetoothLyricsOffsetMs(offsetMs: Int)
+
     suspend fun updateBufferStrategy(strategy: BufferStrategy)
 
     suspend fun updateCustomBufferSeconds(seconds: Int)

--- a/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
+++ b/app/src/main/java/org/hdhmc/saki/playback/SakiPlaybackService.kt
@@ -48,8 +48,10 @@ import org.hdhmc.saki.domain.model.LocalPlayQueueSnapshotSourceType
 import org.hdhmc.saki.domain.model.PlaybackPreferences
 import org.hdhmc.saki.domain.model.ServerEndpoint
 import org.hdhmc.saki.domain.model.Song
+import org.hdhmc.saki.domain.model.SongLyrics
 import org.hdhmc.saki.domain.model.SoundBalancingMode
 import org.hdhmc.saki.domain.model.StreamQuality
+import org.hdhmc.saki.domain.model.normalizeBluetoothLyricsOffsetMs
 import org.hdhmc.saki.domain.repository.LocalPlayQueueRepository
 import org.hdhmc.saki.domain.repository.PlaybackPreferencesRepository
 import org.hdhmc.saki.domain.repository.SubsonicRepository
@@ -88,6 +90,8 @@ private const val CUSTOM_PLAYER_MAX_BUFFER_MS = 5 * 60 * 1_000
 private const val STREAM_PREFETCH_LOG_TAG = "SakiStreamPrefetch"
 private const val STREAM_PREFETCH_REEVALUATION_MS = 30_000L
 private const val STREAM_PREFETCH_RETRY_DELAY_MS = 30_000L
+private const val BLUETOOTH_LYRICS_MIN_POLL_DELAY_MS = 50L
+private const val BLUETOOTH_LYRICS_MAX_POLL_DELAY_MS = 500L
 
 private fun Long.coerceKnownDuration(): Long? {
     return takeIf { it != C.TIME_UNSET && it > 0L }
@@ -158,6 +162,36 @@ private data class ActiveServerSeek(
     val offsetMs: Long,
     val streamQuality: StreamQuality,
 )
+
+private data class BluetoothLyricsDisplayConfig(
+    val enabled: Boolean,
+    val offsetMs: Int,
+)
+
+private data class BluetoothLyricsDisplayState(
+    val lyrics: SongLyrics,
+    val offsetMs: Int,
+)
+
+internal fun bluetoothLyricsLookupPositionMs(
+    playbackPositionMs: Long,
+    offsetMs: Int,
+): Long {
+    val safePositionMs = playbackPositionMs.coerceAtLeast(0L)
+    val normalizedOffsetMs = normalizeBluetoothLyricsOffsetMs(offsetMs).toLong()
+    return safePositionMs.coerceAtMost(Long.MAX_VALUE - normalizedOffsetMs) + normalizedOffsetMs
+}
+
+internal fun bluetoothLyricsPollDelayMs(
+    lookupPositionMs: Long,
+    nextLineStartMs: Long?,
+): Long {
+    if (nextLineStartMs == null) return BLUETOOTH_LYRICS_MAX_POLL_DELAY_MS
+    return (nextLineStartMs - lookupPositionMs).coerceIn(
+        BLUETOOTH_LYRICS_MIN_POLL_DELAY_MS,
+        BLUETOOTH_LYRICS_MAX_POLL_DELAY_MS,
+    )
+}
 
 internal fun shouldPauseOffsetStreamAtEnd(repeatMode: Int, mediaItemCount: Int): Boolean =
     repeatMode == Player.REPEAT_MODE_ONE ||
@@ -424,50 +458,72 @@ class SakiPlaybackService : MediaSessionService() {
         playerScope.launch {
             combine(
                 playbackPreferencesRepository.observePreferences()
-                    .map { it.bluetoothLyricsEnabled }
+                    .map { prefs ->
+                        BluetoothLyricsDisplayConfig(
+                            enabled = prefs.bluetoothLyricsEnabled,
+                            offsetMs = normalizeBluetoothLyricsOffsetMs(prefs.bluetoothLyricsOffsetMs),
+                        )
+                    }
                     .distinctUntilChanged(),
                 lyricsHolder.lyrics,
-            ) { enabled, lyrics -> if (enabled) lyrics else null }
-                .collectLatest { lyrics ->
-                    if (lyrics == null || !lyrics.synced) {
-                        restoreOriginalTitle()
-                        return@collectLatest
-                    }
-                    var lastLyricText: String? = null
-                    try {
-                        while (true) {
-                            val activePlayer = player ?: break
-                            if (!activePlayer.isPlaying) {
-                                delay(500)
-                                continue
-                            }
-                            mediaSession ?: break
-                            val positionMs = activePlayer.logicalCurrentPositionMs()
-                            val lines = lyrics.lines
-                            val index = lines.binarySearchLastBefore(positionMs)
-                            val text = if (index >= 0) lines[index].text.takeIf { it.isNotBlank() } else null
-                            if (text != null && text != lastLyricText) {
-                                lastLyricText = text
-                                val item = activePlayer.currentMediaItem ?: break
-                                if (originalMediaTitle == null) {
-                                    originalMediaTitle = item.mediaMetadata.title
-                                    originalMediaId = item.mediaId
-                                }
-                                val updated = item.buildUpon()
-                                    .setMediaMetadata(
-                                        item.mediaMetadata.buildUpon()
-                                            .setTitle(text)
-                                            .build(),
-                                    )
-                                    .build()
-                                activePlayer.replaceMediaItem(activePlayer.currentMediaItemIndex, updated)
-                            }
-                            delay(500)
-                        }
-                    } finally {
-                        restoreOriginalTitle()
-                    }
+            ) { config, lyrics ->
+                if (config.enabled && lyrics != null) {
+                    BluetoothLyricsDisplayState(lyrics = lyrics, offsetMs = config.offsetMs)
+                } else {
+                    null
                 }
+            }.collectLatest { displayState ->
+                if (displayState == null || !displayState.lyrics.synced) {
+                    restoreOriginalTitle()
+                    return@collectLatest
+                }
+                val lyrics = displayState.lyrics
+                var lastLyricText: String? = null
+                try {
+                    while (true) {
+                        val activePlayer = player ?: break
+                        if (!activePlayer.isPlaying) {
+                            delay(500)
+                            continue
+                        }
+                        mediaSession ?: break
+                        // This lead time is intentionally isolated to media-metadata lyrics.
+                        // The in-app scrolling/karaoke lyrics continue to use the unmodified
+                        // playback timeline exposed through LyricsHolder and the player state.
+                        val positionMs = bluetoothLyricsLookupPositionMs(
+                            playbackPositionMs = activePlayer.logicalCurrentPositionMs(),
+                            offsetMs = displayState.offsetMs,
+                        )
+                        val lines = lyrics.lines
+                        val index = lines.binarySearchLastBefore(positionMs)
+                        val text = if (index >= 0) lines[index].text.takeIf { it.isNotBlank() } else null
+                        if (text != null && text != lastLyricText) {
+                            lastLyricText = text
+                            val item = activePlayer.currentMediaItem ?: break
+                            if (originalMediaTitle == null) {
+                                originalMediaTitle = item.mediaMetadata.title
+                                originalMediaId = item.mediaId
+                            }
+                            val updated = item.buildUpon()
+                                .setMediaMetadata(
+                                    item.mediaMetadata.buildUpon()
+                                        .setTitle(text)
+                                        .build(),
+                                )
+                                .build()
+                            activePlayer.replaceMediaItem(activePlayer.currentMediaItemIndex, updated)
+                        }
+                        delay(
+                            bluetoothLyricsPollDelayMs(
+                                lookupPositionMs = positionMs,
+                                nextLineStartMs = lines.getOrNull(index + 1)?.startMs,
+                            ),
+                        )
+                    }
+                } finally {
+                    restoreOriginalTitle()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiApp.kt
@@ -365,6 +365,7 @@ private fun SettingsRoute(
         onUpdateDefaultAlbumFeed = viewModel::updateDefaultAlbumFeed,
         onUpdateSongsPageSize = viewModel::updateSongsPageSize,
         onUpdateBluetoothLyrics = viewModel::updateBluetoothLyrics,
+        onUpdateBluetoothLyricsOffsetMs = viewModel::updateBluetoothLyricsOffsetMs,
         onUpdateBufferStrategy = viewModel::updateBufferStrategy,
         onUpdateCustomBufferSeconds = viewModel::updateCustomBufferSeconds,
         onExportConfig = viewModel::exportConfig,

--- a/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/SakiAppViewModel.kt
@@ -1475,6 +1475,18 @@ class SakiAppViewModel @Inject constructor(
         }
     }
 
+    fun updateBluetoothLyricsOffsetMs(offsetMs: Int) {
+        viewModelScope.launch {
+            runCatching {
+                playbackPreferencesRepository.updateBluetoothLyricsOffsetMs(offsetMs)
+            }.onFailure { throwable ->
+                snackbarMessages.emit(
+                    SnackbarMessage(throwable.localizedOr(R.string.error_update_bluetooth_lyrics_offset)),
+                )
+            }
+        }
+    }
+
     fun updateBufferStrategy(strategy: org.hdhmc.saki.domain.model.BufferStrategy) {
         viewModelScope.launch {
             runCatching {

--- a/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/hdhmc/saki/presentation/settings/SettingsScreen.kt
@@ -74,28 +74,31 @@ import androidx.compose.ui.unit.dp
 import org.hdhmc.saki.R
 import org.hdhmc.saki.domain.model.AlbumListType
 import org.hdhmc.saki.domain.model.AppLanguage
-import org.hdhmc.saki.domain.model.CachedSong
-import org.hdhmc.saki.domain.model.DefaultBrowseTab
-import org.hdhmc.saki.domain.model.DEFAULT_THEME_SEED_KEY
-import org.hdhmc.saki.domain.model.ThemeMode
-import org.hdhmc.saki.domain.model.SakiPaletteStyle
-import org.hdhmc.saki.domain.model.MAX_STREAM_CACHE_SIZE_MB
-import org.hdhmc.saki.domain.model.MIN_STREAM_CACHE_SIZE_MB
 import org.hdhmc.saki.domain.model.BufferStrategy
+import org.hdhmc.saki.domain.model.BLUETOOTH_LYRICS_OFFSET_STEP_MS
+import org.hdhmc.saki.domain.model.CachedSong
 import org.hdhmc.saki.domain.model.CUSTOM_BUFFER_STEP_SECONDS
+import org.hdhmc.saki.domain.model.DEFAULT_THEME_SEED_KEY
+import org.hdhmc.saki.domain.model.DefaultBrowseTab
+import org.hdhmc.saki.domain.model.IMAGE_CACHE_SIZE_STEP_MB
+import org.hdhmc.saki.domain.model.MAX_BLUETOOTH_LYRICS_OFFSET_MS
 import org.hdhmc.saki.domain.model.MAX_CUSTOM_BUFFER_SECONDS
 import org.hdhmc.saki.domain.model.MAX_IMAGE_CACHE_SIZE_MB
-import org.hdhmc.saki.domain.model.IMAGE_CACHE_SIZE_STEP_MB
-import org.hdhmc.saki.domain.model.MIN_IMAGE_CACHE_SIZE_MB
-import org.hdhmc.saki.domain.model.MIN_CUSTOM_BUFFER_SECONDS
 import org.hdhmc.saki.domain.model.MAX_SONGS_PAGE_SIZE
+import org.hdhmc.saki.domain.model.MAX_STREAM_CACHE_SIZE_MB
+import org.hdhmc.saki.domain.model.MIN_BLUETOOTH_LYRICS_OFFSET_MS
+import org.hdhmc.saki.domain.model.MIN_CUSTOM_BUFFER_SECONDS
+import org.hdhmc.saki.domain.model.MIN_IMAGE_CACHE_SIZE_MB
 import org.hdhmc.saki.domain.model.MIN_SONGS_PAGE_SIZE
+import org.hdhmc.saki.domain.model.MIN_STREAM_CACHE_SIZE_MB
+import org.hdhmc.saki.domain.model.SakiPaletteStyle
 import org.hdhmc.saki.domain.model.ServerConfig
 import org.hdhmc.saki.domain.model.SONGS_PAGE_SIZE_STEP
 import org.hdhmc.saki.domain.model.SoundBalancingMode
 import org.hdhmc.saki.domain.model.STREAM_CACHE_SIZE_STEP_MB
 import org.hdhmc.saki.domain.model.StreamQuality
 import org.hdhmc.saki.domain.model.TextScale
+import org.hdhmc.saki.domain.model.ThemeMode
 import org.hdhmc.saki.presentation.SakiSettingsUiState
 import org.hdhmc.saki.presentation.labelRes
 import org.hdhmc.saki.presentation.library.ArtworkCard
@@ -143,6 +146,7 @@ fun SettingsScreen(
     onUpdateDefaultAlbumFeed: (AlbumListType) -> Unit,
     onUpdateSongsPageSize: (Int) -> Unit,
     onUpdateBluetoothLyrics: (Boolean) -> Unit,
+    onUpdateBluetoothLyricsOffsetMs: (Int) -> Unit,
     onUpdateBufferStrategy: (BufferStrategy) -> Unit,
     onUpdateCustomBufferSeconds: (Int) -> Unit,
     onExportConfig: (android.net.Uri) -> Unit,
@@ -172,6 +176,10 @@ fun SettingsScreen(
     val configuredSongsPageSize = uiState.appPreferences.songsPageSize
     var songsPageSizeSliderValue by remember(configuredSongsPageSize) {
         mutableFloatStateOf(configuredSongsPageSize.toFloat())
+    }
+    val configuredBluetoothLyricsOffsetMs = uiState.playbackPreferences.bluetoothLyricsOffsetMs
+    var bluetoothLyricsOffsetSliderValue by remember(configuredBluetoothLyricsOffsetMs) {
+        mutableFloatStateOf(configuredBluetoothLyricsOffsetMs.toFloat())
     }
 
     // Precompute the theme-color swatch palette once, off the scroll path. Otherwise the theme
@@ -986,6 +994,52 @@ fun SettingsScreen(
                         onCheckedChange = null,
                     )
                 }
+                if (checked) {
+                    val previewOffsetMs = bluetoothLyricsOffsetSliderValue.toBluetoothLyricsOffsetMs()
+                    Text(
+                        text = stringResource(R.string.settings_bluetooth_lyrics_offset_title),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_bluetooth_lyrics_offset_body),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = formatBluetoothLyricsOffset(previewOffsetMs),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Slider(
+                        value = bluetoothLyricsOffsetSliderValue,
+                        onValueChange = { bluetoothLyricsOffsetSliderValue = it },
+                        valueRange = MIN_BLUETOOTH_LYRICS_OFFSET_MS.toFloat()..
+                            MAX_BLUETOOTH_LYRICS_OFFSET_MS.toFloat(),
+                        steps = BLUETOOTH_LYRICS_OFFSET_SLIDER_STEPS,
+                        onValueChangeFinished = {
+                            val newOffsetMs = bluetoothLyricsOffsetSliderValue
+                                .toBluetoothLyricsOffsetMs()
+                            bluetoothLyricsOffsetSliderValue = newOffsetMs.toFloat()
+                            if (newOffsetMs != configuredBluetoothLyricsOffsetMs) {
+                                onUpdateBluetoothLyricsOffsetMs(newOffsetMs)
+                            }
+                        },
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Text(
+                            text = formatBluetoothLyricsOffset(MIN_BLUETOOTH_LYRICS_OFFSET_MS),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = formatBluetoothLyricsOffset(MAX_BLUETOOTH_LYRICS_OFFSET_MS),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
             }
         }
 
@@ -1330,6 +1384,10 @@ private const val STREAM_CACHE_SLIDER_STEPS =
 private const val SONGS_PAGE_SIZE_SLIDER_STEPS =
     ((MAX_SONGS_PAGE_SIZE - MIN_SONGS_PAGE_SIZE) / SONGS_PAGE_SIZE_STEP) - 1
 
+private const val BLUETOOTH_LYRICS_OFFSET_SLIDER_STEPS =
+    ((MAX_BLUETOOTH_LYRICS_OFFSET_MS - MIN_BLUETOOTH_LYRICS_OFFSET_MS) /
+        BLUETOOTH_LYRICS_OFFSET_STEP_MS) - 1
+
 private fun Float.toStreamCacheSizeMb(): Int {
     val stepsFromMin = ((this - MIN_STREAM_CACHE_SIZE_MB) / STREAM_CACHE_SIZE_STEP_MB).roundToInt()
     return (MIN_STREAM_CACHE_SIZE_MB + (stepsFromMin * STREAM_CACHE_SIZE_STEP_MB))
@@ -1346,6 +1404,26 @@ private fun Float.toBufferSeconds(): Int {
     val stepsFromMin = ((this - MIN_CUSTOM_BUFFER_SECONDS) / CUSTOM_BUFFER_STEP_SECONDS).roundToInt()
     return (MIN_CUSTOM_BUFFER_SECONDS + (stepsFromMin * CUSTOM_BUFFER_STEP_SECONDS))
         .coerceIn(MIN_CUSTOM_BUFFER_SECONDS, MAX_CUSTOM_BUFFER_SECONDS)
+}
+
+private fun Float.toBluetoothLyricsOffsetMs(): Int {
+    val stepsFromMin =
+        ((this - MIN_BLUETOOTH_LYRICS_OFFSET_MS) / BLUETOOTH_LYRICS_OFFSET_STEP_MS).roundToInt()
+    return (MIN_BLUETOOTH_LYRICS_OFFSET_MS +
+        (stepsFromMin * BLUETOOTH_LYRICS_OFFSET_STEP_MS))
+        .coerceIn(MIN_BLUETOOTH_LYRICS_OFFSET_MS, MAX_BLUETOOTH_LYRICS_OFFSET_MS)
+}
+
+@Composable
+private fun formatBluetoothLyricsOffset(offsetMs: Int): String {
+    return if (offsetMs == 0) {
+        stringResource(R.string.settings_bluetooth_lyrics_offset_none)
+    } else {
+        stringResource(
+            R.string.settings_bluetooth_lyrics_offset_value,
+            offsetMs / 1_000f,
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -47,6 +47,10 @@
     <string name="settings_experimental_body">部分功能可能不适用于所有设备。</string>
     <string name="settings_bluetooth_lyrics_title">蓝牙 / 通知栏歌词</string>
     <string name="settings_bluetooth_lyrics_body">在媒体通知、锁屏和蓝牙设备（车载音响、耳机）上显示当前歌词。</string>
+    <string name="settings_bluetooth_lyrics_offset_title">歌词提前量</string>
+    <string name="settings_bluetooth_lyrics_offset_body">让蓝牙、通知栏和车载歌词提前显示以补偿传输延迟，不影响应用内滚动歌词。</string>
+    <string name="settings_bluetooth_lyrics_offset_none">不调整</string>
+    <string name="settings_bluetooth_lyrics_offset_value">提前 %1$.2f 秒</string>
     <string name="settings_backup_restore_title">备份与恢复</string>
     <string name="settings_backup_restore_body">导出或导入服务器配置和设置。注意：导出文件中的密码为明文。</string>
     <string name="settings_export">导出</string>
@@ -322,6 +326,7 @@
     <string name="message_stream_cache_limit_updated">串流缓存上限已更新。</string>
     <string name="error_update_stream_cache_size">无法更新串流缓存大小。</string>
     <string name="error_update_bluetooth_lyrics">无法更新蓝牙歌词设置。</string>
+    <string name="error_update_bluetooth_lyrics_offset">无法更新蓝牙歌词提前量。</string>
     <string name="message_buffer_strategy_set">缓冲策略已设为 %1$s，重启应用后生效。</string>
     <string name="error_update_buffer_strategy">无法更新缓冲策略。</string>
     <string name="message_custom_buffer_set">自定义缓冲已设为 %1$d 秒，重启应用后生效。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,10 @@
     <string name="settings_experimental_body">Features that may not work on all devices.</string>
     <string name="settings_bluetooth_lyrics_title">Bluetooth / notification lyrics</string>
     <string name="settings_bluetooth_lyrics_body">Show current lyric line in media notification, lock screen, and Bluetooth devices (car stereos, headphones).</string>
+    <string name="settings_bluetooth_lyrics_offset_title">Lyrics lead time</string>
+    <string name="settings_bluetooth_lyrics_offset_body">Show Bluetooth, notification, and car lyrics slightly early to compensate for transport delay. In-app lyrics are unchanged.</string>
+    <string name="settings_bluetooth_lyrics_offset_none">No adjustment</string>
+    <string name="settings_bluetooth_lyrics_offset_value">%1$.2f s early</string>
     <string name="settings_backup_restore_title">Backup &amp; Restore</string>
     <string name="settings_backup_restore_body">Export or import server configuration and settings. Warning: exported files contain server passwords in plaintext.</string>
     <string name="settings_export">Export</string>
@@ -330,6 +334,7 @@
     <string name="message_stream_cache_limit_updated">Stream cache limit updated.</string>
     <string name="error_update_stream_cache_size">Unable to update stream cache size.</string>
     <string name="error_update_bluetooth_lyrics">Unable to update Bluetooth lyrics.</string>
+    <string name="error_update_bluetooth_lyrics_offset">Unable to update Bluetooth lyrics lead time.</string>
     <string name="message_buffer_strategy_set">Buffer strategy set to %1$s. Restart app to apply.</string>
     <string name="error_update_buffer_strategy">Unable to update buffer strategy.</string>
     <string name="message_custom_buffer_set">Custom buffer set to %1$d s. Restart app to apply.</string>

--- a/app/src/test/java/org/hdhmc/saki/playback/BluetoothLyricsOffsetTest.kt
+++ b/app/src/test/java/org/hdhmc/saki/playback/BluetoothLyricsOffsetTest.kt
@@ -1,0 +1,44 @@
+package org.hdhmc.saki.playback
+
+import org.hdhmc.saki.domain.model.PlaybackPreferences
+import org.hdhmc.saki.domain.model.normalizeBluetoothLyricsOffsetMs
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BluetoothLyricsOffsetTest {
+    @Test
+    fun `Bluetooth lyrics offset defaults to no adjustment`() {
+        assertEquals(0, PlaybackPreferences().bluetoothLyricsOffsetMs)
+    }
+
+    @Test
+    fun `Bluetooth lyrics offset is clamped and snapped to quarter seconds`() {
+        assertEquals(0, normalizeBluetoothLyricsOffsetMs(-1))
+        assertEquals(0, normalizeBluetoothLyricsOffsetMs(124))
+        assertEquals(250, normalizeBluetoothLyricsOffsetMs(125))
+        assertEquals(500, normalizeBluetoothLyricsOffsetMs(376))
+        assertEquals(2_000, normalizeBluetoothLyricsOffsetMs(2_001))
+    }
+
+    @Test
+    fun `Bluetooth lyrics lookup advances only its local lookup position`() {
+        val playbackPositionMs = 10_000L
+
+        assertEquals(
+            playbackPositionMs,
+            bluetoothLyricsLookupPositionMs(playbackPositionMs, offsetMs = 0),
+        )
+        assertEquals(
+            10_250L,
+            bluetoothLyricsLookupPositionMs(playbackPositionMs, offsetMs = 250),
+        )
+    }
+
+    @Test
+    fun `Bluetooth lyrics polling follows nearby line boundaries without busy polling`() {
+        assertEquals(250L, bluetoothLyricsPollDelayMs(lookupPositionMs = 10_000L, nextLineStartMs = 10_250L))
+        assertEquals(50L, bluetoothLyricsPollDelayMs(lookupPositionMs = 10_000L, nextLineStartMs = 9_900L))
+        assertEquals(500L, bluetoothLyricsPollDelayMs(lookupPositionMs = 10_000L, nextLineStartMs = 12_000L))
+        assertEquals(500L, bluetoothLyricsPollDelayMs(lookupPositionMs = 10_000L, nextLineStartMs = null))
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable 0–2 second Bluetooth lyrics lead time with 0.25 second steps and no adjustment by default
- apply the offset only to notification, lock-screen, Bluetooth, and car metadata lyrics without changing in-app scrolling or karaoke timing
- persist and back up the preference, with localized settings UI and boundary normalization
- schedule metadata updates around nearby lyric boundaries so quarter-second adjustments remain observable without busy polling

## Validation
- `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --no-daemon`
- `git diff --check`
